### PR TITLE
feat: add shutdown functionality in the NetworkCallbackUtils class

### DIFF
--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -31,6 +31,7 @@ import com.rudderstack.sdk.kotlin.core.internals.platform.PlatformType
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.internals.utils.isAnalyticsActive
 import com.rudderstack.sdk.kotlin.core.provideAnalyticsConfiguration
+import org.jetbrains.annotations.ApiStatus.Experimental
 
 private const val MIN_SESSION_ID_LENGTH = 10
 
@@ -173,9 +174,10 @@ class Analytics(
      * In case multiple [NavController]s are used, call this method for each of them.
      *
      * @param navController [NavController] to be tracked
-     * @param activity [Activity] of the `NavHostFragment` or the parent composable in which [navController] is instantiated.
+     * @param activity [Activity] of the [NavHostFragment] or the parent composable in which [navController] is instantiated.
      */
     @Synchronized
+    @Experimental
     fun setNavigationDestinationsTracking(navController: NavController, activity: Activity) {
         if (!isAnalyticsActive()) return
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -31,7 +31,6 @@ import com.rudderstack.sdk.kotlin.core.internals.platform.PlatformType
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.internals.utils.isAnalyticsActive
 import com.rudderstack.sdk.kotlin.core.provideAnalyticsConfiguration
-import org.jetbrains.annotations.ApiStatus.Experimental
 
 private const val MIN_SESSION_ID_LENGTH = 10
 
@@ -174,10 +173,9 @@ class Analytics(
      * In case multiple [NavController]s are used, call this method for each of them.
      *
      * @param navController [NavController] to be tracked
-     * @param activity [Activity] of the [NavHostFragment] or the parent composable in which [navController] is instantiated.
+     * @param activity [Activity] of the `NavHostFragment` or the parent composable in which [navController] is instantiated.
      */
     @Synchronized
-    @Experimental
     fun setNavigationDestinationsTracking(navController: NavController, activity: Activity) {
         if (!isAnalyticsActive()) return
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/NetworkInfoPlugin.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/NetworkInfoPlugin.kt
@@ -76,4 +76,8 @@ internal class NetworkInfoPlugin(
             }
         )
     }
+
+    override fun teardown() {
+        networkUtils.teardown()
+    }
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/utils/network/NetworkCallbackUtils.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/utils/network/NetworkCallbackUtils.kt
@@ -12,6 +12,8 @@ import androidx.core.content.ContextCompat
  */
 internal class NetworkCallbackUtils(private val context: Context) {
 
+    private lateinit var connectivityManager: ConnectivityManager
+
     /**
      * Checks if the device is connected to a cellular network.
      *
@@ -52,17 +54,22 @@ internal class NetworkCallbackUtils(private val context: Context) {
 
     @Throws(RuntimeException::class)
     internal fun setup() {
-        val connectivityManager =
+        this.connectivityManager =
             ContextCompat.getSystemService(context, ConnectivityManager::class.java) as ConnectivityManager
 
         val cellularRequest: NetworkRequest = NetworkRequest.Builder()
             .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
             .build()
-        connectivityManager.registerNetworkCallback(cellularRequest, cellularCallback)
+        this.connectivityManager.registerNetworkCallback(cellularRequest, cellularCallback)
 
         val wifiRequest: NetworkRequest = NetworkRequest.Builder()
             .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
             .build()
-        connectivityManager.registerNetworkCallback(wifiRequest, wifiCallback)
+        this.connectivityManager.registerNetworkCallback(wifiRequest, wifiCallback)
+    }
+
+    internal fun teardown() {
+        this.connectivityManager.unregisterNetworkCallback(cellularCallback)
+        this.connectivityManager.unregisterNetworkCallback(wifiCallback)
     }
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/utils/network/NetworkUtils.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/utils/network/NetworkUtils.kt
@@ -41,4 +41,8 @@ internal class NetworkUtils(
     }
 
     internal fun isBluetoothEnabled(): Boolean = defaultNetworkUtils.isBluetoothEnabled()
+
+    internal fun teardown() {
+        networkCallbackUtils?.teardown()
+    }
 }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/plugins/NetworkInfoPluginTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/plugins/NetworkInfoPluginTest.kt
@@ -10,6 +10,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -85,6 +86,13 @@ class NetworkInfoPluginTest {
             actual.toString(),
             true
         )
+    }
+
+    @Test
+    fun `when teardown is called, then network utils teardown is called`() = runTest {
+        networkInfoPlugin.teardown()
+
+        verify { mockNetworkUtils.teardown() }
     }
 }
 

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/network/NetworkUtilsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/network/NetworkUtilsTest.kt
@@ -121,4 +121,13 @@ class NetworkUtilsTest {
 
         assertEquals(expectedBluetoothStatus, isBluetoothEnabled)
     }
+
+    @Test
+    fun `when teardown is called, then network callback utils teardown is called`() {
+        val networkUtils = NetworkUtils(mockNetworkCallbackUtils, mockDefaultNetworkUtils)
+
+        networkUtils.teardown()
+
+        verify { mockNetworkCallbackUtils.teardown() }
+    }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- Added the process to unregister network callbacks when shutdown is called.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

- I noticed that currently on shutdown call we don't unregister the callbacks and this leads to duplicate callback register when app is initialised after shutdown (app shouldn't be stopped in this process). 
- I fixed this behaviour by registering on the shutdown.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

1. Open `NetworkCallbackUtils` class and put debug pointers on `cellularCallback` and `wifiCallback` methods.
2. Call shutdown.
3. Toggle shutdown and cellular network -> The control shouldn't reach to the callbacks.
4. Initialise the SDK again -> Now the control should reach and only once.

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->
