### PR TITLE
refactor: remove IntegrationState in integrations

### DIFF
--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -14,7 +14,6 @@ import com.rudderstack.sdk.kotlin.android.plugins.NetworkInfoPlugin
 import com.rudderstack.sdk.kotlin.android.plugins.OSInfoPlugin
 import com.rudderstack.sdk.kotlin.android.plugins.ScreenInfoPlugin
 import com.rudderstack.sdk.kotlin.android.plugins.TimezoneInfoPlugin
-import com.rudderstack.sdk.kotlin.android.plugins.devicemode.DestinationResult
 import com.rudderstack.sdk.kotlin.android.plugins.devicemode.IntegrationPlugin
 import com.rudderstack.sdk.kotlin.android.plugins.devicemode.IntegrationsManagementPlugin
 import com.rudderstack.sdk.kotlin.android.plugins.lifecyclemanagment.ActivityLifecycleManagementPlugin
@@ -241,20 +240,6 @@ class Analytics(
         if (!isAnalyticsActive()) return
 
         integrationsManagementPlugin?.removeIntegration(plugin)
-    }
-
-    /**
-     * Registers a callback to be invoked when the destination of the [plugin] is ready.
-     *
-     * @param plugin The [IntegrationPlugin] for which the callback needs to be invoked.
-     * @param onReady The callback to be invoked when the destination is ready.
-     */
-    fun onDestinationReady(plugin: IntegrationPlugin, onReady: (Any?, DestinationResult) -> Unit) {
-        if (!isAnalyticsActive()) return
-
-        initIntegrationsManagementPlugin()
-
-        integrationsManagementPlugin?.onDestinationReady(plugin, onReady)
     }
 
     private fun initIntegrationsManagementPlugin() {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/devicemode/IntegrationPlugin.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/devicemode/IntegrationPlugin.kt
@@ -8,10 +8,14 @@ import com.rudderstack.sdk.kotlin.core.internals.models.SourceConfig
 import com.rudderstack.sdk.kotlin.core.internals.plugins.EventPlugin
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.internals.plugins.PluginChain
+import com.rudderstack.sdk.kotlin.core.internals.utils.Result
 import com.rudderstack.sdk.kotlin.core.internals.utils.defaultExceptionHandler
 import com.rudderstack.sdk.kotlin.core.internals.utils.safelyExecute
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonObject
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.concurrent.withLock
 
 /**
  * Base plugin class for all integration plugins.
@@ -31,15 +35,16 @@ abstract class IntegrationPlugin : EventPlugin {
      */
     abstract val key: String
 
-    @Volatile
-    internal var integrationState: IntegrationState = IntegrationState.Uninitialised
-        private set
-
     private lateinit var pluginChain: PluginChain
     private val pluginList = CopyOnWriteArrayList<Plugin>()
 
     @Volatile
     private var isPluginSetup = false
+
+    @Volatile
+    private lateinit var destinationResult: DestinationResult
+    private val callbacks = mutableListOf<(Any?, DestinationResult) -> Unit>()
+    private val mutex = Mutex()
 
     /**
      * Creates the destination instance. Override this method for the initialisation of destination.
@@ -51,19 +56,16 @@ abstract class IntegrationPlugin : EventPlugin {
     protected abstract fun create(destinationConfig: JsonObject): Boolean
 
     /**
-     * Updates the destination.
+     * Updates the destination for subsequent fetches of [SourceConfig].
      * Override this method if any kind of updating/reinitialising is required for a destination when
      * a new [SourceConfig] is fetched from control plane.
      *
      * @param destinationConfig The newly fetched configuration for the destination.
-     * @return true if the destination was updated successfully AND ready to accept new events, false otherwise.
+     * @param isDestinationDisabled `true` if the destination is disabled or absent in the dashboard, `false` otherwise.
      *
-     * **Note**: If the destination is not ready to accept new events, return false. The false return value indicates
-     * that no change to the state of the destination was made.
+     * **Note** - If the destination is disabled in dashboard, stop sending events to this destination.
      */
-    protected open fun update(destinationConfig: JsonObject): Boolean {
-        return false
-    }
+    protected abstract fun update(destinationConfig: JsonObject?, isDestinationDisabled: Boolean)
 
     /**
      * Returns the instance of the destination which was created.
@@ -93,25 +95,50 @@ abstract class IntegrationPlugin : EventPlugin {
         applyCustomPlugins()
     }
 
-    internal fun findAndInitDestination(sourceConfig: SourceConfig) {
-        findDestinationAndExecuteBlock(sourceConfig) { destinationConfig ->
-            createSafelyAndChangeState(destinationConfig)
+    internal suspend fun findAndInitDestination(sourceConfig: SourceConfig) {
+        findDestination(sourceConfig)?.let { configDestination ->
+            if (!configDestination.isDestinationEnabled) {
+                val errorMessage = "Destination $key is disabled in dashboard. " +
+                    "No events will be sent to this destination."
+                LoggerAnalytics.warn("IntegrationPlugin: $errorMessage")
+                destinationResult = Result.Failure(null, SdkNotInitializedException(errorMessage))
+                return
+            }
+            createSafelyAndSetResult(configDestination.destinationConfig)
+        } ?: run {
+            val errorMessage = "Destination $key not found in the source config. " +
+                "No events will be sent to this destination."
+            LoggerAnalytics.warn("IntegrationPlugin: $errorMessage")
+            destinationResult = Result.Failure(null, SdkNotInitializedException(errorMessage))
         }
+        notifyCallbacks()
     }
 
-    internal fun findAndUpdateDestination(sourceConfig: SourceConfig) {
-        findDestinationAndExecuteBlock(sourceConfig) { destinationConfig ->
-            updateSafelyAndChangeState(destinationConfig)
+    internal suspend fun findAndUpdateDestination(sourceConfig: SourceConfig) {
+        findDestination(sourceConfig)?.let { configDestination ->
+            if (!configDestination.isDestinationEnabled) {
+                LoggerAnalytics.warn(
+                    "IntegrationPlugin: Destination $key is disabled in dashboard. " +
+                        "No events will be sent to this destination."
+                )
+                updateSafely(null, true)
+                return
+            }
+            updateSafely(configDestination.destinationConfig, false)
+        } ?: run {
+            updateSafely(null, true)
+            LoggerAnalytics.warn(
+                "IntegrationPlugin: Destination $key not found in the source config. " +
+                    "No events will be sent to this destination."
+            )
         }
     }
 
     final override suspend fun intercept(event: Event): Event {
-        if (integrationState.isReady()) {
-            event.copy<Event>()
-                .let { pluginChain.applyPlugins(Plugin.PluginType.PreProcess, it) }
-                ?.let { pluginChain.applyPlugins(Plugin.PluginType.OnProcess, it) }
-                ?.let { handleEvent(it) }
-        }
+        event.copy<Event>()
+            .let { pluginChain.applyPlugins(Plugin.PluginType.PreProcess, it) }
+            ?.let { pluginChain.applyPlugins(Plugin.PluginType.OnProcess, it) }
+            ?.let { mutex.withLock { handleEvent(it) } }
 
         return event
     }
@@ -153,57 +180,52 @@ abstract class IntegrationPlugin : EventPlugin {
         }
     }
 
-    private inline fun findDestinationAndExecuteBlock(sourceConfig: SourceConfig, block: (JsonObject) -> Unit) {
-        findDestination(sourceConfig)?.let { configDestination ->
-            if (!configDestination.isDestinationEnabled) {
-                val errorMessage = "Destination $key is disabled in dashboard. No events will be sent to this destination."
-                LoggerAnalytics.warn(errorMessage)
-                integrationState = IntegrationState.Failed(SdkNotInitializedException(errorMessage))
-                return
+    suspend fun onDestinationReady(callback: (Any?, DestinationResult) -> Unit) {
+        if (::destinationResult.isInitialized) {
+            callback(getDestinationInstance(), destinationResult)
+        } else {
+            mutex.withLock {
+                callbacks.add(callback)
             }
-            block(configDestination.destinationConfig)
-        } ?: run {
-            val errorMessage = "Destination $key not found in the source config. No events will be sent to this destination."
-            integrationState = IntegrationState.Failed(SdkNotInitializedException(errorMessage))
-            LoggerAnalytics.warn("IntegrationPlugin: $errorMessage")
         }
     }
 
-    private fun createSafelyAndChangeState(destinationConfig: JsonObject) {
+    private suspend fun notifyCallbacks() {
+        mutex.withLock {
+            callbacks.forEach { callback -> callback(getDestinationInstance(), destinationResult) }
+            callbacks.clear()
+        }
+    }
+
+    private suspend fun createSafelyAndSetResult(destinationConfig: JsonObject) {
         safelyExecute(
             block = {
-                when (create(destinationConfig)) {
+                when (
+                    mutex.withLock { create(destinationConfig) }
+                ) {
                     true -> {
-                        integrationState = IntegrationState.Ready
+                        destinationResult = Result.Success(Unit)
                         LoggerAnalytics.debug("IntegrationPlugin: Destination $key is ready.")
                     }
+
                     false -> {
                         val errorMessage = "Destination $key failed to initialise."
-                        integrationState = IntegrationState.Failed(SdkNotInitializedException(errorMessage))
+                        destinationResult = Result.Failure(null, SdkNotInitializedException(errorMessage))
                         LoggerAnalytics.warn("IntegrationPlugin: $errorMessage")
                     }
                 }
             },
             onException = {
-                integrationState = IntegrationState.Failed(it)
+                destinationResult = Result.Failure(null, it)
                 LoggerAnalytics.error("IntegrationPlugin: Error: ${it.message} initializing destination $key.")
             }
         )
     }
 
-    private fun updateSafelyAndChangeState(destinationConfig: JsonObject) {
+    private suspend fun updateSafely(destinationConfig: JsonObject?, isDestinationDisabled: Boolean) {
         safelyExecute(
             block = {
-                when (update(destinationConfig)) {
-                    true -> {
-                        integrationState = IntegrationState.Ready
-                        LoggerAnalytics.debug("IntegrationPlugin: Destination $key updated.")
-                    }
-                    false -> {
-                        val errorMessage = "Destination $key failed to update."
-                        LoggerAnalytics.debug("IntegrationPlugin: $errorMessage")
-                    }
-                }
+                mutex.withLock { update(destinationConfig, isDestinationDisabled) }
             },
             onException = { exception ->
                 defaultExceptionHandler(
@@ -226,14 +248,4 @@ abstract class IntegrationPlugin : EventPlugin {
     private fun findDestination(sourceConfig: SourceConfig): Destination? {
         return sourceConfig.source.destinations.firstOrNull { it.destinationDefinition.displayName == key }
     }
-}
-
-internal sealed interface IntegrationState {
-    data object Ready : IntegrationState
-    data object Uninitialised : IntegrationState
-    data class Failed(
-        val exception: Exception
-    ) : IntegrationState
-
-    fun isReady() = this == Ready
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/devicemode/IntegrationsManagementPlugin.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/devicemode/IntegrationsManagementPlugin.kt
@@ -3,14 +3,14 @@ package com.rudderstack.sdk.kotlin.android.plugins.devicemode
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.models.Event
-import com.rudderstack.sdk.kotlin.core.internals.models.SourceConfig
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.internals.plugins.PluginChain
-import com.rudderstack.sdk.kotlin.core.internals.utils.Result
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectIndexed
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.ConcurrentHashMap
 
 internal const val MAX_QUEUE_SIZE = 1000
@@ -32,8 +32,9 @@ internal class IntegrationsManagementPlugin : Plugin {
 
     private val queuedEventsChannel: Channel<Event> = Channel(MAX_QUEUE_SIZE)
 
-    private val isSourceEnabled: Boolean
-        get() = analytics.sourceConfigState.value.source.isSourceEnabled
+    @Volatile
+    private var areDestinationsInitialised: Boolean = false
+    private val mutex = Mutex()
 
     override fun setup(analytics: Analytics) {
         super.setup(analytics)
@@ -45,16 +46,19 @@ internal class IntegrationsManagementPlugin : Plugin {
                 .collectIndexed { index, sourceConfig ->
                     val isFirstEmission = index == FIRST_INDEX
 
-                    integrationPluginChain.applyClosure { plugin ->
-                        if (plugin is IntegrationPlugin) {
-                            when (isFirstEmission) {
-                                true -> initAndNotifyCallbacks(sourceConfig, plugin)
-                                false -> plugin.findAndUpdateDestination(sourceConfig)
+                    mutex.withLock {
+                        integrationPluginChain.applySuspendingClosure { plugin ->
+                            if (plugin is IntegrationPlugin) {
+                                when (isFirstEmission) {
+                                    true -> plugin.findAndInitDestination(sourceConfig)
+                                    false -> plugin.findAndUpdateDestination(sourceConfig)
+                                }
                             }
                         }
-                    }
-                    if (isFirstEmission) {
-                        processEvents()
+                        if (isFirstEmission) {
+                            areDestinationsInitialised = true
+                            processEvents()
+                        }
                     }
                 }
         }
@@ -77,20 +81,14 @@ internal class IntegrationsManagementPlugin : Plugin {
         destinationReadyCallbacks.clear()
     }
 
-    internal fun onDestinationReady(plugin: IntegrationPlugin, onReady: (Any?, DestinationResult) -> Unit) {
-        destinationReadyCallbacks
-            .getOrPut(plugin.key) { mutableListOf() }
-            .add(onReady)
-
-        if (integrationPluginChain.hasIntegration(plugin)) {
-            notifyDestinationCallbacks(plugin)
-        }
-    }
-
     internal fun addIntegration(plugin: IntegrationPlugin) {
         integrationPluginChain.add(plugin)
-        if (isSourceEnabled) {
-            initAndNotifyCallbacks(analytics.sourceConfigState.value, plugin)
+        analytics.analyticsScope.launch {
+            mutex.withLock {
+                if (areDestinationsInitialised) {
+                    plugin.findAndInitDestination(analytics.sourceConfigState.value)
+                }
+            }
         }
     }
 
@@ -101,12 +99,12 @@ internal class IntegrationsManagementPlugin : Plugin {
     internal fun reset() {
         integrationPluginChain.applyClosure { plugin ->
             if (plugin is IntegrationPlugin) {
-                if (plugin.integrationState.isReady()) {
+                if (areDestinationsInitialised) {
                     plugin.reset()
                 } else {
                     LoggerAnalytics.debug(
-                        "IntegrationsManagementPlugin: Destination ${plugin.key} is " +
-                            "not ready yet. Reset discarded."
+                        "IntegrationsManagementPlugin: Integrations are " +
+                            "not initialised yet. Reset discarded."
                     )
                 }
             }
@@ -116,49 +114,15 @@ internal class IntegrationsManagementPlugin : Plugin {
     internal fun flush() {
         integrationPluginChain.applyClosure { plugin ->
             if (plugin is IntegrationPlugin) {
-                if (plugin.integrationState.isReady()) {
+                if (areDestinationsInitialised) {
                     plugin.flush()
                 } else {
                     LoggerAnalytics.debug(
-                        "IntegrationsManagementPlugin: Destination ${plugin.key} is " +
-                            "not ready yet. Flush discarded."
+                        "IntegrationsManagementPlugin: Integrations are " +
+                            "not initialised yet. Flush discarded."
                     )
                 }
             }
-        }
-    }
-
-    @Synchronized
-    private fun initAndNotifyCallbacks(sourceConfig: SourceConfig, plugin: IntegrationPlugin) {
-        plugin.findAndInitDestination(sourceConfig)
-        notifyDestinationCallbacks(plugin)
-    }
-
-    @Synchronized
-    private fun notifyDestinationCallbacks(plugin: IntegrationPlugin) {
-        val callBacks = destinationReadyCallbacks[plugin.key]?.toList()
-        callBacks?.forEach { callback ->
-            when (val integrationState = plugin.integrationState) {
-                is IntegrationState.Ready -> notifyAndRemoveCallback(plugin, callback, Result.Success(Unit))
-                is IntegrationState.Failed -> notifyAndRemoveCallback(
-                    plugin,
-                    callback,
-                    Result.Failure(error = integrationState.exception)
-                )
-                is IntegrationState.Uninitialised -> Unit
-            }
-        }
-    }
-
-    private fun notifyAndRemoveCallback(
-        plugin: IntegrationPlugin,
-        callback: (Any?, DestinationResult) -> Unit,
-        result: DestinationResult
-    ) {
-        callback.invoke(plugin.getDestinationInstance(), result)
-        destinationReadyCallbacks[plugin.key]?.remove(callback)
-        if (destinationReadyCallbacks[plugin.key].isNullOrEmpty()) {
-            destinationReadyCallbacks.remove(plugin.key)
         }
     }
 
@@ -174,8 +138,4 @@ internal class IntegrationsManagementPlugin : Plugin {
             }
         }
     }
-}
-
-private fun PluginChain.hasIntegration(plugin: IntegrationPlugin): Boolean {
-    return findAll(Plugin.PluginType.Destination, IntegrationPlugin::class).contains(plugin)
 }

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/RudderAnalyticsUtils.kt
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/RudderAnalyticsUtils.kt
@@ -16,6 +16,8 @@ import com.rudderstack.sdk.kotlin.core.internals.models.Event
 import com.rudderstack.sdk.kotlin.core.internals.models.TrackEvent
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.internals.utils.Result
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -51,7 +53,7 @@ object RudderAnalyticsUtils {
                 }
             )
         ))
-        
+
         val sampleIntegrationPlugin = SampleIntegrationPlugin()
         sampleIntegrationPlugin.add(object : Plugin {
             override val pluginType: Plugin.PluginType = Plugin.PluginType.PreProcess
@@ -65,12 +67,15 @@ object RudderAnalyticsUtils {
                 return event
             }
         })
-        analytics.onDestinationReady(sampleIntegrationPlugin) { _, destinationResult ->
-            when (destinationResult) {
-                is Result.Success ->
-                    LoggerAnalytics.debug("SampleAmplitudePlugin: destination ready")
-                is Result.Failure ->
-                    LoggerAnalytics.debug("SampleAmplitudePlugin: destination failed to initialise: ${destinationResult.error.message}.")
+        GlobalScope.launch {
+            sampleIntegrationPlugin.onDestinationReady { _, destinationResult ->
+                when (destinationResult) {
+                    is Result.Success ->
+                        LoggerAnalytics.debug("SampleAmplitudePlugin: destination ready")
+
+                    is Result.Failure ->
+                        LoggerAnalytics.debug("SampleAmplitudePlugin: destination failed to initialise: ${destinationResult.error.message}.")
+                }
             }
         }
         analytics.addIntegration(sampleIntegrationPlugin)

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/customplugins/SampleIntegrationPlugin.kt
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/customplugins/SampleIntegrationPlugin.kt
@@ -29,12 +29,11 @@ class SampleIntegrationPlugin: IntegrationPlugin() {
         }
     }
 
-    override fun update(destinationConfig: JsonObject): Boolean {
+    override fun update(destinationConfig: JsonObject?, isDestinationDisabled: Boolean) {
         // Update destination instance if needed
-        if (destinationSdk == null) {
-            return create(destinationConfig)
+        if (destinationSdk == null && destinationConfig != null) {
+            create(destinationConfig)
         }
-        return false
     }
 
     override fun getDestinationInstance(): Any? {

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/plugins/PluginChain.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/plugins/PluginChain.kt
@@ -63,6 +63,12 @@ class PluginChain(
         }
     }
 
+    suspend fun applySuspendingClosure(closure: suspend (Plugin) -> Unit) {
+        pluginList.forEach { (_, mediator) ->
+            mediator.applySuspendingClosure(closure)
+        }
+    }
+
     /**
      * Finds all plugins of the given class and type in the plugin chain.
      */

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/plugins/PluginInteractor.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/plugins/PluginInteractor.kt
@@ -57,6 +57,12 @@ class PluginInteractor(private var pluginList: CopyOnWriteArrayList<Plugin> = Co
         }
     }
 
+    suspend fun applySuspendingClosure(closure: suspend (Plugin) -> Unit) {
+        pluginList.forEach { plugin ->
+            closure(plugin)
+        }
+    }
+
     /**
      * Finds a plugin of the given class in the list
      * and returns it if found, otherwise returns null.


### PR DESCRIPTION
## Description of the change

This PR removes the `IntegrationState` from the `IntegrationPlugin`. It also handles potential race conditions (which can occur during dynamic update) by using `Mutex`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
