### PR TITLE
feat: allow setting of externalIds for all events type

### DIFF
--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -228,7 +228,6 @@ open class Analytics protected constructor(
             SetUserIdTraitsAndExternalIdsAction(
                 newUserId = userId,
                 newTraits = traits,
-                newExternalIds = options.externalIds,
                 analytics = this
             )
         )

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -17,13 +17,13 @@ import com.rudderstack.sdk.kotlin.core.internals.models.connectivity.Connectivit
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.ResetUserIdentityAction
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.SetAnonymousIdAction
+import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.SetUserIdAndTraitsAction
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.SetUserIdForAliasEvent
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.SetUserIdTraitsAndExternalIdsAction
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.UserIdentity
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.resetUserIdentity
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.storeAnonymousId
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.storeUserId
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.storeUserIdTraitsAndExternalIds
+import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.storeUserIdAndTraits
 import com.rudderstack.sdk.kotlin.core.internals.platform.Platform
 import com.rudderstack.sdk.kotlin.core.internals.platform.PlatformType
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
@@ -225,14 +225,14 @@ open class Analytics protected constructor(
         if (!isAnalyticsActive()) return
 
         userIdentityState.dispatch(
-            SetUserIdTraitsAndExternalIdsAction(
+            SetUserIdAndTraitsAction(
                 newUserId = userId,
                 newTraits = traits,
                 analytics = this
             )
         )
         analyticsScope.launch {
-            userIdentityState.value.storeUserIdTraitsAndExternalIds(
+            userIdentityState.value.storeUserIdAndTraits(
                 storage = storage
             )
         }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/Event.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/Event.kt
@@ -5,10 +5,10 @@ import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.UserIdentit
 import com.rudderstack.sdk.kotlin.core.internals.platform.PlatformType
 import com.rudderstack.sdk.kotlin.core.internals.utils.DateTimeUtils
 import com.rudderstack.sdk.kotlin.core.internals.utils.addPersistedValues
+import com.rudderstack.sdk.kotlin.core.internals.utils.addRudderOptionFields
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
 import com.rudderstack.sdk.kotlin.core.internals.utils.provideEmptyUserIdentityState
-import com.rudderstack.sdk.kotlin.core.internals.utils.updateIntegrationOptionsAndCustomCustomContext
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -112,7 +112,7 @@ sealed class Event {
 
     internal fun updateData(platform: PlatformType) {
         this.channel = platform
-        this.updateIntegrationOptionsAndCustomCustomContext()
+        this.addRudderOptionFields()
         this.addPersistedValues()
     }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityAction.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityAction.kt
@@ -16,7 +16,6 @@ internal class ResetUserIdentityAction(
             anonymousId = anonymousId,
             userId = String.empty(),
             traits = emptyJsonObject,
-            externalIds = emptyList(),
         )
     }
 
@@ -32,6 +31,5 @@ internal suspend fun UserIdentity.resetUserIdentity(clearAnonymousId: Boolean, s
     storage.apply {
         remove(StorageKeys.USER_ID)
         remove(StorageKeys.TRAITS)
-        remove(StorageKeys.EXTERNAL_IDS)
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdAndTraitsAction.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdAndTraitsAction.kt
@@ -9,8 +9,7 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.mergeWithHigherPriorityTo
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 
-// TODO("Change it to SetUserIdAndTraitsAction")
-internal class SetUserIdTraitsAndExternalIdsAction(
+internal class SetUserIdAndTraitsAction(
     private val newUserId: String,
     private val newTraits: RudderTraits,
     private val analytics: Analytics,
@@ -40,13 +39,12 @@ internal class SetUserIdTraitsAndExternalIdsAction(
     private fun resetValuesIfUserIdChanged(isUserIdChanged: Boolean) {
         if (isUserIdChanged) {
             analytics.analyticsScope.launch(analytics.storageDispatcher) {
-                resetUserIdTraitsAndExternalIds()
+                resetUserIdAndTraits()
             }
         }
     }
 
-    // TODO("Change it to resetUserIdAndTraitsActions)
-    private suspend fun resetUserIdTraitsAndExternalIds() {
+    private suspend fun resetUserIdAndTraits() {
         analytics.storage.let {
             it.remove(StorageKeys.USER_ID)
             it.remove(StorageKeys.TRAITS)
@@ -61,8 +59,7 @@ private inline fun <T> getUpdatedValues(
     isUserIdChanged: Boolean
 ): T = if (isUserIdChanged) newValue else previousValue.mergeWithPriority(newValue)
 
-// TODO("Change it to .storeUserIdAndTraits)
-internal suspend fun UserIdentity.storeUserIdTraitsAndExternalIds(storage: Storage) {
+internal suspend fun UserIdentity.storeUserIdAndTraits(storage: Storage) {
     storage.write(StorageKeys.USER_ID, userId)
     storage.write(StorageKeys.TRAITS, LenientJson.encodeToString(traits))
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdTraitsAndExternalIdsAction.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdTraitsAndExternalIdsAction.kt
@@ -1,7 +1,6 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.useridentity
 
 import com.rudderstack.sdk.kotlin.core.Analytics
-import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderTraits
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
@@ -10,10 +9,10 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.mergeWithHigherPriorityTo
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 
+// TODO("Change it to SetUserIdAndTraitsAction")
 internal class SetUserIdTraitsAndExternalIdsAction(
     private val newUserId: String,
     private val newTraits: RudderTraits,
-    private val newExternalIds: List<ExternalId>,
     private val analytics: Analytics,
 ) : UserIdentity.UserIdentityAction {
 
@@ -27,16 +26,9 @@ internal class SetUserIdTraitsAndExternalIdsAction(
             isUserIdChanged = isUserIdChanged
         )
 
-        val updatedExternalIds: List<ExternalId> = getUpdatedValues(
-            previousValue = currentState.externalIds,
-            newValue = this.newExternalIds,
-            mergeWithPriority = { other -> this mergeWithHigherPriorityTo other },
-            isUserIdChanged = isUserIdChanged
-        )
-
         resetValuesIfUserIdChanged(isUserIdChanged = isUserIdChanged)
 
-        return currentState.copy(userId = newUserId, traits = updatedTraits, externalIds = updatedExternalIds)
+        return currentState.copy(userId = newUserId, traits = updatedTraits)
     }
 
     private fun isUserIdChanged(currentState: UserIdentity): Boolean {
@@ -53,11 +45,11 @@ internal class SetUserIdTraitsAndExternalIdsAction(
         }
     }
 
+    // TODO("Change it to resetUserIdAndTraitsActions)
     private suspend fun resetUserIdTraitsAndExternalIds() {
         analytics.storage.let {
             it.remove(StorageKeys.USER_ID)
             it.remove(StorageKeys.TRAITS)
-            it.remove(StorageKeys.EXTERNAL_IDS)
         }
     }
 }
@@ -69,8 +61,8 @@ private inline fun <T> getUpdatedValues(
     isUserIdChanged: Boolean
 ): T = if (isUserIdChanged) newValue else previousValue.mergeWithPriority(newValue)
 
+// TODO("Change it to .storeUserIdAndTraits)
 internal suspend fun UserIdentity.storeUserIdTraitsAndExternalIds(storage: Storage) {
     storage.write(StorageKeys.USER_ID, userId)
     storage.write(StorageKeys.TRAITS, LenientJson.encodeToString(traits))
-    storage.write(StorageKeys.EXTERNAL_IDS, LenientJson.encodeToString(externalIds))
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/UserIdentity.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/UserIdentity.kt
@@ -1,6 +1,5 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.useridentity
 
-import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderTraits
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
 import com.rudderstack.sdk.kotlin.core.internals.statemanagement.FlowAction
@@ -26,16 +25,11 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.readValuesOrDefault
  *
  * @property traits A collection of traits associated with the user. Traits are key-value pairs that can be used
  * to store additional information about a user, such as their name, email, or other properties.
- *
- * @property externalIds A list of external identifiers associated with the user. External IDs are used to track
- * users across different systems and platforms. Each external ID is a key-value pair that includes an ID type
- * and a value.
  */
 data class UserIdentity(
     val anonymousId: String,
     val userId: String,
     val traits: RudderTraits,
-    val externalIds: List<ExternalId> = emptyList(),
 ) {
 
     companion object {
@@ -44,7 +38,6 @@ data class UserIdentity(
             anonymousId = storage.readString(StorageKeys.ANONYMOUS_ID, defaultVal = generateUUID()),
             userId = storage.readString(StorageKeys.USER_ID, defaultVal = String.empty()),
             traits = storage.readValuesOrDefault(key = StorageKeys.TRAITS, defaultValue = emptyJsonObject),
-            externalIds = storage.readValuesOrDefault(key = StorageKeys.EXTERNAL_IDS, defaultValue = emptyList()),
         )
     }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
@@ -178,11 +178,6 @@ enum class StorageKeys(val key: String) {
     TRAITS("traits"),
 
     /**
-     * Key for storing the external ids.
-     */
-    EXTERNAL_IDS("external_ids"),
-
-    /**
      * Key for storing the session id of the client.
      */
     SESSION_ID("session_id"),

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MessageUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MessageUtils.kt
@@ -1,12 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.utils
 
-import com.rudderstack.sdk.kotlin.core.internals.models.AliasEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.Event
-import com.rudderstack.sdk.kotlin.core.internals.models.GroupEvent
-import com.rudderstack.sdk.kotlin.core.internals.models.IdentifyEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderTraits
-import com.rudderstack.sdk.kotlin.core.internals.models.ScreenEvent
-import com.rudderstack.sdk.kotlin.core.internals.models.TrackEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.UserIdentity
 import kotlinx.serialization.json.JsonObject
@@ -36,20 +31,17 @@ private val DEFAULT_INTEGRATIONS = buildJsonObject {
     put("All", true)
 }
 
+// TODO("Change the name to addRudderOptionsFields")
 internal fun Event.updateIntegrationOptionsAndCustomCustomContext() {
-    when (this) {
-        is TrackEvent, is ScreenEvent, is GroupEvent, is IdentifyEvent, is AliasEvent -> {
-            this.integrations = DEFAULT_INTEGRATIONS mergeWithHigherPriorityTo options.integrations
-            this.context = options.customContext mergeWithHigherPriorityTo context
-        }
-    }
+    this.integrations = DEFAULT_INTEGRATIONS mergeWithHigherPriorityTo options.integrations
+    this.context = options.customContext mergeWithHigherPriorityTo context
+    this.context = options.externalIds.toJsonObject() mergeWithHigherPriorityTo context
 }
 
 internal fun Event.addPersistedValues() {
     this.setAnonymousId()
     this.setUserId()
     this.setTraitsInContext { this.buildTraits() }
-    this.setExternalIdInContext()
 }
 
 private fun Event.setAnonymousId() {
@@ -82,11 +74,4 @@ private fun getDefaultTraits(anonymousId: String): RudderTraits = buildJsonObjec
     put(ANONYMOUS_ID, anonymousId)
 }
 
-private fun Event.setExternalIdInContext() {
-    val externalIds = userIdentityState.externalIds.toJsonObject()
-    if (externalIds.isNotEmpty()) {
-        this.context = this.context mergeWithHigherPriorityTo externalIds
-    }
-}
-
-internal fun provideEmptyUserIdentityState() = UserIdentity(String.empty(), String.empty(), emptyJsonObject, emptyList())
+internal fun provideEmptyUserIdentityState() = UserIdentity(String.empty(), String.empty(), emptyJsonObject)

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MessageUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MessageUtils.kt
@@ -31,8 +31,7 @@ private val DEFAULT_INTEGRATIONS = buildJsonObject {
     put("All", true)
 }
 
-// TODO("Change the name to addRudderOptionsFields")
-internal fun Event.updateIntegrationOptionsAndCustomCustomContext() {
+internal fun Event.addRudderOptionFields() {
     this.integrations = DEFAULT_INTEGRATIONS mergeWithHigherPriorityTo options.integrations
     this.context = options.customContext mergeWithHigherPriorityTo context
     this.context = options.externalIds.toJsonObject() mergeWithHigherPriorityTo context

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StorageUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StorageUtils.kt
@@ -4,10 +4,7 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 
 /**
- * Reads the value from the storage for the given key and returns it.
- *
- * This function currently used to read the `Traits` and `ExternalIds` from the storage
- * and convert them to the respective types and return them.
+ * Retrieves the value from storage for the given key, converts it to the appropriate type, and returns it.
  *
  * @param key The key to read the value for.
  * @param defaultValue The default value to return if the key is not found.

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
@@ -37,7 +37,6 @@ internal fun provideOnlyAnonymousIdState(): UserIdentity {
         anonymousId = ANONYMOUS_ID,
         userId = String.empty(),
         traits = emptyJsonObject,
-        externalIds = emptyList()
     )
 }
 

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/GroupEventTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/GroupEventTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 
 private const val groupWithDefaultArguments = "message/group/group_with_default_arguments.json"
 private const val groupWithTraits = "message/group/group_with_traits.json"
+private const val groupWithExternalIdsOption = "message/group/group_with_external_ids_option.json"
 private const val groupWithIntegrationsOption = "message/group/group_with_integrations_option.json"
 private const val groupWithCustomContextsOption = "message/group/group_with_custom_contexts_option.json"
 private const val groupWithAllArguments = "message/group/group_with_all_arguments.json"
@@ -98,7 +99,7 @@ class GroupEventTest {
 
     @Test
     fun `given group  event with externalIds option, when serialized, then it matches expected JSON`() {
-        val expectedJsonString = readFileTrimmed(groupWithDefaultArguments)
+        val expectedJsonString = readFileTrimmed(groupWithExternalIdsOption)
         val groupEvent = GroupEvent(
             groupId = GROUP_ID,
             options = RudderOption(

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/IdentifyEventTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/IdentifyEventTest.kt
@@ -64,7 +64,7 @@ class IdentifyEventTest {
     @Test
     fun `given only options is passed, when identify event is made, then only options is set`() {
         val expectedJsonString = readFileTrimmed(identifyEventsWithOnlyOptions)
-        val userIdentityState: UserIdentity = provideUserIdentityState(externalIds = provideSampleExternalIdsPayload())
+        val userIdentityState: UserIdentity = provideUserIdentityState()
         val identifyEvent = IdentifyEvent(
             options = RudderOption(
                 integrations = provideSampleIntegrationsPayload(),
@@ -106,7 +106,6 @@ class IdentifyEventTest {
         val expectedJsonString = readFileTrimmed(identifyEventsWithOnlyUserIdAndOptions)
         val userIdentityState: UserIdentity = provideUserIdentityState(
             userId = USER_ID,
-            externalIds = provideSampleExternalIdsPayload()
         )
         val identifyEvent = IdentifyEvent(
             options = RudderOption(
@@ -130,7 +129,6 @@ class IdentifyEventTest {
         val expectedJsonString = readFileTrimmed(identifyEventsWithOnlyTraitsAndOptions)
         val userIdentityState: UserIdentity = provideUserIdentityState(
             traits = provideSampleJsonPayload(),
-            externalIds = provideSampleExternalIdsPayload()
         )
         val identifyEvent = IdentifyEvent(
             options = RudderOption(
@@ -155,7 +153,6 @@ class IdentifyEventTest {
         val userIdentityState: UserIdentity = provideUserIdentityState(
             userId = USER_ID,
             traits = provideSampleJsonPayload(),
-            externalIds = provideSampleExternalIdsPayload()
         )
         val identifyEvent = IdentifyEvent(
             options = RudderOption(
@@ -180,7 +177,6 @@ class IdentifyEventTest {
         val userIdentityState: UserIdentity = provideUserIdentityState(
             userId = USER_ID,
             traits = provideSampleJsonPayload(),
-            externalIds = provideSampleExternalIdsPayload()
         )
         val identifyEvent = IdentifyEvent(
             options = RudderOption(

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/ScreenEventTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/ScreenEventTest.kt
@@ -17,6 +17,7 @@ private const val screenWithDefaultArguments = "message/screen/screen_with_defau
 private const val screenWithCategoryProperty = "message/screen/screen_with_category_property.json"
 private const val screenWithProperties = "message/screen/screen_with_properties.json"
 private const val screenWithIntegrationsOption = "message/screen/screen_with_integrations_option.json"
+private const val screenWithExternalIdsOption = "message/screen/screen_with_external_ids_option.json"
 private const val screenWithCustomContextsOption = "message/screen/screen_with_custom_contexts_option.json"
 private const val screenWithAllArguments = "message/screen/screen_with_all_arguments.json"
 private const val screenWithAllArgumentsFromServer = "message/screen/screen_with_all_arguments_from_server.json"
@@ -124,7 +125,7 @@ class ScreenEventTest {
 
     @Test
     fun `given screen event with externalIds option, when serialized, then it matches expected JSON`() {
-        val expectedJsonString = readFileTrimmed(screenWithDefaultArguments)
+        val expectedJsonString = readFileTrimmed(screenWithExternalIdsOption)
         val screenEvent = ScreenEvent(
             screenName = SCREEN_NAME,
             properties = provideDefaultScreenProperties(),

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/TrackEventTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/TrackEventTest.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 private const val trackWithDefaultArguments = "message/track/track_with_default_arguments.json"
 private const val trackWithProperties = "message/track/track_with_properties.json"
 private const val trackWithIntegrationsOption = "message/track/track_with_integrations_option.json"
+private const val trackWithExternalIdsOption = "message/track/track_with_external_ids_option.json"
 private const val trackWithCustomContextsOption = "message/track/track_with_custom_contexts_option.json"
 private const val trackWithAllArguments = "message/track/track_with_all_arguments.json"
 private const val trackWithAllArgumentsFromServer = "message/track/track_with_all_arguments_from_server.json"
@@ -100,7 +101,7 @@ class TrackEventTest {
 
     @Test
     fun `given track event with externalIds option, when serialized, then it matches expected JSON`() {
-        val expectedJsonString = readFileTrimmed(trackWithDefaultArguments)
+        val expectedJsonString = readFileTrimmed(trackWithExternalIdsOption)
         val trackEvent = TrackEvent(
             event = EVENT_NAME,
             properties = emptyJsonObject,

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/provider/UserIdentityProvider.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/provider/UserIdentityProvider.kt
@@ -1,7 +1,6 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.provider
 
 import com.rudderstack.sdk.kotlin.core.ANONYMOUS_ID
-import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderTraits
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.UserIdentity
@@ -11,10 +10,8 @@ fun provideUserIdentityState(
     anonymousId: String = ANONYMOUS_ID,
     userId: String = String.empty(),
     traits: RudderTraits = emptyJsonObject,
-    externalIds: List<ExternalId> = emptyList(),
 ) = UserIdentity(
     anonymousId = anonymousId,
     userId = userId,
     traits = traits,
-    externalIds = externalIds,
 )

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityActionTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityActionTest.kt
@@ -2,7 +2,6 @@ package com.rudderstack.sdk.kotlin.core.internals.models.useridentity
 
 import com.rudderstack.sdk.kotlin.core.ANONYMOUS_ID
 import com.rudderstack.sdk.kotlin.core.Analytics
-import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.provider.provideUserIdentityState
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
@@ -21,7 +20,6 @@ import org.junit.Test
 private const val NEW_ANONYMOUS_ID = "newAnonymousId"
 private const val USER_ID = "user1"
 private val TRAITS = buildJsonObject { put("key-1", "value-1") }
-private val EXTERNAL_IDS = listOf(ExternalId("externalIdType1", "externalIdValue1"))
 
 class ResetUserIdentityActionTest {
 
@@ -81,7 +79,6 @@ class ResetUserIdentityActionTest {
                     write(StorageKeys.ANONYMOUS_ID, NEW_ANONYMOUS_ID)
                     remove(StorageKeys.USER_ID)
                     remove(StorageKeys.TRAITS)
-                    remove(StorageKeys.EXTERNAL_IDS)
                 }
             }
         }
@@ -102,7 +99,6 @@ class ResetUserIdentityActionTest {
                 storage.apply {
                     remove(StorageKeys.USER_ID)
                     remove(StorageKeys.TRAITS)
-                    remove(StorageKeys.EXTERNAL_IDS)
                 }
             }
         }
@@ -113,5 +109,4 @@ private fun provideUserIdentityStateAfterFirstIdentifyEventIsMade(): UserIdentit
         anonymousId = ANONYMOUS_ID,
         userId = USER_ID,
         traits = TRAITS,
-        externalIds = EXTERNAL_IDS
     )

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdAndTraitsActionTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdAndTraitsActionTest.kt
@@ -27,7 +27,7 @@ private val EXTERNAL_IDS_2 = listOf(ExternalId("externalIdType2", "externalIdVal
 private val TRAITS_1_OVERLAP = buildJsonObject { put("key-1", "value-2") }
 private val EXTERNAL_IDS_1_OVERLAP = listOf(ExternalId("externalIdType1", "externalIdValue2"))
 
-class SetUserIdTraitsAndExternalIdsActionTest {
+class SetUserIdAndTraitsActionTest {
 
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
@@ -38,7 +38,7 @@ class SetUserIdTraitsAndExternalIdsActionTest {
         runTest {
             val userIdentityState = provideUserIdentityInitialState()
 
-            val result = SetUserIdTraitsAndExternalIdsAction(USER_1, TRAITS_1, EXTERNAL_IDS_1, mockAnalytics)
+            val result = SetUserIdAndTraitsAction(USER_1, TRAITS_1, EXTERNAL_IDS_1, mockAnalytics)
                 .reduce(userIdentityState)
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -52,7 +52,7 @@ class SetUserIdTraitsAndExternalIdsActionTest {
         runTest {
             val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
-            val result = SetUserIdTraitsAndExternalIdsAction(USER_1, TRAITS_2, EXTERNAL_IDS_2, mockAnalytics)
+            val result = SetUserIdAndTraitsAction(USER_1, TRAITS_2, EXTERNAL_IDS_2, mockAnalytics)
                 .reduce(userIdentityState)
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -65,7 +65,7 @@ class SetUserIdTraitsAndExternalIdsActionTest {
         runTest {
             val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
-            val result = SetUserIdTraitsAndExternalIdsAction(USER_1, TRAITS_1_OVERLAP, EXTERNAL_IDS_1_OVERLAP, mockAnalytics)
+            val result = SetUserIdAndTraitsAction(USER_1, TRAITS_1_OVERLAP, EXTERNAL_IDS_1_OVERLAP, mockAnalytics)
                 .reduce(userIdentityState)
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -78,7 +78,7 @@ class SetUserIdTraitsAndExternalIdsActionTest {
         runTest {
             val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
-            val result = SetUserIdTraitsAndExternalIdsAction(USER_2, TRAITS_2, EXTERNAL_IDS_2, mockAnalytics)
+            val result = SetUserIdAndTraitsAction(USER_2, TRAITS_2, EXTERNAL_IDS_2, mockAnalytics)
                 .reduce(userIdentityState)
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -91,7 +91,7 @@ class SetUserIdTraitsAndExternalIdsActionTest {
     fun `when values are stored, then those values should be persisted in storage`() = runTest {
         val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
-        userIdentityState.storeUserIdTraitsAndExternalIds(mockAnalytics.storage)
+        userIdentityState.storeUserIdAndTraits(mockAnalytics.storage)
 
         coVerify {
             mockAnalytics.storage.write(StorageKeys.USER_ID, USER_1)

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdAndTraitsActionTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdAndTraitsActionTest.kt
@@ -1,7 +1,6 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.useridentity
 
 import com.rudderstack.sdk.kotlin.core.Analytics
-import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.LenientJson
@@ -22,10 +21,7 @@ private const val USER_1 = "user1"
 private const val USER_2 = "user2"
 private val TRAITS_1 = buildJsonObject { put("key-1", "value-1") }
 private val TRAITS_2 = buildJsonObject { put("key-2", "value-2") }
-private val EXTERNAL_IDS_1 = listOf(ExternalId("externalIdType1", "externalIdValue1"))
-private val EXTERNAL_IDS_2 = listOf(ExternalId("externalIdType2", "externalIdValue2"))
 private val TRAITS_1_OVERLAP = buildJsonObject { put("key-1", "value-2") }
-private val EXTERNAL_IDS_1_OVERLAP = listOf(ExternalId("externalIdType1", "externalIdValue2"))
 
 class SetUserIdAndTraitsActionTest {
 
@@ -34,11 +30,11 @@ class SetUserIdAndTraitsActionTest {
     private val mockAnalytics: Analytics = mockAnalytics(testScope, testDispatcher)
 
     @Test
-    fun `given identify event is made for the first time, when identify event is made, then it should update the user id, traits and external ids`() =
+    fun `given identify event is made for the first time, when identify event is made, then it should update all the values`() =
         runTest {
             val userIdentityState = provideUserIdentityInitialState()
 
-            val result = SetUserIdAndTraitsAction(USER_1, TRAITS_1, EXTERNAL_IDS_1, mockAnalytics)
+            val result = SetUserIdAndTraitsAction(USER_1, TRAITS_1, mockAnalytics)
                 .reduce(userIdentityState)
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -52,7 +48,7 @@ class SetUserIdAndTraitsActionTest {
         runTest {
             val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
-            val result = SetUserIdAndTraitsAction(USER_1, TRAITS_2, EXTERNAL_IDS_2, mockAnalytics)
+            val result = SetUserIdAndTraitsAction(USER_1, TRAITS_2, mockAnalytics)
                 .reduce(userIdentityState)
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -65,7 +61,7 @@ class SetUserIdAndTraitsActionTest {
         runTest {
             val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
-            val result = SetUserIdAndTraitsAction(USER_1, TRAITS_1_OVERLAP, EXTERNAL_IDS_1_OVERLAP, mockAnalytics)
+            val result = SetUserIdAndTraitsAction(USER_1, TRAITS_1_OVERLAP, mockAnalytics)
                 .reduce(userIdentityState)
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -74,11 +70,11 @@ class SetUserIdAndTraitsActionTest {
         }
 
     @Test
-    fun `given two identify events with different user id is made, when identify event is made, then it should update the user id, traits and external ids`() =
+    fun `given two identify events with different user id is made, when identify event is made, then it should update all the values`() =
         runTest {
             val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
-            val result = SetUserIdAndTraitsAction(USER_2, TRAITS_2, EXTERNAL_IDS_2, mockAnalytics)
+            val result = SetUserIdAndTraitsAction(USER_2, TRAITS_2, mockAnalytics)
                 .reduce(userIdentityState)
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -88,7 +84,7 @@ class SetUserIdAndTraitsActionTest {
         }
 
     @Test
-    fun `when values are stored, then those values should be persisted in storage`() = runTest {
+    fun `when values are stored, then it should be persisted in storage`() = runTest {
         val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
         userIdentityState.storeUserIdAndTraits(mockAnalytics.storage)
@@ -96,14 +92,12 @@ class SetUserIdAndTraitsActionTest {
         coVerify {
             mockAnalytics.storage.write(StorageKeys.USER_ID, USER_1)
             mockAnalytics.storage.write(StorageKeys.TRAITS, LenientJson.encodeToString(TRAITS_1))
-            mockAnalytics.storage.write(StorageKeys.EXTERNAL_IDS, LenientJson.encodeToString(EXTERNAL_IDS_1))
         }
     }
 
     private fun verifyUserIdChangedBehaviour() {
         coVerify { mockAnalytics.storage.remove(StorageKeys.USER_ID) }
         coVerify { mockAnalytics.storage.remove(StorageKeys.TRAITS) }
-        coVerify { mockAnalytics.storage.remove(StorageKeys.EXTERNAL_IDS) }
     }
 }
 
@@ -112,7 +106,6 @@ private fun provideUserIdentityInitialState(): UserIdentity =
         anonymousId = DEFAULT_ANONYMOUS_ID,
         userId = String.empty(),
         traits = emptyJsonObject,
-        externalIds = emptyList()
     )
 
 private fun provideUserIdentityStateAfterFirstIdentifyEventIsMade(): UserIdentity =
@@ -120,21 +113,18 @@ private fun provideUserIdentityStateAfterFirstIdentifyEventIsMade(): UserIdentit
         anonymousId = DEFAULT_ANONYMOUS_ID,
         userId = USER_1,
         traits = TRAITS_1,
-        externalIds = EXTERNAL_IDS_1
     )
 
 private fun provideUserIdentityWithMergedTraitsAndExternalIds(): UserIdentity = UserIdentity(
     anonymousId = DEFAULT_ANONYMOUS_ID,
     userId = USER_1,
     traits = TRAITS_1 mergeWithHigherPriorityTo TRAITS_2,
-    externalIds = EXTERNAL_IDS_1 mergeWithHigherPriorityTo EXTERNAL_IDS_2,
 )
 
 private fun provideUserIdentityWithOverriddenTraitsAndExternalIds(): UserIdentity = UserIdentity(
     anonymousId = DEFAULT_ANONYMOUS_ID,
     userId = USER_1,
     traits = TRAITS_1_OVERLAP,
-    externalIds = EXTERNAL_IDS_1_OVERLAP
 )
 
 private fun provideUserIdentityAfterSecondIdentifyEventIsMade(): UserIdentity =
@@ -142,5 +132,4 @@ private fun provideUserIdentityAfterSecondIdentifyEventIsMade(): UserIdentity =
         anonymousId = DEFAULT_ANONYMOUS_ID,
         userId = USER_2,
         traits = TRAITS_2,
-        externalIds = EXTERNAL_IDS_2
 )

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdForAliasEventTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdForAliasEventTest.kt
@@ -35,7 +35,7 @@ class SetUserIdForAliasEventTest {
     fun `when user id is stored, then those values should be persisted in storage`() = runTest {
         val userIdentityState = provideUserIdentityStateAfterUserIdIsSetForAliasEvent()
 
-        userIdentityState.storeUserIdTraitsAndExternalIds(mockAnalytics.storage)
+        userIdentityState.storeUserIdAndTraits(mockAnalytics.storage)
 
         coVerify {
             mockAnalytics.storage.write(StorageKeys.USER_ID, ALIAS_ID)

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdForAliasEventTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/SetUserIdForAliasEventTest.kt
@@ -48,7 +48,6 @@ private fun provideUserIdentityInitialState(): UserIdentity =
         anonymousId = DEFAULT_ANONYMOUS_ID,
         userId = USER_ID,
         traits = emptyJsonObject,
-        externalIds = emptyList()
     )
 
 private fun provideUserIdentityStateAfterUserIdIsSetForAliasEvent(): UserIdentity =
@@ -56,5 +55,4 @@ private fun provideUserIdentityStateAfterUserIdIsSetForAliasEvent(): UserIdentit
         anonymousId = DEFAULT_ANONYMOUS_ID,
         userId = ALIAS_ID,
         traits = emptyJsonObject,
-        externalIds = emptyList()
     )

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StorageUtilsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StorageUtilsTest.kt
@@ -1,6 +1,5 @@
 package com.rudderstack.sdk.kotlin.core.internals.utils
 
-import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderTraits
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
@@ -43,26 +42,6 @@ class StorageUtilsTest {
         val expected = emptyJsonObject
         assertEquals(expected, result)
     }
-
-    @Test
-    fun `given value is of List of ExternalIds type, when externalIds are read from storage, then return List of ExternalIds object`() {
-        every { mockStorage.readString(any(), any()) } returns getListOfExternalIdsString()
-
-        val result = mockStorage.readValuesOrDefault<List<ExternalId>>(key = StorageKeys.EXTERNAL_IDS, defaultValue = emptyList())
-
-        val expected = getListOfExternalIds()
-        assertEquals(expected, result)
-    }
-
-    @Test
-    fun `given value is of List of ExternalIds type, when empty externalIds are read from storage, then return default value`() {
-        every { mockStorage.readString(any(), any()) } returns "[]"
-
-        val result = mockStorage.readValuesOrDefault<List<ExternalId>>(key = StorageKeys.EXTERNAL_IDS, defaultValue = emptyList())
-
-        val expected = emptyList<ExternalId>()
-        assertEquals(expected, result)
-    }
 }
 
 private fun getTraitsString() =
@@ -78,23 +57,3 @@ private fun getTraitsJson() =
         put("key-1", "value-1")
         put("anonymousId", "<anonymousId>")
     }
-
-private fun getListOfExternalIdsString() =
-    """
-        [
-          {
-            "id": "id 1",
-            "type": "brazeExternalId"
-          },
-          {
-            "id": "id 2",
-            "type": "ga4"
-          }
-        ]
-    """.trimIndent()
-
-private fun getListOfExternalIds() =
-    listOf(
-        ExternalId(type = "brazeExternalId", id = "id 1"),
-        ExternalId(type = "ga4", id = "id 2"),
-    )

--- a/core/src/test/resources/message/alias/alias_events_with_all_arguments.json
+++ b/core/src/test/resources/message/alias/alias_events_with_all_arguments.json
@@ -3,6 +3,16 @@
   "type": "alias",
   "messageId": "<message-id>",
   "context": {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
     "key-1": "String value",
     "key-2": 123,
     "key-3": true,

--- a/core/src/test/resources/message/alias/alias_events_with_all_arguments_from_server.json
+++ b/core/src/test/resources/message/alias/alias_events_with_all_arguments_from_server.json
@@ -3,6 +3,16 @@
   "type": "alias",
   "messageId": "<message-id>",
   "context": {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
     "key-1": "String value",
     "key-2": 123,
     "key-3": true,

--- a/core/src/test/resources/message/group/group_with_all_arguments.json
+++ b/core/src/test/resources/message/group/group_with_all_arguments.json
@@ -22,6 +22,16 @@
   "type": "group",
   "messageId": "<message-id>",
   "context": {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
     "key-1": "String value",
     "key-2": 123,
     "key-3": true,

--- a/core/src/test/resources/message/group/group_with_all_arguments_from_server.json
+++ b/core/src/test/resources/message/group/group_with_all_arguments_from_server.json
@@ -22,6 +22,16 @@
   "type": "group",
   "messageId": "<message-id>",
   "context": {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
     "key-1": "String value",
     "key-2": 123,
     "key-3": true,

--- a/core/src/test/resources/message/group/group_with_external_ids_option.json
+++ b/core/src/test/resources/message/group/group_with_external_ids_option.json
@@ -1,0 +1,27 @@
+{
+  "groupId": "Group Id 1",
+  "type": "group",
+  "messageId": "<message-id>",
+  "context": {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
+    "traits": {
+      "anonymousId": "<anonymous-id>"
+    }
+  },
+  "originalTimestamp": "<original-timestamp>",
+  "sentAt": "{{ RSA_DEF_SENT_AT_TS }}",
+  "integrations": {
+    "All": true
+  },
+  "anonymousId": "<anonymous-id>",
+  "channel": "mobile"
+}

--- a/core/src/test/resources/message/screen/screen_with_all_arguments.json
+++ b/core/src/test/resources/message/screen/screen_with_all_arguments.json
@@ -24,6 +24,16 @@
   "type": "screen",
   "messageId": "<message-id>",
   "context": {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
     "key-1": "String value",
     "key-2": 123,
     "key-3": true,

--- a/core/src/test/resources/message/screen/screen_with_all_arguments_from_server.json
+++ b/core/src/test/resources/message/screen/screen_with_all_arguments_from_server.json
@@ -24,6 +24,16 @@
   "type": "screen",
   "messageId": "<message-id>",
   "context": {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
     "key-1": "String value",
     "key-2": 123,
     "key-3": true,

--- a/core/src/test/resources/message/screen/screen_with_external_ids_option.json
+++ b/core/src/test/resources/message/screen/screen_with_external_ids_option.json
@@ -1,0 +1,30 @@
+{
+  "event": "Test Screen 1",
+  "properties": {
+    "name": "Test Screen 1"
+  },
+  "type": "screen",
+  "messageId": "<message-id>",
+  "context": {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
+    "traits": {
+      "anonymousId": "<anonymous-id>"
+    }
+  },
+  "originalTimestamp": "<original-timestamp>",
+  "sentAt": "{{ RSA_DEF_SENT_AT_TS }}",
+  "integrations": {
+    "All": true
+  },
+  "anonymousId": "<anonymous-id>",
+  "channel": "mobile"
+}

--- a/core/src/test/resources/message/track/track_with_all_arguments.json
+++ b/core/src/test/resources/message/track/track_with_all_arguments.json
@@ -17,6 +17,16 @@
   "type" : "track",
   "messageId" : "<message-id>",
   "context" : {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
     "key-1" : "String value",
     "key-2" : 123,
     "key-3" : true,

--- a/core/src/test/resources/message/track/track_with_all_arguments_from_server.json
+++ b/core/src/test/resources/message/track/track_with_all_arguments_from_server.json
@@ -17,6 +17,16 @@
   "type" : "track",
   "messageId" : "<message-id>",
   "context" : {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
     "key-1" : "String value",
     "key-2" : 123,
     "key-3" : true,

--- a/core/src/test/resources/message/track/track_with_external_ids_option.json
+++ b/core/src/test/resources/message/track/track_with_external_ids_option.json
@@ -1,0 +1,27 @@
+{
+  "event" : "Track event 1",
+  "type" : "track",
+  "messageId" : "<message-id>",
+  "context" : {
+    "externalId": [
+      {
+        "type": "key-1",
+        "id": "value-1"
+      },
+      {
+        "type": "key-2",
+        "id": "value-2"
+      }
+    ],
+    "traits": {
+      "anonymousId": "<anonymous-id>"
+    }
+  },
+  "originalTimestamp" : "<original-timestamp>",
+  "sentAt" : "{{ RSA_DEF_SENT_AT_TS }}",
+  "integrations" : {
+    "All" : true
+  },
+  "anonymousId" : "<anonymous-id>",
+  "channel" : "mobile"
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- We have allowed the setting of `externalIds` for all event types: `identify`, `track`, `screen`, `group` and `alias`.
- Now, this value will no longer be persisted by the SDK

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

- Removed `externalIds` field from `UserIdentity`.
- Allowed processing of this fields for all events type.
- Now, this property is no longer stored.
- Updated the test cases.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

- Make any events (e.g., track, screen etc.) and include the options field with externalIds and the payload will contain `externalIds` field in the context.
```
RudderAnalyticsUtils.analytics.track(
    name = "Track at ${Date()}",
    properties = Properties(emptyMap()),
    options = RudderOption(
        customContext = buildJsonObject {
            put("key-1", "value-1")
        },
        integrations = buildJsonObject {
            put("Amplitude", true)
            put("INTERCOM", buildJsonObject {
                put("lookup", "phone")
            })
        },
        externalIds = listOf(                          // Add this
            ExternalId(type = "brazeExternalId", id = "value1234"),
        )
    )
)
```
- Make another event (say) identify without that field and its payload will not have that field.

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

Previously this value could only be set using `identify` event and it's persisted and available for all other event types. Now, the user needs to pass this value explicitly wherever needed.

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->

Now, if someone needs to pass this field in the automatically tracked events (e.g., lifecycle and/or screen) they need to set this value using custom plugins.