### PR TITLE
chore: add custom option plugin

### DIFF
--- a/android/src/main/kotlin/com/rudderstack/android/sdk/utils/JSON.kt
+++ b/android/src/main/kotlin/com/rudderstack/android/sdk/utils/JSON.kt
@@ -18,6 +18,6 @@ internal fun JsonObjectBuilder.putUndefinedIfNull(key: String, value: CharSequen
  *
  * @param other The JSON object to merge with the current JSON object.
  */
-infix fun JsonObject.mergeWithHigherPriorityTo(other: JsonObject): JsonObject {
+internal infix fun JsonObject.mergeWithHigherPriorityTo(other: JsonObject): JsonObject {
     return JsonObject(this.toMap() + other.toMap())
 }

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/customplugins/OptionPlugin.kt
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/customplugins/OptionPlugin.kt
@@ -1,12 +1,11 @@
 package com.rudderstack.sampleapp.analytics.customplugins
 
-import com.rudderstack.android.sdk.utils.mergeWithHigherPriorityTo
 import com.rudderstack.kotlin.sdk.Analytics
 import com.rudderstack.kotlin.sdk.internals.logger.LoggerAnalytics
 import com.rudderstack.kotlin.sdk.internals.models.Message
 import com.rudderstack.kotlin.sdk.internals.models.RudderOption
 import com.rudderstack.kotlin.sdk.internals.plugins.Plugin
-import com.rudderstack.kotlin.sdk.internals.utils.mergeWithHigherPriorityTo
+import kotlinx.serialization.json.JsonObject
 
 /**
  * A plugin that adds custom context and integrations to each message. Note: External IDs should not be updated here.
@@ -45,3 +44,21 @@ class OptionPlugin (
         message.integrations = message.integrations mergeWithHigherPriorityTo option.integrations
     }
 }
+
+/**
+ * Merges the current JSON object with another JSON object, giving higher priority to the other JSON object.
+ *
+ * @param other The JSON object to merge with the current JSON object.
+ */
+infix fun JsonObject.mergeWithHigherPriorityTo(other: JsonObject): JsonObject {
+    return JsonObject(this.toMap() + other.toMap())
+}
+/**
+ * Merges the current map with another map, giving higher priority to the other map.
+ *
+ * @param other The map to merge with the current map.
+ */
+infix fun <K, V> Map<K, V>.mergeWithHigherPriorityTo(other: Map<K, V>): Map<K, V> {
+    return this + other
+}
+

--- a/core/src/main/kotlin/com/rudderstack/kotlin/sdk/internals/utils/MapUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/kotlin/sdk/internals/utils/MapUtils.kt
@@ -5,6 +5,6 @@ package com.rudderstack.kotlin.sdk.internals.utils
  *
  * @param other The map to merge with the current map.
  */
-infix fun <K, V> Map<K, V>.mergeWithHigherPriorityTo(other: Map<K, V>): Map<K, V> {
+internal infix fun <K, V> Map<K, V>.mergeWithHigherPriorityTo(other: Map<K, V>): Map<K, V> {
     return this + other
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- In this PR, we added a custom plugin in the Android app for demonstration purposes.
- The user can utilise this plugin to add the `integrations` and `custom context` in all the events.
- The value provided in this plugin will override the values set in the message object.

NOTE: This plugin needs to be added just after the SDK initialisation to ensure all the events including the lifecycle contain the updated values.
NOTE: This plugin shouldn't be used to set the `externalId` option. That should only be set using an identify event. 

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

- We added a custom `RudderOption` plugin in the sample app for demonstration purposes.
- This plugin needs to be added just after the SDK initialisation.
- It is an alternative to v1 SDK's feature, where the user can pass the option while SDK init. Now the same thing could be handled in the form of a custom plugin.

```
Analytics(
    configuration = Configuration(
        trackApplicationLifecycleEvents = true,
        writeKey = "<WRITE_KEY>",
        application = application,
        dataPlaneUrl = "<DATA_PLANE_URL>",
        logLevel = Logger.LogLevel.VERBOSE,
    )
)
// ADD THE CUSTOM OPTION PLUGIN LIKE THIS:
analytics.add(OptionPlugin(
    option = RudderOption(
        customContext = buildJsonObject {
            put("key", "value")
        },
        integrations = mapOf(
            "CleverTap" to true
        ),
    )
))
```

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

- Run the app and note the following values get automatically added in the events payload.

CustomContext: key: value
Integrations: CleverTap: true

```
{
    "anonymousId": "e33b32fa-d3d3-4b30-9879-0548fb3f65f6",
    "channel": "mobile",
    "context": {
        "app": {
            "build": "100",
            "name": "Rudder-Android-Libs",
            "namespace": "com.rudderstack.android.sampleapp",
            "version": "0.1.0"
        },
        "device": {
            "adTrackingEnabled": true,
            "id": "11c89c643bfb7b71",
            "manufacturer": "Google",
            "model": "sdk_gphone64_arm64",
            "name": "emu64a",
            "type": "Android"
        },
        "key": "value",                                                    <----- Custom Context
        "library": {
            "name": "com.rudderstack.android.sdk",
            "version": "1.0.0"
        },
        "locale": "en-US",
        "network": {
            "bluetooth": true,
            "carrier": "T-Mobile",
            "cellular": true,
            "wifi": true
        },
        "os": {
            "name": "Android",
            "version": "14"
        },
        "screen": {
            "density": 560,
            "height": 2808,
            "width": 1440
        },
        "timezone": "Asia/Kolkata",
        "traits": {
            "anonymousId": "e33b32fa-d3d3-4b30-9879-0548fb3f65f6"
        }
    },
    "event": "Application Installed",
    "integrations": {
        "All": true,
        "CleverTap": true                                                   <------ Integrations
    },
    "messageId": "65745861-ac35-44f8-86e2-bd1937026fcb",
    "originalTimestamp": "2024-11-15T08:42:34.040Z",
    "properties": {
        "build": 100,
        "version": "0.1.0"
    },
    "receivedAt": "2024-11-15T08:42:36.228Z",
    "request_ip": "49.37.34.249",
    "rudderId": "f02902c4-48e1-434e-82ce-a97db6f5e079",
    "sentAt": "2024-11-15T08:42:34.437Z",
    "type": "track"
}
```

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

<img width="242" alt="image" src="https://github.com/user-attachments/assets/9b96d19c-b17b-4f7f-aabe-7ccf93405c6e">

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->

As of now, any plugins can only be added after the SDK initialisation. It might happen that some events are made and then these plugins are added, then those events could miss these values. In order to ensure every event has the updated values, we can consider having **a way to collect these custom plugins as a part of the SDK initialisation** (probably as a configuration parameter.)