### PR TITLE
refactor: update ErrorStatus enum for improved error handling

### DIFF
--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
@@ -1,11 +1,10 @@
 package com.rudderstack.sdk.kotlin.core.internals.network
 
 private const val BAD_REQUEST_CODE = 400
-private const val INVALID_WRITE_KEY_CODE = 401
+private const val UNAUTHORIZED_CODE = 401
 private const val RESOURCE_NOT_FOUND_CODE = 404
+private const val PAYLOAD_TOO_LARGE_CODE = 413
 private const val TOO_MANY_REQUESTS_CODE = 429
-private const val SERVER_ERROR_CODE = 500
-private const val NETWORK_CONNECTION_TIMEOUT_ERROR_CODE = 599
 
 /**
  * Enum class representing various error statuses that can occur during an operation.
@@ -18,42 +17,32 @@ enum class ErrorStatus {
     /**
      * Indicates a bad request error, typically associated with HTTP status code 400.
      */
-    BAD_REQUEST,
+    ERROR_400,
 
     /**
      * Indicates an invalid write key error, typically associated with HTTP status code 401.
      */
-    INVALID_WRITE_KEY,
+    ERROR_401,
 
     /**
      * Indicates that the requested resource was not found, typically associated with HTTP status code 404.
      */
-    RESOURCE_NOT_FOUND,
+    ERROR_404,
+
+    /**
+     * Indicates that the request entity is too large, typically associated with HTTP status code 413.
+     */
+    ERROR_413,
 
     /**
      * Indicates that the rate limit has been exceeded, typically associated with HTTP status code 429.
      */
-    TOO_MANY_REQUESTS,
+    ERROR_429,
 
     /**
-     * Indicates a server error, typically associated with HTTP status code 500.
+     * Indicates a retry able error, typically associated with HTTP status code 4xx-5xx, excluding other error listed above.
      */
