### PR TITLE
feat: use property syntax all the properties that are persisted

### DIFF
--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
@@ -49,6 +49,7 @@ internal class MockMemoryStorage : Storage {
 
     override fun close() {
         messageBatchMap.clear()
+        propertiesMap.clear()
     }
 
     override fun readInt(key: StorageKeys, defaultVal: Int): Int {

--- a/app/src/main/java/com/rudderstack/sampleapp/mainview/MainActivity.kt
+++ b/app/src/main/java/com/rudderstack/sampleapp/mainview/MainActivity.kt
@@ -146,6 +146,17 @@ class MainActivity : ComponentActivity() {
                 weight = .5f,
                 viewModel = viewModel
             )
+            Spacer(modifier = Modifier.height(2.dp))
+            CreateRowOfApis(
+                names = arrayOf(
+                    AnalyticsState.SetAnonymousId,
+                    AnalyticsState.GetAnonymousId,
+                    AnalyticsState.GetUserId,
+                    AnalyticsState.GetTraits,
+                ),
+                weight = .5f,
+                viewModel = viewModel
+            )
             CreateLogcat(state.logDataList)
         }
     }

--- a/app/src/main/java/com/rudderstack/sampleapp/mainview/MainViewModel.kt
+++ b/app/src/main/java/com/rudderstack/sampleapp/mainview/MainViewModel.kt
@@ -6,6 +6,9 @@ import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.Properties
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sampleapp.analytics.RudderAnalyticsUtils
+import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.anonymousId
+import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.traits
+import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.userId
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -117,6 +120,26 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             AnalyticsState.Initialize -> {
                 RudderAnalyticsUtils.initialize(getApplication())
                 "SDK initialized"
+            }
+
+            AnalyticsState.SetAnonymousId -> {
+                RudderAnalyticsUtils.analytics.anonymousId = "Custom Anonymous ID"
+                "Anonymous ID is set as: ${RudderAnalyticsUtils.analytics.anonymousId}"
+            }
+
+            AnalyticsState.GetAnonymousId -> {
+                val anonymousId = RudderAnalyticsUtils.analytics.anonymousId
+                "Anonymous ID: $anonymousId"
+            }
+
+            AnalyticsState.GetUserId -> {
+                val userId = RudderAnalyticsUtils.analytics.userId
+                "User ID: $userId"
+            }
+
+            AnalyticsState.GetTraits -> {
+                val traits = RudderAnalyticsUtils.analytics.traits
+                "Traits: $traits"
             }
         }
         if (log.isNotEmpty()) addLogData(LogData(Date(), log))

--- a/app/src/main/java/com/rudderstack/sampleapp/mainview/MainViewModel.kt
+++ b/app/src/main/java/com/rudderstack/sampleapp/mainview/MainViewModel.kt
@@ -6,9 +6,6 @@ import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.Properties
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sampleapp.analytics.RudderAnalyticsUtils
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.anonymousId
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.traits
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.userId
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update

