### PR TITLE
feat: implement connectivity observer

### DIFF
--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -3,6 +3,7 @@ package com.rudderstack.sdk.kotlin.android
 import android.app.Activity
 import androidx.navigation.NavController
 import androidx.navigation.NavController.OnDestinationChangedListener
+import com.rudderstack.sdk.kotlin.android.connectivity.AndroidConnectivityObserver
 import com.rudderstack.sdk.kotlin.android.logger.AndroidLogger
 import com.rudderstack.sdk.kotlin.android.plugins.AndroidLifecyclePlugin
 import com.rudderstack.sdk.kotlin.android.plugins.AppInfoPlugin
@@ -22,6 +23,7 @@ import com.rudderstack.sdk.kotlin.android.plugins.sessiontracking.SessionTrackin
 import com.rudderstack.sdk.kotlin.android.state.NavContext
 import com.rudderstack.sdk.kotlin.android.storage.provideAndroidStorage
 import com.rudderstack.sdk.kotlin.core.Analytics
+import com.rudderstack.sdk.kotlin.core.internals.connectivity.ConnectivityObserver
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.platform.Platform
 import com.rudderstack.sdk.kotlin.core.internals.platform.PlatformType
@@ -77,6 +79,7 @@ class Analytics(
     internal val activityLifecycleManagementPlugin = ActivityLifecycleManagementPlugin()
     internal val processLifecycleManagementPlugin = ProcessLifecycleManagementPlugin()
     private val sessionTrackingPlugin = SessionTrackingPlugin()
+    override lateinit var connectivityObserver: ConnectivityObserver
 
     init {
         setup()
@@ -220,6 +223,8 @@ class Analytics(
         // adding lifecycle management plugins last so that lifecycle callbacks are invoked after all the observers in plugins are added.
         add(processLifecycleManagementPlugin)
         add(activityLifecycleManagementPlugin)
+
+        connectivityObserver = AndroidConnectivityObserver((configuration as Configuration).application, this)
     }
 
     override fun getPlatformType(): PlatformType = PlatformType.Mobile

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -224,7 +224,7 @@ class Analytics(
         add(processLifecycleManagementPlugin)
         add(activityLifecycleManagementPlugin)
 
-        connectivityObserver = AndroidConnectivityObserver((configuration as Configuration).application, this)
+        connectivityObserver = AndroidConnectivityObserver((configuration as Configuration).application, this.analyticsScope)
     }
 
     override fun getPlatformType(): PlatformType = PlatformType.Mobile

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
@@ -122,7 +122,7 @@ internal fun createNetworkCallback(networkAvailable: AtomicBoolean, notifySubscr
     object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
             super.onAvailable(network)
-            notifySubscriberOnceOnNetworkAvailable(networkAvailable, notifySubscriber)
+            enableNetworkAndNotify(networkAvailable, notifySubscriber)
         }
 
         override fun onLost(network: Network) {
@@ -132,12 +132,12 @@ internal fun createNetworkCallback(networkAvailable: AtomicBoolean, notifySubscr
     }
 
 @VisibleForTesting
-internal fun createBroadcastReceiver(networkAvailable: AtomicBoolean, notifySubscriber: () -> Unit,) =
+internal fun createBroadcastReceiver(networkAvailable: AtomicBoolean, notifySubscriber: () -> Unit) =
     object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent?) {
             (context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager).activeNetworkInfo?.let {
                 when (it.isConnected) {
-                    true -> notifySubscriberOnceOnNetworkAvailable(networkAvailable, notifySubscriber)
+                    true -> enableNetworkAndNotify(networkAvailable, notifySubscriber)
                     false -> networkAvailable.set(false)
                 }
             } ?: run { // if activeNetworkInfo is null, it means the device is not connected to any network.
@@ -146,8 +146,7 @@ internal fun createBroadcastReceiver(networkAvailable: AtomicBoolean, notifySubs
         }
     }
 
-private inline fun notifySubscriberOnceOnNetworkAvailable(networkAvailable: AtomicBoolean, notifySubscriber: () -> Unit) {
-    if (!networkAvailable.getAndSet(true)) {
-        notifySubscriber()
-    }
+private inline fun enableNetworkAndNotify(networkAvailable: AtomicBoolean, notifySubscriber: () -> Unit) {
+    networkAvailable.set(true)
+    notifySubscriber()
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
@@ -11,6 +11,8 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkInfo
 import android.os.Build
+import androidx.annotation.VisibleForTesting
+import com.rudderstack.sdk.kotlin.android.utils.runBasedOnSDK
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.connectivity.ConnectivityObserver
 import com.rudderstack.sdk.kotlin.core.internals.connectivity.ConnectivitySubscriber
@@ -46,57 +48,49 @@ internal class AndroidConnectivityObserver(
     private val pendingSubscribers = CopyOnWriteArrayList<suspend () -> Unit>()
 
     private val networkCallback by lazy {
-        object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                super.onAvailable(network)
-                networkAvailable.set(true)
-                notifySubscriber()
-            }
+        createNetworkCallback(networkAvailable) {
+            notifySubscribers()
         }
     }
-
-    private val connectivityReceiver: BroadcastReceiver by lazy {
-        object : BroadcastReceiver() {
-            override fun onReceive(context: Context, intent: Intent?) {
-                val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-                val networkInfo: NetworkInfo? = connectivityManager.activeNetworkInfo
-                val isConnected = networkInfo != null && networkInfo.isConnected
-                if (isConnected) {
-                    networkAvailable.set(true)
-                    notifySubscriber()
-                }
-            }
-        }
+    private val broadcastReceiver: BroadcastReceiver by lazy {
+        createBroadcastReceiver(networkAvailable) { notifySubscribers() }
     }
 
     init {
-        safelyExecute({ registerConnectivityObserver() }) {
-            LoggerAnalytics.error(
-                "Failed to register connectivity subscriber. Setting network availability to true.",
-                it
-            )
-            networkAvailable = AtomicBoolean(true)
-            notifySubscriber()
-        }
+        safelyExecute(
+            block = { registerConnectivityObserver() },
+            onException = {
+                LoggerAnalytics.error(
+                    "Failed to register connectivity subscriber. Setting network availability to true.",
+                    it
+                )
+                networkAvailable = AtomicBoolean(true)
+                notifySubscribers()
+            },
+        )
     }
 
     @Throws(RuntimeException::class)
     private fun registerConnectivityObserver() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            val connectivityManager = this.application.getSystemService(ConnectivityManager::class.java)
-            connectivityManager.registerDefaultNetworkCallback(networkCallback)
-        } else {
-            val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
-            this.application.registerReceiver(connectivityReceiver, intentFilter)
-        }
+        runBasedOnSDK(
+            minCompatibleVersion = Build.VERSION_CODES.N,
+            onCompatibleVersion = {
+                val connectivityManager: ConnectivityManager = application.getSystemService(ConnectivityManager::class.java)
+                connectivityManager.registerDefaultNetworkCallback(networkCallback)
+            },
+            onLegacyVersion = {
+                val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
+                this.application.registerReceiver(broadcastReceiver, intentFilter)
+            },
+        )
     }
 
-    private fun notifySubscriber() {
+    private fun notifySubscribers() {
         this.coreAnalytics.analyticsScope.launch {
-            pendingSubscribers.forEach {
-                it()
+            pendingSubscribers.also {
+                it.forEach { subscriber -> subscriber() }
+                it.clear()
             }
-            pendingSubscribers.clear()
         }
     }
 
@@ -117,3 +111,27 @@ internal class AndroidConnectivityObserver(
         }
     }
 }
+
+@VisibleForTesting
+internal fun createNetworkCallback(networkAvailable: AtomicBoolean, notifySubscriber: () -> Unit) =
+    object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            super.onAvailable(network)
+            networkAvailable.set(true)
+            notifySubscriber()
+        }
+    }
+
+@VisibleForTesting
+internal fun createBroadcastReceiver(networkAvailable: AtomicBoolean, notifySubscriber: () -> Unit) =
+    object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent?) {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val networkInfo: NetworkInfo? = connectivityManager.activeNetworkInfo
+            val isConnected = networkInfo != null && networkInfo.isConnected
+            if (isConnected) {
+                networkAvailable.set(true)
+                notifySubscriber()
+            }
+        }
+    }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
@@ -103,7 +103,7 @@ internal class AndroidConnectivityObserver(
      *
      * @param subscriber The subscriber to be notified when the network is available.
      */
-    override suspend fun notifyImmediatelyOrSubscribe(subscriber: suspend () -> Unit) {
+    override suspend fun immediateNotifyOrObserveConnectivity(subscriber: suspend () -> Unit) {
         networkAvailable.get().also {
             when (it) {
                 true -> subscriber()

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
@@ -18,6 +18,7 @@ import com.rudderstack.sdk.kotlin.core.internals.connectivity.ConnectivityObserv
 import com.rudderstack.sdk.kotlin.core.internals.connectivity.ConnectivitySubscriber
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.utils.safelyExecute
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
@@ -37,11 +38,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  * **NOTE**: Subscribers are notified exactly once.
  *
  * @param application The [Application] instance.
- * @param coreAnalytics The core [Analytics] instance.
+ * @param analyticsScope The core [Analytics] instance.
  */
 internal class AndroidConnectivityObserver(
     private val application: Application,
-    private val coreAnalytics: Analytics,
+    private val analyticsScope: CoroutineScope,
 ) : ConnectivityObserver {
 
     private var networkAvailable: AtomicBoolean = AtomicBoolean(false)
@@ -86,7 +87,7 @@ internal class AndroidConnectivityObserver(
     }
 
     private fun notifySubscribers() {
-        this.coreAnalytics.analyticsScope.launch {
+        this.analyticsScope.launch {
             pendingSubscribers.also {
                 it.forEach { subscriber -> subscriber() }
                 it.clear()

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
@@ -44,7 +44,7 @@ internal class AndroidConnectivityObserver(
     private val analyticsScope: CoroutineScope,
 ) : ConnectivityObserver {
 
-    private var networkAvailable: AtomicBoolean = AtomicBoolean(false)
+    private val networkAvailable: AtomicBoolean = AtomicBoolean(false)
     private val pendingSubscribers = CopyOnWriteArrayList<suspend () -> Unit>()
 
     private val networkCallback by lazy { createNetworkCallback(networkAvailable) { notifySubscribers() } }
@@ -87,7 +87,7 @@ internal class AndroidConnectivityObserver(
      * while monitoring the network connection status.
      */
     private fun defaultBehaviour() {
-        networkAvailable = AtomicBoolean(true)
+        networkAvailable.set(true)
         notifySubscribers()
     }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserver.kt
@@ -35,11 +35,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  * **NOTE**: Subscribers are notified exactly once.
  *
  * @param application The [Application] instance.
- * @param analytics The [Analytics] instance.
+ * @param coreAnalytics The core [Analytics] instance.
  */
 internal class AndroidConnectivityObserver(
     private val application: Application,
-    private val analytics: Analytics,
+    private val coreAnalytics: Analytics,
 ) : ConnectivityObserver {
 
     private var networkAvailable: AtomicBoolean = AtomicBoolean(false)
@@ -92,7 +92,7 @@ internal class AndroidConnectivityObserver(
     }
 
     private fun notifySubscriber() {
-        this.analytics.analyticsScope.launch {
+        this.coreAnalytics.analyticsScope.launch {
             pendingSubscribers.forEach {
                 it()
             }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/utils/AndroidUtils.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/utils/AndroidUtils.kt
@@ -1,0 +1,39 @@
+package com.rudderstack.sdk.kotlin.android.utils
+
+import android.os.Build
+import androidx.annotation.ChecksSdkIntAtLeast
+import com.rudderstack.sdk.kotlin.android.utils.AppSDKVersion.getVersionSDKInt
+
+/**
+ * Executes the provided lambda function based on the current SDK version.
+ *
+ * This function compares the current SDK version with a specified minimum compatible version.
+ * If the current SDK version is greater than or equal to the minimum version,
+ * it runs the `onCompatibleVersion` lambda. Otherwise, it runs the `onLegacyVersion` lambda.
+ *
+ * @param minCompatibleVersion The minimum SDK version required to execute `onCompatibleVersion`.
+ * @param onCompatibleVersion A lambda function to execute if the current SDK version is compatible.
+ * @param onLegacyVersion A lambda function to execute if the current SDK version is below the required minimum.
+ */
+@ChecksSdkIntAtLeast(parameter = 0, lambda = 1)
+internal inline fun runBasedOnSDK(minCompatibleVersion: Int, onCompatibleVersion: () -> Unit, onLegacyVersion: () -> Unit,) {
+    if (getVersionSDKInt() >= minCompatibleVersion) {
+        onCompatibleVersion()
+    } else {
+        onLegacyVersion()
+    }
+}
+
+/**
+ * A utility object to retrieve the current SDK version of the Android platform.
+ *
+ * This wrapper around `Build.VERSION.SDK_INT` allows for easier testing and mocking
+ * during unit tests. By encapsulating the SDK version retrieval in a separate function,
+ * it becomes possible to mock `getVersionSDKInt()` and simulate different SDK versions
+ * without relying on the actual device or emulator environment.
+ */
+internal object AppSDKVersion {
+    fun getVersionSDKInt(): Int {
+        return Build.VERSION.SDK_INT
+    }
+}

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserverTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserverTest.kt
@@ -1,0 +1,208 @@
+package com.rudderstack.sdk.kotlin.android.connectivity
+
+import android.app.Application
+import android.content.BroadcastReceiver
+import android.net.ConnectivityManager
+import android.os.Build
+import com.rudderstack.sdk.kotlin.android.utils.AppSDKVersion
+import com.rudderstack.sdk.kotlin.android.utils.mockAnalytics
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.invoke
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.unmockkStatic
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
+
+class AndroidConnectivityObserverTest {
+
+    @MockK
+    private lateinit var mockApplication: Application
+
+    @MockK
+    private lateinit var mockNetworkCallback: ConnectivityManager.NetworkCallback
+
+    @MockK
+    private lateinit var mockBroadcastReceiver: BroadcastReceiver
+
+    @MockK
+    private lateinit var mockConnectivityManager: ConnectivityManager
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+    private val mockAnalytics = mockAnalytics(testScope, testDispatcher)
+
+    private val networkCallbackAvailabilitySlot = slot<AtomicBoolean>()
+    private val networkCallbackSubscribersSlot = slot<() -> Unit>()
+
+    private val broadcastReceiverAvailabilitySlot = slot<AtomicBoolean>()
+    private val broadcastReceiverSubscribersSlot = slot<() -> Unit>()
+
+    private val sdkVersions = listOf(
+        Build.VERSION_CODES.N,          // Compatible SDK version
+        Build.VERSION_CODES.LOLLIPOP,   // Legacy SDK version
+    )
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        every { mockApplication.getSystemService(ConnectivityManager::class.java) } returns mockConnectivityManager
+
+        mockkStatic(::createBroadcastReceiver, ::createNetworkCallback)
+        every {
+            createNetworkCallback(
+                networkAvailable = capture(networkCallbackAvailabilitySlot),
+                notifySubscriber = capture(networkCallbackSubscribersSlot),
+            )
+        } returns mockNetworkCallback
+        every {
+            createBroadcastReceiver(
+                networkAvailable = capture(broadcastReceiverAvailabilitySlot),
+                notifySubscriber = capture(broadcastReceiverSubscribersSlot),
+            )
+        } returns mockBroadcastReceiver
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(::createNetworkCallback, ::createBroadcastReceiver)
+    }
+
+    @Test
+    fun `given connection is not available initially, when connection gets available, then pending subscribers are notified`() =
+        runTest(testDispatcher) {
+            sdkVersions.forEach { sdkVersion ->
+                val subscriber1 = createSpySubscriber()
+                val subscriber2 = createSpySubscriber()
+                mockkObject(AppSDKVersion)
+                every { AppSDKVersion.getVersionSDKInt() } returns sdkVersion
+                AndroidConnectivityObserver(
+                    application = mockApplication,
+                    coreAnalytics = mockAnalytics,
+                ).also {
+                    // This will be added in the pending subscribers list and will be notified when the network is available.
+                    it.notifyImmediatelyOrSubscribe { subscriber1.subscribe() }
+                    it.notifyImmediatelyOrSubscribe { subscriber2.subscribe() }
+                }
+
+                simulateNetworkAvailability()
+
+                assertTrue(networkCallbackSubscribersSlot.isCaptured)
+                verifySubscribersAreNotified(subscriber1, subscriber2)
+            }
+        }
+
+    @Test
+    fun `given connection is available initially, when subscribed, then they are notified immediately`() =
+        runTest(testDispatcher) {
+            sdkVersions.forEach { sdkVersion ->
+                val subscriber1 = createSpySubscriber()
+                val subscriber2 = createSpySubscriber()
+                mockkObject(AppSDKVersion)
+                every { AppSDKVersion.getVersionSDKInt() } returns sdkVersion
+                val androidConnectivityObserver = AndroidConnectivityObserver(
+                    application = mockApplication,
+                    coreAnalytics = mockAnalytics,
+                )
+                simulateNetworkAvailability()
+
+                // This will be notified immediately as the network is available.
+                androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber1.subscribe() }
+                androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber2.subscribe() }
+
+                verifySubscribersAreNotified(subscriber1, subscriber2)
+            }
+        }
+
+    @Test
+    fun `given initially connection is not available, when connection gets available, then both pending and new subscribers are notified`() =
+        runTest(testDispatcher) {
+            sdkVersions.forEach { sdkVersion ->
+                val subscriber1 = createSpySubscriber()
+                val subscriber2 = createSpySubscriber()
+                mockkObject(AppSDKVersion)
+                every { AppSDKVersion.getVersionSDKInt() } returns sdkVersion
+                val androidConnectivityObserver = AndroidConnectivityObserver(
+                    application = mockApplication,
+                    coreAnalytics = mockAnalytics,
+                ).also {
+                    // This will be added in the pending subscribers list and will be notified when the network is available.
+                    it.notifyImmediatelyOrSubscribe { subscriber1.subscribe() }
+                }
+
+                simulateNetworkAvailability()
+                // This will be notified immediately as the network is available.
+                androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber2.subscribe() }
+
+                assertTrue(networkCallbackSubscribersSlot.isCaptured)
+                verifySubscribersAreNotified(subscriber1, subscriber2)
+            }
+        }
+
+    @Test
+    fun `given some exception is thrown and compatible SDK version is used and initially no subscriber is present, when subscribed, then they are notified immediately`() =
+        runTest(testDispatcher) {
+            val subscriber1 = createSpySubscriber()
+            val subscriber2 = createSpySubscriber()
+            mockkObject(AppSDKVersion)
+            every { AppSDKVersion.getVersionSDKInt() } returns Build.VERSION_CODES.N
+            // As per the API of getSystemService, it can throw RuntimeException.
+            every { mockApplication.getSystemService(ConnectivityManager::class.java) } throws RuntimeException()
+            val androidConnectivityObserver = AndroidConnectivityObserver(
+                application = mockApplication,
+                coreAnalytics = mockAnalytics,
+            )
+
+            // They will be notified immediately.
+            androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber1.subscribe() }
+            androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber2.subscribe() }
+
+            verifySubscribersAreNotified(subscriber1, subscriber2)
+        }
+
+    private fun simulateNetworkAvailability() {
+        if (networkCallbackAvailabilitySlot.isCaptured) {
+            networkCallbackAvailabilitySlot.captured.set(true)
+            networkCallbackSubscribersSlot.invoke()
+        }
+        if (broadcastReceiverAvailabilitySlot.isCaptured) {
+            broadcastReceiverAvailabilitySlot.captured.set(true)
+            broadcastReceiverSubscribersSlot.invoke()
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+    }
+
+    private fun verifySubscribersAreNotified(subscriber1: NetworkObserver, subscriber2: NetworkObserver) {
+        coVerify(exactly = 1) { subscriber1.subscribe() }
+        coVerify(exactly = 1) { subscriber2.subscribe() }
+    }
+
+    private fun createSpySubscriber(): NetworkObserver {
+        return spyk(NetworkObserver()).apply {
+            coEvery { subscribe() } just Runs
+        }
+    }
+}
+
+// As Mockk doesn't support spying on suspend lambda function, we need to create a class for the same.
+private class NetworkObserver {
+
+    fun subscribe() {
+        // Do nothing
+    }
+}

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserverTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserverTest.kt
@@ -91,10 +91,7 @@ class AndroidConnectivityObserverTest {
                 val subscriber2 = createSpySubscriber()
                 mockkObject(AppSDKVersion)
                 every { AppSDKVersion.getVersionSDKInt() } returns sdkVersion
-                AndroidConnectivityObserver(
-                    application = mockApplication,
-                    coreAnalytics = mockAnalytics,
-                ).also {
+                provideAndroidConnectivityObserver().also {
                     // This will be added in the pending subscribers list and will be notified when the network is available.
                     it.notifyImmediatelyOrSubscribe { subscriber1.subscribe() }
                     it.notifyImmediatelyOrSubscribe { subscriber2.subscribe() }
@@ -115,10 +112,7 @@ class AndroidConnectivityObserverTest {
                 val subscriber2 = createSpySubscriber()
                 mockkObject(AppSDKVersion)
                 every { AppSDKVersion.getVersionSDKInt() } returns sdkVersion
-                val androidConnectivityObserver = AndroidConnectivityObserver(
-                    application = mockApplication,
-                    coreAnalytics = mockAnalytics,
-                )
+                val androidConnectivityObserver = provideAndroidConnectivityObserver()
                 simulateNetworkAvailability()
 
                 // This will be notified immediately as the network is available.
@@ -137,10 +131,7 @@ class AndroidConnectivityObserverTest {
                 val subscriber2 = createSpySubscriber()
                 mockkObject(AppSDKVersion)
                 every { AppSDKVersion.getVersionSDKInt() } returns sdkVersion
-                val androidConnectivityObserver = AndroidConnectivityObserver(
-                    application = mockApplication,
-                    coreAnalytics = mockAnalytics,
-                ).also {
+                val androidConnectivityObserver = provideAndroidConnectivityObserver().also {
                     // This will be added in the pending subscribers list and will be notified when the network is available.
                     it.notifyImmediatelyOrSubscribe { subscriber1.subscribe() }
                 }
@@ -163,10 +154,7 @@ class AndroidConnectivityObserverTest {
             every { AppSDKVersion.getVersionSDKInt() } returns Build.VERSION_CODES.N
             // As per the API of getSystemService, it can throw RuntimeException.
             every { mockApplication.getSystemService(ConnectivityManager::class.java) } throws RuntimeException()
-            val androidConnectivityObserver = AndroidConnectivityObserver(
-                application = mockApplication,
-                coreAnalytics = mockAnalytics,
-            )
+            val androidConnectivityObserver = provideAndroidConnectivityObserver()
 
             // They will be notified immediately.
             androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber1.subscribe() }
@@ -174,6 +162,11 @@ class AndroidConnectivityObserverTest {
 
             verifySubscribersAreNotified(subscriber1, subscriber2)
         }
+
+    private fun provideAndroidConnectivityObserver() = AndroidConnectivityObserver(
+        application = mockApplication,
+        analyticsScope = mockAnalytics.analyticsScope,
+    )
 
     private fun simulateNetworkAvailability() {
         if (networkCallbackAvailabilitySlot.isCaptured) {

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserverTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserverTest.kt
@@ -92,8 +92,8 @@ class AndroidConnectivityObserverTest {
                 every { AppSDKVersion.getVersionSDKInt() } returns sdkVersion
                 provideAndroidConnectivityObserver().also {
                     // This will be added in the pending subscribers list and will be notified when the network is available.
-                    it.notifyImmediatelyOrSubscribe { subscriber1.execute() }
-                    it.notifyImmediatelyOrSubscribe { subscriber2.execute() }
+                    it.immediateNotifyOrObserveConnectivity { subscriber1.execute() }
+                    it.immediateNotifyOrObserveConnectivity { subscriber2.execute() }
                 }
 
                 simulateNetworkAvailability()
@@ -114,8 +114,8 @@ class AndroidConnectivityObserverTest {
                 simulateNetworkAvailability()
 
                 // This will be notified immediately as the network is available.
-                androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber1.execute() }
-                androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber2.execute() }
+                androidConnectivityObserver.immediateNotifyOrObserveConnectivity { subscriber1.execute() }
+                androidConnectivityObserver.immediateNotifyOrObserveConnectivity { subscriber2.execute() }
 
                 verifySubscribersAreNotified(subscriber1, subscriber2)
             }
@@ -130,12 +130,12 @@ class AndroidConnectivityObserverTest {
                 every { AppSDKVersion.getVersionSDKInt() } returns sdkVersion
                 val androidConnectivityObserver = provideAndroidConnectivityObserver().also {
                     // This will be added in the pending subscribers list and will be notified when the network is available.
-                    it.notifyImmediatelyOrSubscribe { subscriber1.execute() }
+                    it.immediateNotifyOrObserveConnectivity { subscriber1.execute() }
                 }
 
                 simulateNetworkAvailability()
                 // This will be notified immediately as the network is available.
-                androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber2.execute() }
+                androidConnectivityObserver.immediateNotifyOrObserveConnectivity { subscriber2.execute() }
 
                 assertTrue(networkCallbackSubscribersSlot.isCaptured)
                 verifySubscribersAreNotified(subscriber1, subscriber2)
@@ -153,8 +153,8 @@ class AndroidConnectivityObserverTest {
             val androidConnectivityObserver = provideAndroidConnectivityObserver()
 
             // They will be notified immediately.
-            androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber1.execute() }
-            androidConnectivityObserver.notifyImmediatelyOrSubscribe { subscriber2.execute() }
+            androidConnectivityObserver.immediateNotifyOrObserveConnectivity { subscriber1.execute() }
+            androidConnectivityObserver.immediateNotifyOrObserveConnectivity { subscriber2.execute() }
 
             verifySubscribersAreNotified(subscriber1, subscriber2)
         }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserverTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/connectivity/AndroidConnectivityObserverTest.kt
@@ -7,13 +7,10 @@ import android.os.Build
 import com.rudderstack.sdk.kotlin.android.utils.AppSDKVersion
 import com.rudderstack.sdk.kotlin.android.utils.mockAnalytics
 import io.mockk.MockKAnnotations
-import io.mockk.Runs
-import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.invoke
-import io.mockk.just
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
@@ -186,9 +183,7 @@ class AndroidConnectivityObserverTest {
     }
 
     private fun createSpySubscriber(): NetworkObserver {
-        return spyk(NetworkObserver()).apply {
-            coEvery { subscribe() } just Runs
-        }
+        return spyk(NetworkObserver())
     }
 }
 

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/AndroidUtilsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/AndroidUtilsTest.kt
@@ -1,0 +1,47 @@
+package com.rudderstack.sdk.kotlin.android.utils
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class AndroidUtilsTest {
+
+    @Before
+    fun setup() {
+        mockkObject(AppSDKVersion)
+    }
+
+    @Test
+    fun `when block is run on compatible SDK version, then run the compatible block`() {
+        val minCompatibleVersion = 24
+        val compatibleBlock = provideSpyBlock()
+        val legacyBlock = provideSpyBlock()
+        every { AppSDKVersion.getVersionSDKInt() } returns 24
+
+        runBasedOnSDK(
+            minCompatibleVersion = minCompatibleVersion,
+            onCompatibleVersion = { compatibleBlock.execute() },
+            onLegacyVersion = { legacyBlock.execute() },
+        )
+
+        verify { compatibleBlock.execute() }
+    }
+
+    @Test
+    fun `when block is run on legacy SDK version, then run the legacy block`() {
+        val minCompatibleVersion = 24
+        val compatibleBlock = provideSpyBlock()
+        val legacyBlock = provideSpyBlock()
+        every { AppSDKVersion.getVersionSDKInt() } returns 21
+
+        runBasedOnSDK(
+            minCompatibleVersion = minCompatibleVersion,
+            onCompatibleVersion = { compatibleBlock.execute() },
+            onLegacyVersion = { legacyBlock.execute() },
+        )
+
+        verify { legacyBlock.execute() }
+    }
+}

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/Utils.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/Utils.kt
@@ -6,6 +6,7 @@ import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 import com.rudderstack.sdk.kotlin.android.Analytics as AndroidAnalytics
@@ -66,4 +67,16 @@ fun mockUri(
 
 fun setupLogger(logger: Logger, level: Logger.LogLevel = Logger.LogLevel.VERBOSE) {
     LoggerAnalytics.setup(logger = logger, logLevel = level)
+}
+
+// As Mockk doesn't seems to support spying on lambda function, we need to create a class for the same.
+class Block {
+
+    fun execute() {
+        // Do nothing
+    }
+}
+
+fun provideSpyBlock(): Block {
+    return spyk(Block())
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -1,5 +1,8 @@
 package com.rudderstack.sdk.kotlin.core
 
+import com.rudderstack.sdk.kotlin.core.internals.connectivity.BaseConnectivityObserver
+import com.rudderstack.sdk.kotlin.core.internals.connectivity.ConnectivityObserver
+import com.rudderstack.sdk.kotlin.core.internals.connectivity.DefaultConnectivityObserver
 import com.rudderstack.sdk.kotlin.core.internals.logger.KotlinLogger
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
@@ -64,7 +67,7 @@ open class Analytics protected constructor(
             analyticsConfiguration.storage
         )
     ),
-) : AnalyticsConfiguration by analyticsConfiguration, Platform {
+) : AnalyticsConfiguration by analyticsConfiguration, Platform, BaseConnectivityObserver() {
 
     private val pluginChain: PluginChain = PluginChain().also { it.analytics = this }
 
@@ -76,6 +79,8 @@ open class Analytics protected constructor(
     @Volatile
     internal var isAnalyticsShutdown = false
         private set
+
+    override val connectivityObserver: ConnectivityObserver by lazy { DefaultConnectivityObserver() }
 
     init {
         processEvents()

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/ConnectivityObserver.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/ConnectivityObserver.kt
@@ -1,0 +1,33 @@
+package com.rudderstack.sdk.kotlin.core.internals.connectivity
+
+import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
+
+/**
+ * Interface for observing network availability.
+ */
+@InternalRudderApi
+interface ConnectivityObserver : ConnectivitySubscriber
+
+/**
+ * Base class for connectivity observers.
+ */
+@InternalRudderApi
+abstract class BaseConnectivityObserver : ConnectivitySubscriber {
+
+    /**
+     * The connectivity observer to be used.
+     */
+    protected abstract val connectivityObserver: ConnectivityObserver
+
+    /**
+     * Observes the network availability and notifies the subscriber immediately if the network is available.
+     * Otherwise, it waits for the network to be available and then notifies the subscriber.
+     *
+     * **NOTE**: Subscriber are notified exactly once.
+     *
+     * @param subscriber The subscriber to be notified when the network is available.
+     */
+    override suspend fun notifyImmediatelyOrSubscribe(subscriber: suspend () -> Unit) {
+        connectivityObserver.notifyImmediatelyOrSubscribe(subscriber)
+    }
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/ConnectivityObserver.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/ConnectivityObserver.kt
@@ -27,7 +27,7 @@ abstract class BaseConnectivityObserver : ConnectivitySubscriber {
      *
      * @param subscriber The subscriber to be notified when the network is available.
      */
-    override suspend fun notifyImmediatelyOrSubscribe(subscriber: suspend () -> Unit) {
-        connectivityObserver.notifyImmediatelyOrSubscribe(subscriber)
+    override suspend fun immediateNotifyOrObserveConnectivity(subscriber: suspend () -> Unit) {
+        connectivityObserver.immediateNotifyOrObserveConnectivity(subscriber)
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/ConnectivitySubscriber.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/ConnectivitySubscriber.kt
@@ -1,0 +1,20 @@
+package com.rudderstack.sdk.kotlin.core.internals.connectivity
+
+import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
+
+/**
+ * Interface for subscribing to network availability.
+ */
+@InternalRudderApi
+interface ConnectivitySubscriber {
+
+    /**
+     * Observes the network availability and notifies the subscriber immediately if the network is available.
+     * Otherwise, it waits for the network to be available and then notifies the subscriber.
+     *
+     * **NOTE**: Subscriber are notified exactly once.
+     *
+     * @param subscriber The subscriber to be notified when the network is available.
+     */
+    suspend fun notifyImmediatelyOrSubscribe(subscriber: suspend () -> Unit)
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/ConnectivitySubscriber.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/ConnectivitySubscriber.kt
@@ -16,5 +16,5 @@ interface ConnectivitySubscriber {
      *
      * @param subscriber The subscriber to be notified when the network is available.
      */
-    suspend fun notifyImmediatelyOrSubscribe(subscriber: suspend () -> Unit)
+    suspend fun immediateNotifyOrObserveConnectivity(subscriber: suspend () -> Unit)
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserver.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserver.kt
@@ -12,7 +12,7 @@ internal class DefaultConnectivityObserver : ConnectivityObserver {
      *
      * @param subscriber The subscriber to be notified.
      */
-    override suspend fun notifyImmediatelyOrSubscribe(subscriber: suspend () -> Unit) {
+    override suspend fun immediateNotifyOrObserveConnectivity(subscriber: suspend () -> Unit) {
         subscriber()
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserver.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserver.kt
@@ -1,0 +1,18 @@
+package com.rudderstack.sdk.kotlin.core.internals.connectivity
+
+/**
+ * Default implementation of [ConnectivityObserver].
+ */
+internal class DefaultConnectivityObserver : ConnectivityObserver {
+
+    /**
+     * Notifies the subscriber immediately.
+     *
+     * **Note**: It assumes that the network is available.
+     *
+     * @param subscriber The subscriber to be notified.
+     */
+    override suspend fun notifyImmediatelyOrSubscribe(subscriber: suspend () -> Unit) {
+        subscriber()
+    }
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/ExceptionHandlingUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/ExceptionHandlingUtils.kt
@@ -1,0 +1,24 @@
+package com.rudderstack.sdk.kotlin.core.internals.utils
+
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
+
+/**
+ * Executes the given block and catches any exception that occurs.
+ *
+ * **NOTE**: It catches the generic `Exception` type. Use it with caution.
+ *
+ * @param block The block to be executed.
+ * @param onException The block to be executed when an exception occurs. Default is to log the exception.
+ */
+@InternalRudderApi
+@Suppress("TooGenericExceptionCaught")
+fun safelyExecute(
+    block: () -> Unit,
+    onException: (Exception) -> Unit = { LoggerAnalytics.error("Exception occurred: $it") }
+) {
+    try {
+        block()
+    } catch (e: Exception) {
+        onException(e)
+    }
+}

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
@@ -79,6 +79,10 @@ class Block {
     fun execute() {
         // Do nothing
     }
+
+    fun executeAndThrowException() {
+        throw Exception("Exception occurred")
+    }
 }
 
 fun provideSpyBlock(): Block {

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
@@ -9,6 +9,7 @@ import com.rudderstack.sdk.kotlin.core.internals.policies.DEFAULT_FLUSH_INTERVAL
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -70,4 +71,16 @@ private fun String.cleanJsonString(): String {
 
 fun setupLogger(logger: Logger, level: Logger.LogLevel = Logger.LogLevel.VERBOSE) {
     LoggerAnalytics.setup(logger = logger, logLevel = level)
+}
+
+// As Mockk doesn't seems to support spying on lambda function, we need to create a class for the same.
+class Block {
+
+    fun execute() {
+        // Do nothing
+    }
+}
+
+fun provideSpyBlock(): Block {
+    return spyk(Block())
 }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
@@ -1,7 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.connectivity
 
+import com.rudderstack.sdk.kotlin.core.provideSpyBlock
 import io.mockk.coVerify
-import io.mockk.spyk
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -9,26 +9,16 @@ class DefaultConnectivityObserverTest {
 
     @Test
     fun `when subscriber is added, then they are notified immediately`() = runTest {
-        val subscriber1 = createSpySubscriber()
-        val subscriber2 = createSpySubscriber()
+        val subscriber1 = provideSpyBlock()
+        val subscriber2 = provideSpyBlock()
         val defaultObserver = DefaultConnectivityObserver()
 
-        defaultObserver.notifyImmediatelyOrSubscribe { subscriber1.subscribe() }
-        defaultObserver.notifyImmediatelyOrSubscribe { subscriber2.subscribe() }
+        defaultObserver.notifyImmediatelyOrSubscribe {
+            subscriber1.execute()
+            defaultObserver.notifyImmediatelyOrSubscribe { subscriber2.execute() }
 
-        coVerify { subscriber1.subscribe() }
-        coVerify { subscriber2.subscribe() }
-    }
-
-    private fun createSpySubscriber(): NetworkObserver {
-        return spyk(NetworkObserver())
-    }
-}
-
-// As Mockk doesn't support spying on suspend lambda function, we need to create a class for the same.
-private class NetworkObserver {
-
-    fun subscribe() {
-        // Do nothing
+            coVerify { subscriber1.execute() }
+            coVerify { subscriber2.execute() }
+        }
     }
 }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
@@ -13,9 +13,9 @@ class DefaultConnectivityObserverTest {
         val subscriber2 = provideSpyBlock()
         val defaultObserver = DefaultConnectivityObserver()
 
-        defaultObserver.notifyImmediatelyOrSubscribe {
+        defaultObserver.immediateNotifyOrObserveConnectivity {
             subscriber1.execute()
-            defaultObserver.notifyImmediatelyOrSubscribe { subscriber2.execute() }
+            defaultObserver.immediateNotifyOrObserveConnectivity { subscriber2.execute() }
 
             coVerify { subscriber1.execute() }
             coVerify { subscriber2.execute() }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
@@ -13,12 +13,10 @@ class DefaultConnectivityObserverTest {
         val subscriber2 = provideSpyBlock()
         val defaultObserver = DefaultConnectivityObserver()
 
-        defaultObserver.immediateNotifyOrObserveConnectivity {
-            subscriber1.execute()
-            defaultObserver.immediateNotifyOrObserveConnectivity { subscriber2.execute() }
+        defaultObserver.immediateNotifyOrObserveConnectivity { subscriber1.execute() }
+        defaultObserver.immediateNotifyOrObserveConnectivity { subscriber2.execute() }
 
-            coVerify { subscriber1.execute() }
-            coVerify { subscriber2.execute() }
-        }
+        coVerify { subscriber1.execute() }
+        coVerify { subscriber2.execute() }
     }
 }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
@@ -1,0 +1,39 @@
+package com.rudderstack.sdk.kotlin.core.internals.connectivity
+
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.spyk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DefaultConnectivityObserverTest {
+
+    @Test
+    fun `when subscriber is added, then they are notified immediately`() = runTest {
+        val subscriber1 = createSpySubscriber()
+        val subscriber2 = createSpySubscriber()
+        val defaultObserver = DefaultConnectivityObserver()
+
+        defaultObserver.notifyImmediatelyOrSubscribe { subscriber1.subscribe() }
+        defaultObserver.notifyImmediatelyOrSubscribe { subscriber2.subscribe() }
+
+        coVerify { subscriber1.subscribe() }
+        coVerify { subscriber2.subscribe() }
+    }
+
+    private fun createSpySubscriber(): NetworkObserver {
+        return spyk(NetworkObserver()).apply {
+            coEvery { subscribe() } just Runs
+        }
+    }
+}
+
+// As Mockk doesn't support spying on suspend lambda function, we need to create a class for the same.
+private class NetworkObserver {
+
+    fun subscribe() {
+        // Do nothing
+    }
+}

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/connectivity/DefaultConnectivityObserverTest.kt
@@ -1,9 +1,6 @@
 package com.rudderstack.sdk.kotlin.core.internals.connectivity
 
-import io.mockk.Runs
-import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.just
 import io.mockk.spyk
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -24,9 +21,7 @@ class DefaultConnectivityObserverTest {
     }
 
     private fun createSpySubscriber(): NetworkObserver {
-        return spyk(NetworkObserver()).apply {
-            coEvery { subscribe() } just Runs
-        }
+        return spyk(NetworkObserver())
     }
 }
 

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/ExceptionHandlingTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/ExceptionHandlingTest.kt
@@ -1,6 +1,6 @@
 package com.rudderstack.sdk.kotlin.core.internals.utils
 
-import io.mockk.spyk
+import com.rudderstack.sdk.kotlin.core.provideSpyBlock
 import io.mockk.verify
 import org.junit.Test
 
@@ -8,50 +8,26 @@ class ExceptionHandlingTest {
 
     @Test
     fun `given exception occurs, when certain block is executed safely, then it should not throw any exception`() {
-        val exceptionBlock = createSpyExceptionBlock()
+        val exceptionBlock = provideSpyBlock()
 
         safelyExecute(
-            block = { exceptionBlock.execute() },
+            block = { exceptionBlock.executeAndThrowException() },
         )
 
-        verify { exceptionBlock.execute() }
+        verify { exceptionBlock.executeAndThrowException() }
     }
 
     @Test
     fun `given exception occurs and default block is provided, when certain block is executed safely, then default block is executed on exception`() {
-        val exceptionBlock = createSpyExceptionBlock()
-        val safeBlock = createSpySafeBlock()
+        val exceptionBlock = provideSpyBlock()
+        val safeBlock = provideSpyBlock()
 
         safelyExecute(
-            block = { exceptionBlock.execute() },
+            block = { exceptionBlock.executeAndThrowException() },
             onException = { safeBlock.execute() },
         )
 
-        verify { exceptionBlock.execute() }
+        verify { exceptionBlock.executeAndThrowException() }
         verify { safeBlock.execute() }
-    }
-
-    private fun createSpyExceptionBlock(): ExceptionBlock {
-        return spyk(ExceptionBlock())
-    }
-
-    private fun createSpySafeBlock(): SafeBlock {
-        return spyk(SafeBlock())
-    }
-}
-
-// As Mockk doesn't support spying on suspend lambda function, we need to create a class for the same.
-private class ExceptionBlock {
-
-    fun execute() {
-        throw Exception("Exception occurred")
-    }
-}
-
-// As Mockk doesn't support spying on suspend lambda function, we need to create a class for the same.
-private class SafeBlock {
-
-    fun execute() {
-        // Execute safely
     }
 }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/ExceptionHandlingTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/ExceptionHandlingTest.kt
@@ -1,0 +1,57 @@
+package com.rudderstack.sdk.kotlin.core.internals.utils
+
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Test
+
+class ExceptionHandlingTest {
+
+    @Test
+    fun `given exception occurs, when certain block is executed safely, then it should not throw any exception`() {
+        val exceptionBlock = createSpyExceptionBlock()
+
+        safelyExecute(
+            block = { exceptionBlock.execute() },
+        )
+
+        verify { exceptionBlock.execute() }
+    }
+
+    @Test
+    fun `given exception occurs and default block is provided, when certain block is executed safely, then default block is executed on exception`() {
+        val exceptionBlock = createSpyExceptionBlock()
+        val safeBlock = createSpySafeBlock()
+
+        safelyExecute(
+            block = { exceptionBlock.execute() },
+            onException = { safeBlock.execute() },
+        )
+
+        verify { exceptionBlock.execute() }
+        verify { safeBlock.execute() }
+    }
+
+    private fun createSpyExceptionBlock(): ExceptionBlock {
+        return spyk(ExceptionBlock())
+    }
+
+    private fun createSpySafeBlock(): SafeBlock {
+        return spyk(SafeBlock())
+    }
+}
+
+// As Mockk doesn't support spying on suspend lambda function, we need to create a class for the same.
+private class ExceptionBlock {
+
+    fun execute() {
+        throw Exception("Exception occurred")
+    }
+}
+
+// As Mockk doesn't support spying on suspend lambda function, we need to create a class for the same.
+private class SafeBlock {
+
+    fun execute() {
+        // Execute safely
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- In this PR, we've added a connection availability observer for the Android and core modules. 
- Android modules rely on the Android OS to handle the connectivity callback, whereas the core module defaults to always enabling network connectivity.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

### Connectivity Observer

- Defined `ConnectivitySubscriber` interface which allows subscribing to observe a network availability.
- Defined `ConnectivityObserver` and `BaseConnectivityObserver` interfaces which provide an interface for the connectivity observers in the respective modules.
- `DefaultConnectivityObserver` (core): It implements `ConnectivityObserver` which doesn't have a logic to check for network availability. It assumes the network is available.
- `AndroidConnectivityObserver` (android): It implements `ConnectivityObserver` and has the logic to detect if the connection is available or not in the Android module. If the connection is available it notifies the subscriber immediately else once it becomes available it notifies them. It handles both legacy version and compatible SDK (i.e., API version `N = 24` or above).
    - **NOTE**: It notifies the subscriber exactly once.
    - **NOTE**: In case there is any exception while checking for connection availability, it goes to the default behaviour of notifying the users immediately and assuming the network is available.
- Analytics: It extends the `BaseConnectivityObserver` and implements the `observer`, a lazy initialisation, to ensure only one observer is active at a time.
- Added some utils methods.
- Added unit test.

Flow chart:

![network_request_flowchart](https://github.com/user-attachments/assets/4e08b2da-3201-4e86-bf7d-fdda2542f643)

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

1. Add this code in the Analytics class:
```
fun testConnectivityObserver() {
    this.analyticsScope.launch {
        this@Analytics.immediateNotifyOrObserveConnectivity {
            println("RudderStack: Network is avaialble")
        }
    }
}
```
2. Call `testConnectivityObserver()` from the sample app.
    a. If connection is available then: `RudderStack: Network is avaialble` will be printed.
    b. If connection is not available while checking then that lambda block will be notified once network becomes available.
3. Try with multiple other scenarios!

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->

Refer to this PR: https://github.com/rudderlabs/rudder-sdk-kotlin/pull/101 for final changes.
