### PR TITLE
feat: move permission out of the Android module

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" android:required="false" />
-    <uses-permission android:name="android.permission.INTERNET"/>
-
 </manifest>

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/NetworkInfoPlugin.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/NetworkInfoPlugin.kt
@@ -64,14 +64,17 @@ internal class NetworkInfoPlugin(
         put(
             NETWORK_KEY,
             buildJsonObject {
-                if (hasPermission(context, permission.ACCESS_NETWORK_STATE)) {
-                    putIfNotNull(NETWORK_CARRIER_KEY, networkUtils.getCarrier())
-                    put(NETWORK_CELLULAR_KEY, networkUtils.isCellularConnected())
+                putIfNotNull(NETWORK_CARRIER_KEY, networkUtils.getCarrier())
+                put(NETWORK_CELLULAR_KEY, networkUtils.isCellularConnected())
+                // If relevant permissions are not granted, skip adding the wifi state
+                if (hasPermission(context, permission.ACCESS_NETWORK_STATE) ||
+                    hasPermission(context, permission.ACCESS_WIFI_STATE)
+                ) {
                     put(NETWORK_WIFI_KEY, networkUtils.isWifiEnabled())
-                    // As per our spec, set this value only if the permission is granted
-                    if (hasPermission(context, permission.BLUETOOTH)) {
-                        put(NETWORK_BLUETOOTH_KEY, networkUtils.isBluetoothEnabled())
-                    }
+                }
+                // As per our spec, set this value only if the permission is granted
+                if (hasPermission(context, permission.BLUETOOTH)) {
+                    put(NETWORK_BLUETOOTH_KEY, networkUtils.isBluetoothEnabled())
                 }
             }
         )

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/utils/network/NetworkCallbackUtils.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/utils/network/NetworkCallbackUtils.kt
@@ -1,5 +1,6 @@
 package com.rudderstack.sdk.kotlin.android.utils.network
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
@@ -53,6 +54,7 @@ internal class NetworkCallbackUtils(private val context: Context) {
     }
 
     @Throws(RuntimeException::class)
+    @SuppressLint("MissingPermission") // This is to suppress the lint error for ACCESS_NETWORK_STATE permission.
     internal fun setup() {
         this.connectivityManager =
             ContextCompat.getSystemService(context, ConnectivityManager::class.java) as ConnectivityManager

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Required: Allows access to the internet for network communication -->
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
+
+    <!-- Optional: Allows access to track both WiFi and Cellular state -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- Optional: Grants access only to track WiFi state if the above permission is not used -->
+    <!--<uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/> -->
+
+    <!-- Optional: Required for Bluetooth functionality: Allows access to track Bluetooth state -->
     <uses-permission android:name="android.permission.BLUETOOTH"/>
+
+    <!-- Optional: Required for advertising features: Allows access to track the advertising ID -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
     <application
         android:name="com.rudderstack.sampleapp.MyApplication"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- The following permission has been removed out of the Android module:
```
<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" android:required="false" />
<uses-permission android:name="android.permission.INTERNET"/>
```
- Added the missing permissions in the Android sample app.
- Added a concise one-line doc in the sample Android app’s `AndroidManifest.xml` file to clarify which permissions are required and which are optional.
- Now Wifi State will only be added in the payload if Wifi permission is present in the `AndroidManifest.xml` file.

NOTE: Please review the `Breaking changes` section properly.
NOTE: Dynamic support works as expected.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

- To access the WiFi and Ceullar states using `ConnectivityManager` the SDK needs `android.permission.ACCESS_NETWORK_STATE` permission. This is the default way to check for these states.
- In case above permission is not added, the Cellular state could still be tracked using the default way.
- But to track the WiFi state (in case the above permission is not added), one needs to add the `android.permission.ACCESS_WIFI_STATE`. This is a fallback approach.
- Permissions:
```
<!-- Required: Allows access to the internet for network communication -->
<uses-permission android:name="android.permission.INTERNET"/>

<!-- Optional: Allows access to track both WiFi and Cellular state -->
<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
<!-- Optional: Grants access only to track WiFi state if the above permission is not used -->
<!--<uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/> -->

<!-- Optional: Required for Bluetooth functionality: Allows access to track Bluetooth state -->
<uses-permission android:name="android.permission.BLUETOOTH"/>

<!-- Optional: Required for advertising features: Allows access to track the advertising ID -->
<uses-permission android:name="com.google.android.gms.permission.AD_ID" />
```

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

1. First, comment these two dependencies in the sample Android app: As these dependencies automatically add the relevant permissions (Internet and Network State)
```
implementation(project(":integrations:adjust"))
implementation(libs.play.services.ads)
```
2. Comment the custom advertising ID plugin class and ensure the app runs successfully. 
3. Run the app - toggle wifi and cellular buttons, and you can observe the corresponding states changes.
4. Note: 
    a. Cellular permission will always be tracked even if you don't add the required permissions (we have v1 logic to track this value as a fallback approach). 
    b. Wifi state will only be tracked if the relevant permissions are added.

Sample payload:
```
"network": {
    "bluetooth": true, // Bluetooth permission is needed
    "carrier": "T-Mobile", // No permission is needed
    "cellular": true, // Either `ACCESS_NETWORK_STATE` permission is needed or works even without permission
    "wifi": false // Either `ACCESS_NETWORK_STATE` or `ACCESS_WIFI_STATE` permission is needed
}
```

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

1. The user needs to add the permission on their Android app.
2. We have removed the permission from our  Android module.
3. If internet permission is not added in the sample app AndroidManifest file: (We are going to discuss internally on improving this behaviour)
    - Our SDK will not be able to send any events.
    - SourceConfig will not be fetched.
    - SDK will keep on retrying based on the flush policy.
    - NOTE: The Event will still be ingested and saved.
4. If WiFi permission (i.e., either `ACCESS_NETWORK_STATE` or `ACCESS_WIFI_STATE`) is not added:
    - We will not add the WiFi field in the payload.

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->

We will discuss how to handle the scenario when the Internet permission is not added.