--- a/app/src/main/java/com/rudderstack/sampleapp/mainview/MainViewModelState.kt
+++ b/app/src/main/java/com/rudderstack/sampleapp/mainview/MainViewModelState.kt
@@ -22,4 +22,8 @@ sealed class AnalyticsState(val eventName: String) {
     object StartSession: AnalyticsState("Start Session")
     object StartSessionWithCustomId: AnalyticsState("Start Session with custom id")
     object EndSession: AnalyticsState("End Session")
+    object SetAnonymousId: AnalyticsState("Set Anonymous Id")
+    object GetAnonymousId: AnalyticsState("Get Anonymous Id")
+    object GetUserId: AnalyticsState("Get User Id")
+    object GetTraits: AnalyticsState("Get Traits")
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -16,7 +16,6 @@ import com.rudderstack.sdk.kotlin.core.internals.models.TrackEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.connectivity.ConnectivityState
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.ResetUserIdentityAction
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.SetAnonymousIdAction
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.SetUserIdForAliasEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.SetUserIdTraitsAndExternalIdsAction
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.UserIdentity
@@ -343,33 +342,6 @@ open class Analytics protected constructor(
     }
 
     /**
-     * Sets or updates the anonymous ID for the current user identity.
-     *
-     * The `setAnonymousId` method is used to update the `anonymousID` value within the `UserIdentityStore`.
-     * This ID is typically generated automatically to track users who have not yet been identified
-     * (e.g., before they log in or sign up). This function dispatches an action to modify the `UserIdentityState`,
-     * ensuring that the new ID is correctly stored and managed.
-     *
-     * @param anonymousId The new anonymous ID to be set for the current user. This ID should be a unique,
-     * non-null string used to represent the user anonymously.
-     */
-    fun setAnonymousId(anonymousId: String) {
-        if (!isAnalyticsActive()) return
-
-        userIdentityState.dispatch(SetAnonymousIdAction(anonymousId))
-        storeAnonymousId()
-    }
-
-    /**
-     * The `getAnonymousId` method always retrieves the current anonymous ID.
-     */
-    fun getAnonymousId(): String? {
-        if (!isAnalyticsActive()) return null
-
-        return userIdentityState.value.anonymousId
-    }
-
-    /**
      * Resets the user identity, clearing the user ID, traits, and external IDs.
      * If clearAnonymousId is true, clears the existing anonymous ID and generate a new one.
      *
@@ -404,7 +376,7 @@ open class Analytics protected constructor(
         }
     }
 
-    private fun storeAnonymousId() {
+    internal fun storeAnonymousId() {
         analyticsScope.launch(storageDispatcher) {
             userIdentityState.value.storeAnonymousId(storage = storage)
         }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/UserIdentity.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/UserIdentity.kt
@@ -1,6 +1,5 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.useridentity
 
-import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderTraits
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
@@ -9,7 +8,6 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
-import com.rudderstack.sdk.kotlin.core.internals.utils.isAnalyticsActive
 import com.rudderstack.sdk.kotlin.core.internals.utils.readValuesOrDefault
 
 /**
@@ -52,74 +50,3 @@ data class UserIdentity(
 
     internal sealed interface UserIdentityAction : FlowAction<UserIdentity>
 }
-
-/**
- * Update or get the stored anonymous ID.
- *
- * The `analyticsInstance.anonymousId` is used to update and get the `anonymousID` value.
- * This ID is typically generated automatically to track users who have not yet been identified
- * (e.g., before they log in or sign up).
- *
- * This can return null if the analytics is shut down.
- *
- * Set the anonymousId:
- * ```kotlin
- * analyticsInstance.anonymousId = "Custom Anonymous ID"
- * ```
- *
- * Get the anonymousId:
- * ```kotlin
- * val anonymousId = analyticsInstance.anonymousId
- * ```
- */
-var Analytics.anonymousId: String?
-    get() {
-        if (!isAnalyticsActive()) return null
-        return userIdentityState.value.anonymousId
-    }
-    set(value) {
-        if (!isAnalyticsActive()) return
-
-        value?.let { anonymousId ->
-            userIdentityState.dispatch(SetAnonymousIdAction(anonymousId))
-            storeAnonymousId()
-        }
-    }
-
-/**
- * Get the user ID.
- *
- * The `analyticsInstance.userId` is used to get the `userId` value.
- * This ID is assigned when an identify event is made.
- *
- * This can return null if the analytics is shut down.
- *
- * Get the userId:
- * ```kotlin
- * val userId = analyticsInstance.userId
- * ```
- */
-val Analytics.userId: String?
-    get() {
-        if (!isAnalyticsActive()) return null
-        return userIdentityState.value.userId
-    }
-
-/**
- * Get the user traits.
- *
- * The `analyticsInstance.traits` is used to get the `traits` value.
- * This traits is assigned when an identify event is made.
- *
- * This can return null if the analytics is shut down.
- *
- * Get the traits:
- * ```kotlin
- * val traits = analyticsInstance.traits
- * ```
- */
-val Analytics.traits: RudderTraits?
-    get() {
-        if (!isAnalyticsActive()) return null
-        return userIdentityState.value.traits
-    }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/UserIdentity.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/UserIdentity.kt
@@ -1,5 +1,6 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.useridentity
 
+import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderTraits
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
@@ -8,6 +9,7 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
+import com.rudderstack.sdk.kotlin.core.internals.utils.isAnalyticsActive
 import com.rudderstack.sdk.kotlin.core.internals.utils.readValuesOrDefault
 
 /**
@@ -50,3 +52,74 @@ data class UserIdentity(
 
     internal sealed interface UserIdentityAction : FlowAction<UserIdentity>
 }
+
+/**
+ * Update or get the stored anonymous ID.
+ *
+ * The `analyticsInstance.anonymousId` is used to update and get the `anonymousID` value.
+ * This ID is typically generated automatically to track users who have not yet been identified
+ * (e.g., before they log in or sign up).
+ *
+ * This can return null if the analytics is shut down.
+ *
+ * Set the anonymousId:
+ * ```kotlin
+ * analyticsInstance.anonymousId = "Custom Anonymous ID"
+ * ```
+ *
+ * Get the anonymousId:
+ * ```kotlin
+ * val anonymousId = analyticsInstance.anonymousId
+ * ```
+ */
+var Analytics.anonymousId: String?
+    get() {
+        if (!isAnalyticsActive()) return null
+        return userIdentityState.value.anonymousId
+    }
+    set(value) {
+        if (!isAnalyticsActive()) return
+
+        value?.let { anonymousId ->
+            userIdentityState.dispatch(SetAnonymousIdAction(anonymousId))
+            storeAnonymousId()
+        }
+    }
+
+/**
+ * Get the user ID.
+ *
+ * The `analyticsInstance.userId` is used to get the `userId` value.
+ * This ID is assigned when an identify event is made.
+ *
+ * This can return null if the analytics is shut down.
+ *
+ * Get the userId:
+ * ```kotlin
+ * val userId = analyticsInstance.userId
+ * ```
+ */
+val Analytics.userId: String?
+    get() {
+        if (!isAnalyticsActive()) return null
+        return userIdentityState.value.userId
+    }
+
+/**
+ * Get the user traits.
+ *
+ * The `analyticsInstance.traits` is used to get the `traits` value.
+ * This traits is assigned when an identify event is made.
+ *
+ * This can return null if the analytics is shut down.
+ *
+ * Get the traits:
+ * ```kotlin
+ * val traits = analyticsInstance.traits
+ * ```
+ */
+val Analytics.traits: RudderTraits?
+    get() {
+        if (!isAnalyticsActive()) return null
+        return userIdentityState.value.traits
+    }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventQueue.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventQueue.kt
@@ -3,6 +3,7 @@ package com.rudderstack.sdk.kotlin.core.internals.queue
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.models.Event
+import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.anonymousId
 import com.rudderstack.sdk.kotlin.core.internals.network.HttpClient
 import com.rudderstack.sdk.kotlin.core.internals.network.HttpClientImpl
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPoliciesFacade
@@ -41,7 +42,7 @@ internal class EventQueue(
             endPoint = BATCH_ENDPOINT,
             authHeaderString = writeKey.encodeToBase64(),
             isGZIPEnabled = gzipEnabled,
-            anonymousIdHeaderString = analytics.getAnonymousId() ?: String.empty()
+            anonymousIdHeaderString = analytics.anonymousId ?: String.empty()
         )
     }
 ) {

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventQueue.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventQueue.kt
@@ -3,7 +3,6 @@ package com.rudderstack.sdk.kotlin.core.internals.queue
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.models.Event
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.anonymousId
 import com.rudderstack.sdk.kotlin.core.internals.network.HttpClient
 import com.rudderstack.sdk.kotlin.core.internals.network.HttpClientImpl
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPoliciesFacade

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -1,0 +1,121 @@
+package com.rudderstack.sdk.kotlin.core
+
+import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
+import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.anonymousId
+import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.traits
+import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.userId
+import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
+import com.rudderstack.sdk.kotlin.core.internals.storage.provideBasicStorage
+import com.rudderstack.sdk.kotlin.core.internals.utils.MockMemoryStorage
+import com.rudderstack.sdk.kotlin.core.internals.utils.empty
+import io.mockk.every
+import io.mockk.mockkStatic
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+private const val CUSTOM_ANONYMOUS_ID = "custom-anonymous-id"
+private const val USER_ID = "user-id"
+private val TRAITS: JsonObject = buildJsonObject { put("key-1", "value-1")  }
+
+class AnalyticsTest {
+
+    private val configuration = provideConfiguration()
+
+    private lateinit var analytics: Analytics
+    private lateinit var mockStorage: Storage
+
+    @Before
+    fun setup() {
+        mockStorage = MockMemoryStorage()
+
+        mockkStatic(::provideBasicStorage)
+        every { provideBasicStorage(any()) } returns mockStorage
+
+        analytics = Analytics(configuration = configuration)
+    }
+
+    @After
+    fun tearDown() {
+        mockStorage.close()
+    }
+
+    @Test
+    fun `when anonymousId is fetched, then it should return UUID as the anonymousId`() {
+        val anonymousId = analytics.anonymousId
+
+        // This pattern ensures the string follows the UUID v4 format.
+        val uuidRegex = Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+        assertTrue(anonymousId?.matches(uuidRegex) == true)
+    }
+
+    @Test
+    fun `given custom anonymousId is set, when anonymousId is fetched, then it should return the custom anonymousId`() {
+        analytics.anonymousId = CUSTOM_ANONYMOUS_ID
+
+        val anonymousId = analytics.anonymousId
+
+        assertTrue(anonymousId == CUSTOM_ANONYMOUS_ID)
+    }
+
+    @Test
+    fun `given empty string is set as custom anonymousId, when anonymousId is fetched, then it should return the empty anonymousId`() {
+        analytics.anonymousId = String.empty()
+
+        val anonymousId = analytics.anonymousId
+
+        assertTrue(anonymousId == String.empty())
+    }
+
+    @Test
+    fun `given sdk is shutdown, when anonymousId is fetched, then it should return null`() {
+        analytics.shutdown()
+
+        val anonymousId = analytics.anonymousId
+
+        assertNull(anonymousId)
+    }
+
+    @Test
+    fun `given userId and traits are set, when they are fetched, then proper values are returned`() {
+        analytics.identify(userId = USER_ID, traits = TRAITS)
+
+        val userId = analytics.userId
+        val traits = analytics.traits
+
+        assertTrue(userId == USER_ID)
+        assertTrue(traits == TRAITS)
+    }
+
+    @Test
+    fun `given userId and traits are not set, when they are fetched, then empty values are returned`() {
+        val userId = analytics.userId
+        val traits = analytics.traits
+
+        assertTrue(userId == String.empty())
+        assertTrue(traits == emptyJsonObject)
+    }
+
+    @Test
+    fun `given userId and traits are not set and sdk is shutdown, when they are fetched, then it should return null`() {
+        analytics.identify(userId = USER_ID, traits = TRAITS)
+        analytics.shutdown()
+
+        val userId = analytics.userId
+        val traits = analytics.traits
+
+        assertNull(userId)
+        assertNull(traits)
+    }
+}
+
+private fun provideConfiguration() =
+    Configuration(
+        writeKey = "<writeKey>",
+        dataPlaneUrl = "https://hosted.rudderlabs.com",
+    )

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -58,7 +58,7 @@ class AnalyticsTest {
     }
 
     @Test
-    fun `given empty string is set as custom anonymousId, when anonymousId is fetched, then it should return the empty anonymousId`() {
+    fun `given empty string is set as anonymousId, when anonymousId is fetched, then it should return the empty value`() {
         analytics.anonymousId = String.empty()
 
         val anonymousId = analytics.anonymousId
@@ -76,7 +76,8 @@ class AnalyticsTest {
     }
 
     @Test
-    fun `given userId and traits are set, when they are fetched, then proper values are returned`() {
+    fun `given userId and traits are set, when they are fetched, then the set values are returned`() {
+        // userId and traits can be set only through identify api
         analytics.identify(userId = USER_ID, traits = TRAITS)
 
         val userId = analytics.userId
@@ -96,8 +97,7 @@ class AnalyticsTest {
     }
 
     @Test
-    fun `given userId and traits are not set and sdk is shutdown, when they are fetched, then it should return null`() {
-        analytics.identify(userId = USER_ID, traits = TRAITS)
+    fun `given sdk is shutdown, when userId and traits are fetched, then it should return null`() {
         analytics.shutdown()
 
         val userId = analytics.userId

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -1,9 +1,6 @@
 package com.rudderstack.sdk.kotlin.core
 
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.anonymousId
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.traits
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.userId
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.provideBasicStorage
 import com.rudderstack.sdk.kotlin.core.internals.utils.MockMemoryStorage

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -15,7 +15,6 @@ import junit.framework.TestCase.assertTrue
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
@@ -38,11 +37,6 @@ class AnalyticsTest {
         every { provideBasicStorage(any()) } returns mockStorage
 
         analytics = Analytics(configuration = configuration)
-    }
-
-    @After
-    fun tearDown() {
-        mockStorage.close()
     }
 
     @Test

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -117,5 +117,5 @@ class AnalyticsTest {
 private fun provideConfiguration() =
     Configuration(
         writeKey = "<writeKey>",
-        dataPlaneUrl = "https://hosted.rudderlabs.com",
+        dataPlaneUrl = "<data_plane_url>",
     )

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -7,6 +7,7 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.MockMemoryStorage
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import io.mockk.every
 import io.mockk.mockkStatic
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
 import kotlinx.serialization.json.JsonObject
@@ -51,7 +52,7 @@ class AnalyticsTest {
 
         val anonymousId = analytics.anonymousId
 
-        assertTrue(anonymousId == CUSTOM_ANONYMOUS_ID)
+        assertEquals(CUSTOM_ANONYMOUS_ID, anonymousId)
     }
 
     @Test
@@ -60,7 +61,7 @@ class AnalyticsTest {
 
         val anonymousId = analytics.anonymousId
 
-        assertTrue(anonymousId == String.empty())
+        assertEquals(String.empty(), anonymousId)
     }
 
     @Test
@@ -80,8 +81,8 @@ class AnalyticsTest {
         val userId = analytics.userId
         val traits = analytics.traits
 
-        assertTrue(userId == USER_ID)
-        assertTrue(traits == TRAITS)
+        assertEquals(USER_ID, userId)
+        assertEquals(TRAITS, traits)
     }
 
     @Test
@@ -89,8 +90,8 @@ class AnalyticsTest {
         val userId = analytics.userId
         val traits = analytics.traits
 
-        assertTrue(userId == String.empty())
-        assertTrue(traits == emptyJsonObject)
+        assertEquals(String.empty(), userId)
+        assertEquals(emptyJsonObject, traits)
     }
 
     @Test

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
@@ -1,0 +1,86 @@
+package com.rudderstack.sdk.kotlin.core.internals.utils
+
+import com.rudderstack.sdk.kotlin.core.internals.storage.LibraryVersion
+import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
+import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
+
+internal class MockMemoryStorage : Storage {
+
+    private val propertiesMap: MutableMap<String, Any> = mutableMapOf()
+    private val messageBatchMap: MutableList<String> = mutableListOf()
+
+    override suspend fun write(key: StorageKeys, value: Boolean) {
+        if (key != StorageKeys.EVENT) {
+            propertiesMap[key.key] = value
+        }
+    }
+
+    override suspend fun write(key: StorageKeys, value: Int) {
+        if (key != StorageKeys.EVENT) {
+            propertiesMap[key.key] = value
+        }
+    }
+
+    override suspend fun write(key: StorageKeys, value: Long) {
+        if (key != StorageKeys.EVENT) {
+            propertiesMap[key.key] = value
+        }
+    }
+
+    override suspend fun write(key: StorageKeys, value: String) {
+        if (key == StorageKeys.EVENT) {
+            messageBatchMap.add(value)
+        } else {
+            propertiesMap[key.key] = value
+        }
+    }
+
+    override suspend fun remove(key: StorageKeys) {
+        propertiesMap.remove(key.key)
+    }
+
+    override fun remove(filePath: String) {
+        messageBatchMap.remove(filePath)
+    }
+
+    override suspend fun rollover() {
+        messageBatchMap.clear()
+    }
+
+    override fun close() {
+        messageBatchMap.clear()
+        propertiesMap.clear()
+    }
+
+    override fun readInt(key: StorageKeys, defaultVal: Int): Int {
+        return (propertiesMap[key.key] as? Int) ?: defaultVal
+    }
+
+    override fun readBoolean(key: StorageKeys, defaultVal: Boolean): Boolean {
+        return (propertiesMap[key.key] as? Boolean) ?: defaultVal
+    }
+
+    override fun readLong(key: StorageKeys, defaultVal: Long): Long {
+        return (propertiesMap[key.key] as? Long) ?: defaultVal
+    }
+
+    override fun readString(key: StorageKeys, defaultVal: String): String {
+        return if (key == StorageKeys.EVENT) {
+            messageBatchMap.joinToString()
+        } else {
+            (propertiesMap[key.key] as? String) ?: defaultVal
+        }
+    }
+
+    override fun readFileList(): List<String> {
+        return messageBatchMap
+    }
+
+    override fun getLibraryVersion(): LibraryVersion {
+        return object : LibraryVersion {
+            override fun getPackageName(): String = "com.rudderstack.sdk.kotlin.core"
+
+            override fun getVersionName() = "1.0.0"
+        }
+    }
+}

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/plugins/RudderStackDataplanePluginTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/plugins/RudderStackDataplanePluginTest.kt
@@ -24,8 +24,10 @@ import org.junit.Before
 import org.junit.Test
 
 private const val ANONYMOUS_ID = "anonymousId"
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class RudderStackDataplanePluginTest {
+
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
 

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/plugins/RudderStackDataplanePluginTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/plugins/RudderStackDataplanePluginTest.kt
@@ -5,6 +5,7 @@ import com.rudderstack.sdk.kotlin.core.internals.models.TrackEvent
 import com.rudderstack.sdk.kotlin.core.internals.queue.EventQueue
 import com.rudderstack.sdk.kotlin.core.mockAnalytics
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.unmockkAll
@@ -22,6 +23,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
+private const val ANONYMOUS_ID = "anonymousId"
 @OptIn(ExperimentalCoroutinesApi::class)
 class RudderStackDataplanePluginTest {
     private val testDispatcher = StandardTestDispatcher()
@@ -36,6 +38,7 @@ class RudderStackDataplanePluginTest {
         Dispatchers.setMain(testDispatcher)
         mockAnalytics = mockAnalytics(testScope, testDispatcher)
         mockEventQueue = mockk(relaxed = true)
+        every { mockAnalytics.userIdentityState.value.anonymousId } returns ANONYMOUS_ID
 
         plugin = spyk(RudderStackDataplanePlugin())
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- We have provided **getters** for all properties, including `userId`, `traits`, and `anonymousId`, that persist in storage (excluding `externalId` as in future we are going to remove its persistence). Also, we've added a **setter** to set only the `anonymousId`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

- We have added getters for all the properties that are persisted and setters only for the anonymousId, as userId and traits can be set while making the `identify` event. I've not provided the option to get the `externalId`, as we've decided to remove the persistence for this value in future PR.
- I've added them as an **extension function** in the `UserIdentity` class itself, where those variables have been defined. 
- They can make a call like this:
```
// Settter
RudderAnalyticsUtils.analytics.anonymousId = "Custom Anonymous ID"
// Getter
val anonymousId = RudderAnalyticsUtils.analytics.anonymousId
val userId = RudderAnalyticsUtils.analytics.userId
val traits = RudderAnalyticsUtils.analytics.traits
```
- I've added buttons to set and fetch these properties.
- Added unit tests.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

- Use the above code snippet or buttons provided in the sample app and you can see the value being fetched and set.
- `anonymousId`:
    - After SDK init, get the anonymousId: It'll return the UUID v4.
    - Call shutdown, and then get the anonymousId: It'll return null.
    - Set the anonymousId, and then get the anonymousId: It'll return the custom anonymousId.
- `userId` and `traits`:
    - After SDK init, get the userId and traits: It'll return empty values.
    - Make and identify the event and set both the values, and then try to get them: It'll return the set values.
    - Call shutdown, and then get them: It'll return null.

<img width="403" alt="image" src="https://github.com/user-attachments/assets/c1f66a55-4e90-43d0-8ed8-ecabf3486cab" />

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

- We have removed the `getAnonymousId` and `setAnonymousId` APIs defined in the Analytics class. Now, the user needs to access this as a property. Now, this is no longer valid:
```kotlin
val anonymousId = analytics.getAnonymousId()
analytics.setAnonymousId("<custom_anonymousId>")
```

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

Before:
<img width="265" alt="image" src="https://github.com/user-attachments/assets/19c5b558-d70f-42ff-a4bf-59cad84844a4" />

After:
<img width="431" alt="image" src="https://github.com/user-attachments/assets/3e69dd92-0fb4-4cfd-ad99-9436a351073a" />

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->

NOTE: We've not added getters for externalId, as we've planned to remove storage support for that property.