### PR TITLE
feat: store events in writeKey specific directories and provide an API to delete the storage

### DIFF
--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPlugin.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPlugin.kt
@@ -21,9 +21,7 @@ internal const val REFERRING_APPLICATION_KEY = "referring_application"
 internal const val URL_KEY = "url"
 internal const val DEEPLINK_OPENED_KEY = "Deep Link Opened"
 
-internal class DeeplinkPlugin(
-    private val checkBuildVersionUseCase: CheckBuildVersionUseCase = CheckBuildVersionUseCase()
-) : Plugin, ActivityLifecycleObserver {
+internal class DeeplinkPlugin : Plugin, ActivityLifecycleObserver {
 
     override val pluginType: Plugin.PluginType = Plugin.PluginType.Utility
 
@@ -66,7 +64,7 @@ internal class DeeplinkPlugin(
     }
 
     private fun Activity.getReferrerString(): String? {
-        return if (checkBuildVersionUseCase.isAndroidVersionLollipopAndAbove()) {
+        return if (CheckBuildVersionUseCase.isAndroidVersionLollipopAndAbove()) {
             this.referrer?.toString()
         } else {
             getReferrerCompatible(this)?.toString()

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -10,7 +10,7 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.MAX_PAYLOAD_SIZE
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
-import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKeyToDirectoryName
+import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKey
 import com.rudderstack.sdk.kotlin.core.internals.utils.toAndroidPrefsKey
 import java.io.File
 
@@ -24,7 +24,7 @@ internal class AndroidStorage(
 ) : Storage {
 
     private val storageDirectory: File =
-        context.getDir(DIRECTORY_NAME.appendWriteKeyToDirectoryName(writeKey), Context.MODE_PRIVATE)
+        context.getDir(DIRECTORY_NAME.appendWriteKey(writeKey), Context.MODE_PRIVATE)
     private val eventBatchFile = EventBatchFileManager(storageDirectory, writeKey, rudderPrefsRepo)
 
     override suspend fun write(key: StorageKeys, value: Boolean) {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -3,6 +3,7 @@ package com.rudderstack.sdk.kotlin.android.storage
 import android.content.Context
 import com.rudderstack.sdk.kotlin.BuildConfig
 import com.rudderstack.sdk.kotlin.android.storage.exceptions.QueuedPayloadTooLargeException
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.storage.EventBatchFileManager
 import com.rudderstack.sdk.kotlin.core.internals.storage.KeyValueStorage
 import com.rudderstack.sdk.kotlin.core.internals.storage.LibraryVersion
@@ -109,8 +110,9 @@ internal class AndroidStorage(
 
     @UseWithCaution
     override fun delete() {
-        storageDirectory.deleteRecursively()
         rudderPrefsRepo.delete()
+        storageDirectory.deleteRecursively()
+        LoggerAnalytics.info("Storage cleared.")
     }
 }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -10,6 +10,7 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.MAX_PAYLOAD_SIZE
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.toAndroidPrefsKey
+import com.rudderstack.sdk.kotlin.core.internals.utils.underscoreSeparator
 import java.io.File
 
 private const val RUDDER_PREFS = "rl_prefs"
@@ -21,7 +22,8 @@ internal class AndroidStorage(
     private val rudderPrefsRepo: KeyValueStorage = SharedPrefsStore(context, RUDDER_PREFS.toAndroidPrefsKey(writeKey))
 ) : Storage {
 
-    private val storageDirectory: File = context.getDir(DIRECTORY_NAME, Context.MODE_PRIVATE)
+    private val storageDirectory: File =
+        context.getDir(DIRECTORY_NAME.appendWriteKeyToDirectoryName(writeKey), Context.MODE_PRIVATE)
     private val eventBatchFile = EventBatchFileManager(storageDirectory, writeKey, rudderPrefsRepo)
 
     override suspend fun write(key: StorageKeys, value: Boolean) {
@@ -117,4 +119,8 @@ internal fun provideAndroidStorage(writeKey: String, application: Context): Stor
         context = application,
         writeKey = writeKey,
     )
+}
+
+private fun String.appendWriteKeyToDirectoryName(writeKey: String): String {
+    return "$this${String.underscoreSeparator()}$writeKey"
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -9,6 +9,7 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.LibraryVersion
 import com.rudderstack.sdk.kotlin.core.internals.storage.MAX_PAYLOAD_SIZE
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.toAndroidPrefsKey
 import com.rudderstack.sdk.kotlin.core.internals.utils.underscoreSeparator
 import java.io.File
@@ -104,6 +105,12 @@ internal class AndroidStorage(
 
             override fun getBuildVersion(): String = android.os.Build.VERSION.SDK_INT.toString()
         }
+    }
+
+    @UseWithCaution
+    override fun deleteStorageAndPreferences() {
+        storageDirectory.deleteRecursively()
+        rudderPrefsRepo.deletePrefs()
     }
 }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -108,7 +108,7 @@ internal class AndroidStorage(
     }
 
     @UseWithCaution
-    override fun deleteStorageAndPreferences() {
+    override fun delete() {
         storageDirectory.deleteRecursively()
         rudderPrefsRepo.delete()
     }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -110,9 +110,14 @@ internal class AndroidStorage(
 
     @UseWithCaution
     override fun delete() {
-        rudderPrefsRepo.delete()
-        storageDirectory.deleteRecursively()
-        LoggerAnalytics.info("Storage cleared.")
+        runCatching {
+            rudderPrefsRepo.delete()
+            storageDirectory.deleteRecursively().let { isDeleted ->
+                LoggerAnalytics.info("Storage directory deleted: $isDeleted")
+            }
+        }.onFailure {
+            LoggerAnalytics.error("Error while clearing storage: ${it.stackTraceToString()}")
+        }
     }
 }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -110,7 +110,7 @@ internal class AndroidStorage(
     @UseWithCaution
     override fun deleteStorageAndPreferences() {
         storageDirectory.deleteRecursively()
-        rudderPrefsRepo.deletePrefs()
+        rudderPrefsRepo.delete()
     }
 }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -110,13 +110,9 @@ internal class AndroidStorage(
 
     @UseWithCaution
     override fun delete() {
-        runCatching {
-            rudderPrefsRepo.delete()
-            storageDirectory.deleteRecursively().let { isDeleted ->
-                LoggerAnalytics.info("Storage directory deleted: $isDeleted")
-            }
-        }.onFailure {
-            LoggerAnalytics.error("Error while clearing storage: ${it.stackTraceToString()}")
+        rudderPrefsRepo.delete()
+        storageDirectory.deleteRecursively().let { isDeleted ->
+            LoggerAnalytics.info("Storage directory deleted: $isDeleted")
         }
     }
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -10,8 +10,8 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.MAX_PAYLOAD_SIZE
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
+import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKeyToDirectoryName
 import com.rudderstack.sdk.kotlin.core.internals.utils.toAndroidPrefsKey
-import com.rudderstack.sdk.kotlin.core.internals.utils.underscoreSeparator
 import java.io.File
 
 private const val RUDDER_PREFS = "rl_prefs"
@@ -126,8 +126,4 @@ internal fun provideAndroidStorage(writeKey: String, application: Context): Stor
         context = application,
         writeKey = writeKey,
     )
-}
-
-private fun String.appendWriteKeyToDirectoryName(writeKey: String): String {
-    return "$this${String.underscoreSeparator()}$writeKey"
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/CheckBuildVersionUseCase.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/CheckBuildVersionUseCase.kt
@@ -4,11 +4,15 @@ import android.annotation.SuppressLint
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 
-internal class CheckBuildVersionUseCase {
+internal object CheckBuildVersionUseCase {
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.LOLLIPOP_MR1)
     @SuppressLint("ObsoleteSdkInt")
     internal fun isAndroidVersionLollipopAndAbove(): Boolean {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
+    }
+
+    internal fun isAndroidVersionNAndAbove(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
     }
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -7,8 +7,8 @@ import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.storage.KeyValueStorage
 
 internal class SharedPrefsStore(
-    context: Context,
-    prefsName: String,
+    private val context: Context,
+    private val prefsName: String,
 ) : KeyValueStorage {
 
     private val preferences: SharedPreferences = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
@@ -43,6 +43,16 @@ internal class SharedPrefsStore(
 
     override fun save(key: String, value: Long) {
         put(key, value)
+    }
+
+    override fun deletePrefs() {
+        if (CheckBuildVersionUseCase.isAndroidVersionNAndAbove()) {
+            context.deleteSharedPreferences(prefsName)
+        } else {
+            // TODO: Test this
+            context.deleteFile(context.applicationInfo.dataDir + "/shared_prefs/$prefsName.xml")
+        }
+        LoggerAnalytics.info("SharedPrefsStore: Preference cleared.")
     }
 
     override fun clear(key: String) {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -65,7 +65,7 @@ internal class SharedPrefsStore(
                         }
                 }
         }
-        LoggerAnalytics.info("SharedPrefsStore: Preference cleared.")
+        LoggerAnalytics.info("Preference cleared.")
     }
 
     override fun clear(key: String) {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -54,15 +54,13 @@ internal class SharedPrefsStore(
         } else {
             File(context.getSharedPreferencesFilePath(prefsName))
                 .takeIf { file -> file.exists() }
-                ?.let { file ->
-                    file.delete()
-                        .let { isDeleted ->
-                            LoggerAnalytics.debug(
-                                "SharedPrefsStore: Path: " +
-                                    "${context.getSharedPreferencesFilePath(prefsName)} " +
-                                    "delete status: $isDeleted"
-                            )
-                        }
+                ?.delete()
+                ?.let { isDeleted ->
+                    LoggerAnalytics.debug(
+                        "SharedPrefsStore: Attempted to delete shared preferences at path: " +
+                            "${context.getSharedPreferencesFilePath(prefsName)}. " +
+                            "Deletion successful: $isDeleted"
+                    )
                 }
         }
         LoggerAnalytics.info("Preference cleared.")

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -48,7 +48,7 @@ internal class SharedPrefsStore(
     }
 
     @UseWithCaution
-    override fun deletePrefs() {
+    override fun delete() {
         if (CheckBuildVersionUseCase.isAndroidVersionNAndAbove()) {
             context.deleteSharedPreferences(prefsName)
         } else {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -49,21 +49,14 @@ internal class SharedPrefsStore(
 
     @UseWithCaution
     override fun delete() {
-        if (CheckBuildVersionUseCase.isAndroidVersionNAndAbove()) {
+        val isDeleted = if (CheckBuildVersionUseCase.isAndroidVersionNAndAbove()) {
             context.deleteSharedPreferences(prefsName)
         } else {
             File(context.getSharedPreferencesFilePath(prefsName))
                 .takeIf { file -> file.exists() }
-                ?.delete()
-                ?.let { isDeleted ->
-                    LoggerAnalytics.debug(
-                        "SharedPrefsStore: Attempted to delete shared preferences at path: " +
-                            "${context.getSharedPreferencesFilePath(prefsName)}. " +
-                            "Deletion successful: $isDeleted"
-                    )
-                }
+                ?.delete() ?: false
         }
-        LoggerAnalytics.info("Preference cleared.")
+        LoggerAnalytics.debug("Attempt to delete shared preferences successful: $isDeleted")
     }
 
     override fun clear(key: String) {

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
@@ -134,7 +134,7 @@ class SharedPrefsStoreTest {
     fun `given android version is N and above, when deletePrefs is called, then verify that shared preference is deleted`() {
         every { CheckBuildVersionUseCase.isAndroidVersionNAndAbove() } returns true
 
-        sharedPrefsStore.deletePrefs()
+        sharedPrefsStore.delete()
 
         verify { mockContext.deleteSharedPreferences(prefsName) }
     }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
@@ -2,6 +2,7 @@ package com.rudderstack.sdk.kotlin.android.storage
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -128,6 +129,7 @@ class SharedPrefsStoreTest {
         }
     }
 
+    @OptIn(UseWithCaution::class)
     @Test
     fun `given android version is N and above, when deletePrefs is called, then verify that shared preference is deleted`() {
         every { CheckBuildVersionUseCase.isAndroidVersionNAndAbove() } returns true
@@ -135,14 +137,5 @@ class SharedPrefsStoreTest {
         sharedPrefsStore.deletePrefs()
 
         verify { mockContext.deleteSharedPreferences(prefsName) }
-    }
-
-    @Test
-    fun `given android version is below N, when deletePrefs is called, then verify that shared preferences is deleted`() {
-        every { CheckBuildVersionUseCase.isAndroidVersionNAndAbove() } returns false
-
-        sharedPrefsStore.deletePrefs()
-
-        verify { mockContext.deleteFile("null/shared_prefs/${prefsName}.xml") }
     }
 }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
@@ -86,7 +86,7 @@ internal class MockMemoryStorage : Storage {
     }
 
     @UseWithCaution
-    override fun deleteStorageAndPreferences() {
+    override fun delete() {
         messageBatchMap.clear()
     }
 }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
@@ -3,6 +3,7 @@ package com.rudderstack.sdk.kotlin.android.utils
 import com.rudderstack.sdk.kotlin.core.internals.storage.LibraryVersion
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 
 internal class MockMemoryStorage : Storage {
 
@@ -82,5 +83,10 @@ internal class MockMemoryStorage : Storage {
 
             override fun getVersionName() = "1.0.0"
         }
+    }
+
+    @UseWithCaution
+    override fun deleteStorageAndPreferences() {
+        messageBatchMap.clear()
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -133,7 +133,7 @@ internal class BasicStorage(writeKey: String) : Storage {
 
     @UseWithCaution
     override fun deleteStorageAndPreferences() {
-        propertiesFile.deletePrefs()
+        propertiesFile.delete()
         storageDirectory.deleteRecursively()
         LoggerAnalytics.info("Storage deleted successfully.")
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -135,7 +135,7 @@ internal class BasicStorage(writeKey: String) : Storage {
     override fun delete() {
         propertiesFile.delete()
         storageDirectory.deleteRecursively()
-        LoggerAnalytics.info("Storage deleted successfully.")
+        LoggerAnalytics.info("Storage cleared.")
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -132,7 +132,7 @@ internal class BasicStorage(writeKey: String) : Storage {
     }
 
     @UseWithCaution
-    override fun deleteStorageAndPreferences() {
+    override fun delete() {
         propertiesFile.delete()
         storageDirectory.deleteRecursively()
         LoggerAnalytics.info("Storage deleted successfully.")

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -133,13 +133,9 @@ internal class BasicStorage(writeKey: String) : Storage {
 
     @UseWithCaution
     override fun delete() {
-        runCatching {
-            propertiesFile.delete()
-            storageDirectory.deleteRecursively().let { isDeleted ->
-                LoggerAnalytics.info("Storage directory deleted: $isDeleted")
-            }
-        }.onFailure {
-            LoggerAnalytics.error("Error while clearing storage: ${it.stackTraceToString()}")
+        propertiesFile.delete()
+        storageDirectory.deleteRecursively().let { isDeleted ->
+            LoggerAnalytics.info("Storage directory deleted: $isDeleted")
         }
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -10,7 +10,7 @@ import java.io.File
 /**
  * The directory where the event files are stored.
  * */
-private const val FILE_DIRECTORY = "/tmp/rudderstack-analytics-kotlin"
+internal const val FILE_DIRECTORY = "/tmp/rudderstack-analytics-kotlin"
 private const val FILE_NAME = "events"
 
 /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -1,14 +1,14 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.storage.exception.PayloadTooLargeException
-import com.rudderstack.sdk.kotlin.core.internals.utils.toFileDirectory
+import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKey
 import source.version.VersionConstants
 import java.io.File
 
 /**
  * The directory where the event files are stored.
  * */
-const val FILE_DIRECTORY = "/tmp/rudderstack-analytics-kotlin/"
+private const val FILE_DIRECTORY = "/tmp/rudderstack-analytics-kotlin"
 private const val FILE_NAME = "events"
 
 /**
@@ -23,9 +23,9 @@ private const val FILE_NAME = "events"
 internal class BasicStorage(writeKey: String) : Storage {
 
     /**
-     * The directory where the storage files are kept, determined by the provided [writeKey].
+     * The directory where the storage files are kept, determined by the provided `writeKey`.
      */
-    private val storageDirectory = File(writeKey.toFileDirectory(FILE_DIRECTORY))
+    private val storageDirectory = File(FILE_DIRECTORY.appendWriteKey(writeKey))
 
     /**
      * The subdirectory within [storageDirectory] where event files are stored.

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -133,9 +133,14 @@ internal class BasicStorage(writeKey: String) : Storage {
 
     @UseWithCaution
     override fun delete() {
-        propertiesFile.delete()
-        storageDirectory.deleteRecursively()
-        LoggerAnalytics.info("Storage cleared.")
+        runCatching {
+            propertiesFile.delete()
+            storageDirectory.deleteRecursively().let { isDeleted ->
+                LoggerAnalytics.info("Storage directory deleted: $isDeleted")
+            }
+        }.onFailure {
+            LoggerAnalytics.error("Error while clearing storage: ${it.stackTraceToString()}")
+        }
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -1,6 +1,8 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.storage.exception.PayloadTooLargeException
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKey
 import source.version.VersionConstants
 import java.io.File
@@ -127,6 +129,13 @@ internal class BasicStorage(writeKey: String) : Storage {
 
             override fun getVersionName(): String = VersionConstants.VERSION_NAME
         }
+    }
+
+    @UseWithCaution
+    override fun deleteStorageAndPreferences() {
+        propertiesFile.deletePrefs()
+        storageDirectory.deleteRecursively()
+        LoggerAnalytics.info("Storage deleted successfully.")
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/EventBatchFileManager.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/EventBatchFileManager.kt
@@ -92,7 +92,7 @@ class EventBatchFileManager(
      */
     fun read(): List<String> {
         val files = directory.listFiles { _, name ->
-            name.contains(writeKey) && !name.endsWith(TMP_SUFFIX)
+            !name.endsWith(TMP_SUFFIX)
         } ?: emptyArray()
         return files.map { it.absolutePath }
     }
@@ -155,7 +155,7 @@ class EventBatchFileManager(
     private fun currentFile(): File {
         if (curFile == null) {
             val index = keyValueStorage.getInt(fileIndexKey, 0)
-            curFile = File(directory, "$writeKey-$index$TMP_SUFFIX")
+            curFile = File(directory, "$index$TMP_SUFFIX")
         }
         return curFile!!
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
@@ -1,6 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 
 /**
  * Interface defining a basic key-value storage mechanism.
@@ -107,11 +108,10 @@ interface KeyValueStorage {
     fun clear(key: String)
 
     /**
-     * Deletes all the preferences stored in the storage.
+     * Deletes all stored preferences from the storage mechanism.
      *
-     * This method clears all preferences stored in the shared preferences file. If the Android system version is
-     * Nougat or above, it removes the entire preferences file. For older versions, it manually deletes the
-     * underlying shared preferences file.
+     * This method deletes the shared preferences file entirely to ensure a clean state.
      */
+    @UseWithCaution
     fun deletePrefs()
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
@@ -108,10 +108,10 @@ interface KeyValueStorage {
     fun clear(key: String)
 
     /**
-     * Deletes all stored preferences from the storage mechanism.
-     *
      * This method deletes the shared preferences file entirely to ensure a clean state.
+     *
+     * **Note**: It is recommended to use this API during shutdown to ensure the file is not removed abruptly, which could lead to unexpected errors.
      */
     @UseWithCaution
-    fun deletePrefs()
+    fun delete()
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
@@ -105,4 +105,13 @@ interface KeyValueStorage {
      * @param key The key used to identify the storage location to be cleared.
      */
     fun clear(key: String)
+
+    /**
+     * Deletes all the preferences stored in the storage.
+     *
+     * This method clears all preferences stored in the shared preferences file. If the Android system version is
+     * Nougat or above, it removes the entire preferences file. For older versions, it manually deletes the
+     * underlying shared preferences file.
+     */
+    fun deletePrefs()
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
@@ -110,7 +110,7 @@ internal class PropertiesFile(
     }
 
     @UseWithCaution
-    override fun deletePrefs() {
+    override fun delete() {
         propsFile.deleteRecursively()
         LoggerAnalytics.info("Preferences deleted successfully.")
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
@@ -111,7 +111,8 @@ internal class PropertiesFile(
 
     @UseWithCaution
     override fun delete() {
-        propsFile.deleteRecursively()
-        LoggerAnalytics.info("Preference cleared.")
+        propsFile.deleteRecursively().let { isDeleted ->
+            LoggerAnalytics.info("Attempt to delete properties file successful: $isDeleted")
+        }
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
@@ -1,6 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.toPropertiesFileName
 import java.io.File
 import java.io.FileInputStream
@@ -106,5 +107,11 @@ internal class PropertiesFile(
         properties.remove(key)
         save()
         return true
+    }
+
+    @UseWithCaution
+    override fun deletePrefs() {
+        propsFile.deleteRecursively()
+        LoggerAnalytics.info("Preferences deleted successfully.")
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
@@ -112,6 +112,6 @@ internal class PropertiesFile(
     @UseWithCaution
     override fun delete() {
         propsFile.deleteRecursively()
-        LoggerAnalytics.info("Preferences deleted successfully.")
+        LoggerAnalytics.info("Preference cleared.")
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
@@ -136,18 +136,16 @@ interface Storage {
     fun getLibraryVersion(): LibraryVersion
 
     /**
-     * Deletes the directory currently being used by the storage implementation, along with the
-     * shared preferences file.
+     * Deletes the storage being used by the implementation, along with any associated configuration.
      *
-     * This operation permanently removes the current directory and its contents, as well as the
-     * shared preferences file.
+     * This operation permanently removes all stored data.
      *
-     * Use this method with caution, as any files or data within these locations will be irretrievably lost.
+     * Use this method with caution, as any data within the storage will be irretrievably lost.
      *
-     * **Note**: It is recommended to call the shutdown API after invoking this method to ensure the SDK is in a consistent state.
+     * **Note**: It is recommended to use this API during shutdown to ensure storage is not removed abruptly, which could lead to unexpected errors.
      */
     @UseWithCaution
-    fun deleteStorageAndPreferences()
+    fun delete()
 }
 
 /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
@@ -1,6 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 
 /**
@@ -133,6 +134,20 @@ interface Storage {
      * @return An instance of [LibraryVersion] containing version details.
      */
     fun getLibraryVersion(): LibraryVersion
+
+    /**
+     * Deletes the directory currently being used by the storage implementation, along with the
+     * shared preferences file.
+     *
+     * This operation permanently removes the current directory and its contents, as well as the
+     * shared preferences file.
+     *
+     * Use this method with caution, as any files or data within these locations will be irretrievably lost.
+     *
+     * **Note**: It is recommended to call the shutdown API after invoking this method to ensure the SDK is in a consistent state.
+     */
+    @UseWithCaution
+    fun deleteStorageAndPreferences()
 }
 
 /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/CustomAnnotations.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/CustomAnnotations.kt
@@ -33,3 +33,32 @@ package com.rudderstack.sdk.kotlin.core.internals.utils
  * ```
  */
 annotation class InternalRudderApi
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This method should be used with caution. Read the API documentation for more details."
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.PROPERTY_GETTER
+)
+/**
+ * This annotation should be applied to methods, classes, or properties that require careful usage
+ * due to potential risks or limited guarantees. APIs annotated with this indicate that additional
+ * attention or understanding is required before use, as misuse may lead to unintended consequences.
+ *
+ * Example usage:
+ * ```
+ * import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
+ *
+ * @UseWithCaution
+ * fun riskyFunction() {
+ *     // Implementation of a cautious function
+ *     ...
+ * }
+ * ```
+ */
+annotation class UseWithCaution

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
@@ -125,6 +125,6 @@ fun generateUUID(): String {
  * @return The formatted directory name.
  */
 @InternalRudderApi
-fun String.appendWriteKeyToDirectoryName(writeKey: String): String {
+fun String.appendWriteKey(writeKey: String): String {
     return "$this${String.underscoreSeparator()}$writeKey"
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
@@ -114,3 +114,17 @@ internal val String.validatedBaseUrl
 fun generateUUID(): String {
     return UUID.randomUUID().toString()
 }
+
+/**
+ * Appends the provided write key to the directory name using an underscore separator (`_`).
+ *
+ * This extension function formats the directory name by appending the given
+ * write key using an underscore separator.
+ *
+ * @param writeKey The write key to be appended to the directory name.
+ * @return The formatted directory name.
+ */
+@InternalRudderApi
+fun String.appendWriteKeyToDirectoryName(writeKey: String): String {
+    return "$this${String.underscoreSeparator()}$writeKey"
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
@@ -5,6 +5,7 @@ import java.util.Locale
 import java.util.UUID
 
 private const val EMPTY_STRING = ""
+private const val UNDERSCORE_SEPARATOR = "_"
 
 /**
  * Encodes the string to a Base64 encoded string.
@@ -85,6 +86,16 @@ internal fun String?.parseFilePaths(): List<String> {
  */
 @InternalRudderApi
 fun String.Companion.empty(): String = EMPTY_STRING
+
+/**
+ * Provides an underscore separator constant.
+ *
+ * This companion object extension function returns an underscore separator (`"_"`).
+ *
+ * @return An underscore separator as a string.
+ */
+@InternalRudderApi
+fun String.Companion.underscoreSeparator(): String = UNDERSCORE_SEPARATOR
 
 /**
  * Validates and formats a base URL by ensuring it ends with a slash (`/`).

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/EventBatchFileManagerTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/EventBatchFileManagerTest.kt
@@ -1,6 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.models.DEFAULT_SENT_AT_TIMESTAMP
+import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKey
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -11,14 +12,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File
 
-private const val TEST_WRITE_KEY = "asdf"
+private const val TEST_WRITE_KEY = "writeKey"
 
 class EventBatchFileManagerTest {
 
     private val writeKey = TEST_WRITE_KEY
-    private val fileName = "$writeKey-0"
+    private val fileName = "0"
     private val epochTimestamp = DEFAULT_SENT_AT_TIMESTAMP
-    private val directory = File(FILE_DIRECTORY)
+    private val directory = File(FILE_DIRECTORY.appendWriteKey(writeKey))
     private val keyValueStorage = PropertiesFile(directory.parentFile, writeKey)
 
     private lateinit var eventBatchFileManager: EventBatchFileManager
@@ -86,11 +87,11 @@ class EventBatchFileManagerTest {
         eventBatchFileManager.storeEvent(createLargeString(800))
         eventBatchFileManager.storeEvent(provideMessagePayload())
 
-        assertFalse(File(directory, "$writeKey-0.tmp").exists())
-        assertTrue(File(directory, "$writeKey-0").exists())
+        assertFalse(File(directory, "0.tmp").exists())
+        assertTrue(File(directory, "0").exists())
 
         val expectedContents = """{"batch":[${provideMessagePayload()}"""
-        val newFile = File(directory, "$writeKey-1.tmp")
+        val newFile = File(directory, "1.tmp")
         assertTrue(newFile.exists())
 
         val actualContents = newFile.readText()
@@ -206,8 +207,8 @@ class EventBatchFileManagerTest {
         file1.rollover()
         file2.rollover()
 
-        assertEquals(listOf("$FILE_DIRECTORY$writeKey1-0"), file1.read())
-        assertEquals(listOf("$FILE_DIRECTORY$writeKey2-0"), file2.read())
+        assertEquals(listOf("${FILE_DIRECTORY.appendWriteKey(writeKey)}/0"), file1.read())
+        assertEquals(listOf("${FILE_DIRECTORY.appendWriteKey(writeKey)}/0"), file2.read())
     }
 
     @Test

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
@@ -83,4 +83,9 @@ internal class MockMemoryStorage : Storage {
             override fun getVersionName() = "1.0.0"
         }
     }
+
+    @UseWithCaution
+    override fun deleteStorageAndPreferences() {
+        messageBatchMap.clear()
+    }
 }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
@@ -85,7 +85,7 @@ internal class MockMemoryStorage : Storage {
     }
 
     @UseWithCaution
-    override fun deleteStorageAndPreferences() {
+    override fun delete() {
         messageBatchMap.clear()
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- In this PR, we have added the mechanism to store events in writeKey-specific directories.
- We have also added a `delete` API to delete the storage and preference file. (This will be utilised in other PR.)
    - **NOTE: This API needs to be called carefully to avoid any crash.**

Advantages of the new approach:
- Events are now grouped by `writeKey`, making it easier to identify all batches associated with a specific key.
- This organisation allows us to delete all related batch files in a single command, improving manageability and cleanup efficiency.
- As the file name length is reduced, this will improve the performance of the SDK by a very, very small margin.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

### Change in the storage Interface

- Added the following methods in `KeyValueStorage.kt` and `Storage.kt`:
```
fun delete()
```

### AndroidStorage

- Now, events will be stored under this directory: `data/user/0/<namespace>/app_rudder-android-store_<writeKey>/<FileNo>`. Refer to the screenshot (a dummy writeKey is being used to show this example)
<img width="403" alt="image" src="https://github.com/user-attachments/assets/e7822352-8390-4b5b-9cb3-5c7a2597af65" />

- All the events will now be grouped by the writeKey.
- **Introduced a new method `delete`: This will be responsible for deleting the `SharedPreferences` file and `Event directory` completely. It is strongly recommended that this be called as part of the `shutdown` process to avoid any crash.**

### SharedPrefsStore (Android)

- Added a `delete` method to delete the SharedPreference file. 
- Two different mechanisms are being used to delete the file based on the Android version.

### BasicStorage.kt (Core)

- Now, events will be stored under this directory: `/tmp/rudderstack-analytics-kotlin_<writeKey>/events/<FileNo>`. Refer to the screenshot (a dummy writeKey is being used to show this example)
<img width="377" alt="image" src="https://github.com/user-attachments/assets/37a66255-c265-42e2-8bf2-c3cc5c7434d1" />

- All the events will now be grouped by the writeKey.
- **Introduced a new method `delete`: This will be responsible for deleting the `Preferences` file and `Event directory` completely. It is strongly recommended that this be called as part of the `shutdown` process to avoid any crash.**

### PropertiesFile.kt (Core)

- Added a `delete` method to delete the Preference file.

### EventBatchFileManager.kt (Common)

- Refactored the logic to remove the use of the `writeKey` from the event file name prefix, i.e., now the event file name will be like this: `0,1,2,3....`.

### CustomAnnotation

- Added a new annotation called `UseWithCaution`. This can be used for the delicate API to warn the developer of the SDK to use the API carefully. Currently, it's being used in the Storage class only.
- NOTE: I've purposefully skipped adding this in the [build.gradle file](https://github.com/rudderlabs/rudder-sdk-kotlin/blob/05de5a197a839b028d993931c9c6e3138f28e252/android/build.gradle.kts#L25-L27), so that the developer would be forced to address the warning.

### CheckBuildVersionUseCase class

- I've made it a singleton class, so that it could be called without instantiating this class.
- Added a new method `isAndroidVersionNAndAbove()`.
- Refactored the existing usage of this class: `DeeplinkPlugin.kt` and `DeeplinkPluginTest.kt`.

### Unit Test

- Update the `MockMemoryStorage.kt`.
- Added test for `SharedPrefsStoreTest.kt`.
- Fixed the failing test.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

1. Add this in the Analytics class `storage.delete()` and call it at some point in time. It'll delete the storage and shared preference file completely.
    a. Check the device explorer to see if the files were deleted or not.
2. After calling the above API, call shutdown and then again call the `initialise`, a new directory will be created and the event will flow normally.
    a. Check the device explorer to see on re-initialisation, a new directory is being created or not.
3. Test the changes on at least two different Android version i.e., any latest Android API and API 21 to 23.
4. Test the changes in the Core module.

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

- Now the events will be stored in a new directory which has the writeKey as its suffix.

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->

- We will utilise the `delete` API to clear the storage. This will be called when the wrong writeKey is used. 
- Note: I'm currently planning to use this in `shutdown`, somehow, but this might change. I'll evaluate this while implementing it.