-    SERVER_ERROR,
-
-    /**
-     * Indicates a network connection timeout error, typically associated with HTTP status code 599.
-     */
-    NETWORK_CONNECTION_TIMEOUT_ERROR,
-
-    /**
-     * Indicates that a retry operation should be attempted due to a transient error condition.
-     */
-    RETRY_ERROR,
-
-    /**
-     * Indicates a general error that does not fall into the specific categories listed above.
-     */
-    GENERAL_ERROR;
+    ERROR_RETRY;
 
     companion object {
         /**
@@ -66,14 +55,12 @@ enum class ErrorStatus {
          * @return The corresponding `ErrorStatus` enum value.
          */
         fun toErrorStatus(errorCode: Int): ErrorStatus = when (errorCode) {
-            BAD_REQUEST_CODE -> BAD_REQUEST
-            INVALID_WRITE_KEY_CODE -> INVALID_WRITE_KEY
-            RESOURCE_NOT_FOUND_CODE -> RESOURCE_NOT_FOUND
-            TOO_MANY_REQUESTS_CODE -> TOO_MANY_REQUESTS
-            SERVER_ERROR_CODE -> SERVER_ERROR
-            NETWORK_CONNECTION_TIMEOUT_ERROR_CODE -> NETWORK_CONNECTION_TIMEOUT_ERROR
-            in SERVER_ERROR_CODE..NETWORK_CONNECTION_TIMEOUT_ERROR_CODE -> RETRY_ERROR
-            else -> GENERAL_ERROR
+            BAD_REQUEST_CODE -> ERROR_400
+            UNAUTHORIZED_CODE -> ERROR_401
+            RESOURCE_NOT_FOUND_CODE -> ERROR_404
+            PAYLOAD_TOO_LARGE_CODE -> ERROR_413
+            TOO_MANY_REQUESTS_CODE -> ERROR_429
+            else -> ERROR_RETRY
         }
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
@@ -39,12 +39,12 @@ enum class ErrorStatus {
     ERROR_RETRY,
 
     /**
-     * Indicates a network unavailable error.
+     * Indicates a retry able error, typically happens when the network is unavailable.
      */
     ERROR_NETWORK_UNAVAILABLE,
 
     /**
-     * Indicates that some unknown error occurred when connecting to the server.
+     * Indicates a fatal error, typically associated with some exception or failure that cannot be retried.
      */
     ERROR_UNKNOWN;
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
@@ -29,7 +29,7 @@ enum class ErrorStatus {
     ERROR_404,
 
     /**
-     * Indicates that the request entity is too large, typically associated with HTTP status code 413.
+     * Indicates that the request payload is too large, typically associated with HTTP status code 413.
      */
     ERROR_413,
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
@@ -4,7 +4,6 @@ private const val BAD_REQUEST_CODE = 400
 private const val UNAUTHORIZED_CODE = 401
 private const val RESOURCE_NOT_FOUND_CODE = 404
 private const val PAYLOAD_TOO_LARGE_CODE = 413
-private const val TOO_MANY_REQUESTS_CODE = 429
 
 /**
  * Enum class representing various error statuses that can occur during an operation.
@@ -35,11 +34,6 @@ enum class ErrorStatus {
     ERROR_413,
 
     /**
-     * Indicates that the rate limit has been exceeded, typically associated with HTTP status code 429.
-     */
-    ERROR_429,
-
-    /**
      * Indicates a retry able error, typically associated with HTTP status code 4xx-5xx, excluding other error listed above.
      */
     ERROR_RETRY;
@@ -59,7 +53,6 @@ enum class ErrorStatus {
             UNAUTHORIZED_CODE -> ERROR_401
             RESOURCE_NOT_FOUND_CODE -> ERROR_404
             PAYLOAD_TOO_LARGE_CODE -> ERROR_413
-            TOO_MANY_REQUESTS_CODE -> ERROR_429
             else -> ERROR_RETRY
         }
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/ErrorStatus.kt
@@ -36,9 +36,20 @@ enum class ErrorStatus {
     /**
      * Indicates a retry able error, typically associated with HTTP status code 4xx-5xx, excluding other error listed above.
      */
-    ERROR_RETRY;
+    ERROR_RETRY,
+
+    /**
+     * Indicates a network unavailable error.
+     */
+    ERROR_NETWORK_UNAVAILABLE,
+
+    /**
+     * Indicates that some unknown error occurred when connecting to the server.
+     */
+    ERROR_UNKNOWN;
 
     companion object {
+
         /**
          * Converts an HTTP status code to a corresponding `ErrorStatus` enum value.
          *

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImpl.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImpl.kt
@@ -6,7 +6,10 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.validatedBaseUrl
 import java.io.IOException
 import java.net.ConnectException
 import java.net.HttpURLConnection
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
 import java.net.URL
+import java.net.UnknownHostException
 import java.util.Locale
 import java.util.zip.GZIPOutputStream
 
@@ -192,9 +195,9 @@ internal class HttpClientImpl private constructor(
         } catch (e: Exception) {
             when (e) {
                 is ConnectException,
-                is java.net.UnknownHostException,
-                is java.net.NoRouteToHostException,
-                is java.net.SocketTimeoutException -> {
+                is UnknownHostException,
+                is NoRouteToHostException,
+                is SocketTimeoutException -> {
                     Result.Failure(status = ErrorStatus.ERROR_NETWORK_UNAVAILABLE, error = e)
                 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImpl.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImpl.kt
@@ -188,7 +188,7 @@ internal class HttpClientImpl private constructor(
             connect()
             constructResponse()
         } catch (e: Exception) {
-            Result.Failure(status = ErrorStatus.GENERAL_ERROR, error = e)
+            Result.Failure(status = toErrorStatus(responseCode), error = e)
         } finally {
             disconnect()
         }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/SourceConfigManagerTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/SourceConfigManagerTest.kt
@@ -134,7 +134,7 @@ class SourceConfigManagerTest {
         runTest(testDispatcher) {
             every { httpClient.getData() } returns Result.Failure(
                 error = Exception(),
-                status = ErrorStatus.SERVER_ERROR
+                status = ErrorStatus.ERROR_RETRY
             )
 
             sourceConfigManager.refreshSourceConfigAndNotifyObservers()

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImplTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImplTest.kt
@@ -77,7 +77,7 @@ class HttpClientImplTest {
 
         val result = getHttpClient.getData()
 
-        assertFailure(result, ErrorStatus.GENERAL_ERROR, exception)
+        assertFailure(result, ErrorStatus.ERROR_RETRY, exception)
     }
 
     @Test
@@ -88,7 +88,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.BAD_REQUEST,
+            ErrorStatus.ERROR_400,
             IOException(provideErrorMessage(400, mockConnection))
         )
     }
@@ -101,7 +101,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.RESOURCE_NOT_FOUND,
+            ErrorStatus.ERROR_404,
             IOException(provideErrorMessage(404, mockConnection))
         )
     }
@@ -114,7 +114,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.SERVER_ERROR,
+            ErrorStatus.ERROR_RETRY,
             IOException(provideErrorMessage(500, mockConnection))
         )
     }
@@ -127,7 +127,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.TOO_MANY_REQUESTS,
+            ErrorStatus.ERROR_429,
             IOException(provideErrorMessage(429, mockConnection))
         )
     }
@@ -140,7 +140,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.GENERAL_ERROR,
+            ErrorStatus.ERROR_RETRY,
             IOException(provideErrorMessage(450, mockConnection))
         )
     }
@@ -164,7 +164,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.INVALID_WRITE_KEY,
+            ErrorStatus.ERROR_401,
             IOException(provideErrorMessage(401, mockConnection))
         )
     }
@@ -194,7 +194,7 @@ class HttpClientImplTest {
 
         val result = postHttpClient.sendData(REQUEST_BODY)
 
-        assertFailure(result, ErrorStatus.GENERAL_ERROR, exception)
+        assertFailure(result, ErrorStatus.ERROR_RETRY, exception)
     }
 
     @Test
@@ -205,7 +205,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.BAD_REQUEST,
+            ErrorStatus.ERROR_400,
             IOException(provideErrorMessage(400, mockConnection))
         )
     }
@@ -218,7 +218,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.RESOURCE_NOT_FOUND,
+            ErrorStatus.ERROR_404,
             IOException(provideErrorMessage(404, mockConnection))
         )
     }
@@ -231,7 +231,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.TOO_MANY_REQUESTS,
+            ErrorStatus.ERROR_429,
             IOException(provideErrorMessage(429, mockConnection))
         )
     }
@@ -244,7 +244,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.GENERAL_ERROR,
+            ErrorStatus.ERROR_RETRY,
             IOException(provideErrorMessage(450, mockConnection))
         )
     }
@@ -257,7 +257,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.SERVER_ERROR,
+            ErrorStatus.ERROR_RETRY,
             IOException(provideErrorMessage(500, mockConnection))
         )
     }
@@ -281,7 +281,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.INVALID_WRITE_KEY,
+            ErrorStatus.ERROR_401,
             IOException(provideErrorMessage(401, mockConnection))
         )
     }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImplTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImplTest.kt
@@ -20,7 +20,6 @@ import java.io.IOException
 import java.net.ConnectException
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
-import java.net.SocketException
 import java.net.UnknownHostException
 
 private const val WRONG_BASE_URL = "<wrong-url>"
@@ -324,14 +323,14 @@ class HttpClientImplTest {
     @Test
     fun `given any unknown exception is thrown, when sendData is called, then return unknown exception`() {
         // This is to simulate a network error.
-        every { mockConnection.connect() } throws SocketException()
+        every { mockConnection.connect() } throws Exception()
 
         val result = postHttpClient.sendData(REQUEST_BODY)
 
         assertFailure(
             result,
-            ErrorStatus.ERROR_RETRY,
-            SocketException()
+            ErrorStatus.ERROR_UNKNOWN,
+            Exception()
         )
     }
 

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImplTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/network/HttpClientImplTest.kt
@@ -127,7 +127,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.ERROR_429,
+            ErrorStatus.ERROR_RETRY,
             IOException(provideErrorMessage(429, mockConnection))
         )
     }
@@ -231,7 +231,7 @@ class HttpClientImplTest {
 
         assertFailure(
             result,
-            ErrorStatus.ERROR_429,
+            ErrorStatus.ERROR_RETRY,
             IOException(provideErrorMessage(429, mockConnection))
         )
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- In this PR, we updated the `Error Status Codes` to better align with the revised requirements.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

### Introduced following error status codes
```
/**
 * Indicates a bad request error, typically associated with HTTP status code 400.
 */
ERROR_400,

/**
 * Indicates an invalid write key error, typically associated with HTTP status code 401.
 */
ERROR_401,

/**
 * Indicates that the requested resource was not found, typically associated with HTTP status code 404.
 */
ERROR_404,

/**
 * Indicates that the request payload is too large, typically associated with HTTP status code 413.
 */
ERROR_413,

/**
 * Indicates a retry able error, typically associated with HTTP status code 4xx-5xx, excluding other error listed above.
 */
ERROR_RETRY,

/**
 * Indicates a network unavailable error.
 */
ERROR_NETWORK_UNAVAILABLE,

/**
 * Indicates that some unknown error occurred when connecting to the server.
 */
ERROR_UNKNOWN;
```
- If the response from the server is properly returned and no exception occurred (e.g., IOException) then return we will return this mapping:
```
BAD_REQUEST_CODE -> ERROR_400
UNAUTHORIZED_CODE -> ERROR_401
RESOURCE_NOT_FOUND_CODE -> ERROR_404
PAYLOAD_TOO_LARGE_CODE -> ERROR_413
else -> ERROR_RETRY
```
- If some exception occurs while establishing the connection, then based on the exception, the network module returns a more detailed failure message. It sets the following error status:
    - `ERROR_NETWORK_UNAVAILABLE`: This signifies the network is unavailable. It is set when `ConnectException`, `UnknownHostException`, `NoRouteToHostException` or `SocketTimeoutException` occurs.
    - `ERROR_RETRY`: This signifies that some IO Exception has occurred. It is set when an `IOException` occurs.
    - `ERROR_UNKNOWN`: This signifies those errors which cannot be handled. It is set when some unhandled exception occurs.
- Added unit test case.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

- Make a network connection and turn off the device internet it'll set the Network unavailable error.

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/23b2e516-d001-4a0f-9fe2-e6f826c8eb9e" />

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->

We will utilise these changes in other PR's. And as required, we'll do the further refactor.