### PR TITLE
fix: add reset call in identify

### DIFF
--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -224,6 +224,10 @@ open class Analytics protected constructor(
     ) {
         if (!isAnalyticsActive()) return
 
+        if (!this.userId.isNullOrEmpty() && this.userId != userId) {
+            reset(clearAnonymousId = true)
+        }
+
         userIdentityState.dispatch(
             SetUserIdAndTraitsAction(
                 newUserId = userId,

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -7,6 +7,8 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.MockMemoryStorage
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import io.mockk.every
 import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -34,7 +36,7 @@ class AnalyticsTest {
         mockkStatic(::provideBasicStorage)
         every { provideBasicStorage(any()) } returns mockStorage
 
-        analytics = Analytics(configuration = configuration)
+        analytics = spyk(Analytics(configuration = configuration))
     }
 
     @Test
@@ -83,6 +85,29 @@ class AnalyticsTest {
 
         assertEquals(USER_ID, userId)
         assertEquals(TRAITS, traits)
+    }
+
+    @Test
+    fun `when identify is called on an anonymous user, then reset is not called`() {
+        analytics.identify(userId = USER_ID, traits = TRAITS)
+
+        verify(exactly = 0) { analytics.reset() }
+    }
+
+    @Test
+    fun `when identify is called with same userId on an identified user, then reset is not called`() {
+        analytics.identify(userId = USER_ID, traits = TRAITS)
+        analytics.identify(userId = USER_ID, traits = TRAITS)
+
+        verify(exactly = 0) { analytics.reset() }
+    }
+
+    @Test
+    fun `when identify is called with different userId on an identified user, then reset is called`() {
+        analytics.identify(userId = USER_ID, traits = TRAITS)
+        analytics.identify(userId = "new-user-id", traits = TRAITS)
+
+        verify(exactly = 1) { analytics.reset(clearAnonymousId = true) }
     }
 
     @Test


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->
This PR adds a `reset` (with `clearAnonymousId` as `true`) call in the `identify` API when identify is called for an already identified user but with a different userId.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->
- Launch the sample app, make an event and note the session id.
- Now, identify the user by calling identify and note the session id. It should be the same, given that the user was previously anonymous.
- Now, call identify with the same userId and check the session id. It should still be the same. The `anonymousId` should also not change.
- Now, call identify with a different userId. It should change both, the `anonymousId` and the `userId`.

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->
This logic is in alignment with JS SDK.
