### PR TITLE
feat: handle 401 error response when sending batch to dataplane

### DIFF
--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPlugin.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPlugin.kt
@@ -21,9 +21,7 @@ internal const val REFERRING_APPLICATION_KEY = "referring_application"
 internal const val URL_KEY = "url"
 internal const val DEEPLINK_OPENED_KEY = "Deep Link Opened"
 
-internal class DeeplinkPlugin(
-    private val checkBuildVersionUseCase: CheckBuildVersionUseCase = CheckBuildVersionUseCase()
-) : Plugin, ActivityLifecycleObserver {
+internal class DeeplinkPlugin : Plugin, ActivityLifecycleObserver {
 
     override val pluginType: Plugin.PluginType = Plugin.PluginType.Utility
 
@@ -66,7 +64,7 @@ internal class DeeplinkPlugin(
     }
 
     private fun Activity.getReferrerString(): String? {
-        return if (checkBuildVersionUseCase.isAndroidVersionLollipopAndAbove()) {
+        return if (CheckBuildVersionUseCase.isAndroidVersionLollipopAndAbove()) {
             this.referrer?.toString()
         } else {
             getReferrerCompatible(this)?.toString()

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -10,7 +10,7 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.MAX_PAYLOAD_SIZE
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
-import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKeyToDirectoryName
+import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKey
 import com.rudderstack.sdk.kotlin.core.internals.utils.toAndroidPrefsKey
 import java.io.File
 
@@ -24,7 +24,7 @@ internal class AndroidStorage(
 ) : Storage {
 
     private val storageDirectory: File =
-        context.getDir(DIRECTORY_NAME.appendWriteKeyToDirectoryName(writeKey), Context.MODE_PRIVATE)
+        context.getDir(DIRECTORY_NAME.appendWriteKey(writeKey), Context.MODE_PRIVATE)
     private val eventBatchFile = EventBatchFileManager(storageDirectory, writeKey, rudderPrefsRepo)
 
     override suspend fun write(key: StorageKeys, value: Boolean) {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -3,6 +3,7 @@ package com.rudderstack.sdk.kotlin.android.storage
 import android.content.Context
 import com.rudderstack.sdk.kotlin.BuildConfig
 import com.rudderstack.sdk.kotlin.android.storage.exceptions.QueuedPayloadTooLargeException
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.storage.EventBatchFileManager
 import com.rudderstack.sdk.kotlin.core.internals.storage.KeyValueStorage
 import com.rudderstack.sdk.kotlin.core.internals.storage.LibraryVersion
@@ -109,8 +110,9 @@ internal class AndroidStorage(
 
     @UseWithCaution
     override fun delete() {
-        storageDirectory.deleteRecursively()
         rudderPrefsRepo.delete()
+        storageDirectory.deleteRecursively()
+        LoggerAnalytics.info("Storage cleared.")
     }
 }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -10,6 +10,7 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.MAX_PAYLOAD_SIZE
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.toAndroidPrefsKey
+import com.rudderstack.sdk.kotlin.core.internals.utils.underscoreSeparator
 import java.io.File
 
 private const val RUDDER_PREFS = "rl_prefs"
@@ -21,7 +22,8 @@ internal class AndroidStorage(
     private val rudderPrefsRepo: KeyValueStorage = SharedPrefsStore(context, RUDDER_PREFS.toAndroidPrefsKey(writeKey))
 ) : Storage {
 
-    private val storageDirectory: File = context.getDir(DIRECTORY_NAME, Context.MODE_PRIVATE)
+    private val storageDirectory: File =
+        context.getDir(DIRECTORY_NAME.appendWriteKeyToDirectoryName(writeKey), Context.MODE_PRIVATE)
     private val eventBatchFile = EventBatchFileManager(storageDirectory, writeKey, rudderPrefsRepo)
 
     override suspend fun write(key: StorageKeys, value: Boolean) {
@@ -117,4 +119,8 @@ internal fun provideAndroidStorage(writeKey: String, application: Context): Stor
         context = application,
         writeKey = writeKey,
     )
+}
+
+private fun String.appendWriteKeyToDirectoryName(writeKey: String): String {
+    return "$this${String.underscoreSeparator()}$writeKey"
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -9,6 +9,7 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.LibraryVersion
 import com.rudderstack.sdk.kotlin.core.internals.storage.MAX_PAYLOAD_SIZE
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.toAndroidPrefsKey
 import com.rudderstack.sdk.kotlin.core.internals.utils.underscoreSeparator
 import java.io.File
@@ -104,6 +105,12 @@ internal class AndroidStorage(
 
             override fun getBuildVersion(): String = android.os.Build.VERSION.SDK_INT.toString()
         }
+    }
+
+    @UseWithCaution
+    override fun deleteStorageAndPreferences() {
+        storageDirectory.deleteRecursively()
+        rudderPrefsRepo.deletePrefs()
     }
 }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -108,7 +108,7 @@ internal class AndroidStorage(
     }
 
     @UseWithCaution
-    override fun deleteStorageAndPreferences() {
+    override fun delete() {
         storageDirectory.deleteRecursively()
         rudderPrefsRepo.delete()
     }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -110,9 +110,14 @@ internal class AndroidStorage(
 
     @UseWithCaution
     override fun delete() {
-        rudderPrefsRepo.delete()
-        storageDirectory.deleteRecursively()
-        LoggerAnalytics.info("Storage cleared.")
+        runCatching {
+            rudderPrefsRepo.delete()
+            storageDirectory.deleteRecursively().let { isDeleted ->
+                LoggerAnalytics.info("Storage directory deleted: $isDeleted")
+            }
+        }.onFailure {
+            LoggerAnalytics.error("Error while clearing storage: ${it.stackTraceToString()}")
+        }
     }
 }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -110,7 +110,7 @@ internal class AndroidStorage(
     @UseWithCaution
     override fun deleteStorageAndPreferences() {
         storageDirectory.deleteRecursively()
-        rudderPrefsRepo.deletePrefs()
+        rudderPrefsRepo.delete()
     }
 }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -110,13 +110,9 @@ internal class AndroidStorage(
 
     @UseWithCaution
     override fun delete() {
-        runCatching {
-            rudderPrefsRepo.delete()
-            storageDirectory.deleteRecursively().let { isDeleted ->
-                LoggerAnalytics.info("Storage directory deleted: $isDeleted")
-            }
-        }.onFailure {
-            LoggerAnalytics.error("Error while clearing storage: ${it.stackTraceToString()}")
+        rudderPrefsRepo.delete()
+        storageDirectory.deleteRecursively().let { isDeleted ->
+            LoggerAnalytics.info("Storage directory deleted: $isDeleted")
         }
     }
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -10,8 +10,8 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.MAX_PAYLOAD_SIZE
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
+import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKeyToDirectoryName
 import com.rudderstack.sdk.kotlin.core.internals.utils.toAndroidPrefsKey
-import com.rudderstack.sdk.kotlin.core.internals.utils.underscoreSeparator
 import java.io.File
 
 private const val RUDDER_PREFS = "rl_prefs"
@@ -126,8 +126,4 @@ internal fun provideAndroidStorage(writeKey: String, application: Context): Stor
         context = application,
         writeKey = writeKey,
     )
-}
-
-private fun String.appendWriteKeyToDirectoryName(writeKey: String): String {
-    return "$this${String.underscoreSeparator()}$writeKey"
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/AndroidStorage.kt
@@ -72,6 +72,7 @@ internal class AndroidStorage(
 
     override fun close() {
         eventBatchFile.closeAndReset()
+        LoggerAnalytics.info("Storage closed")
     }
 
     override fun readInt(key: StorageKeys, defaultVal: Int): Int {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/CheckBuildVersionUseCase.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/CheckBuildVersionUseCase.kt
@@ -4,11 +4,15 @@ import android.annotation.SuppressLint
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 
-internal class CheckBuildVersionUseCase {
+internal object CheckBuildVersionUseCase {
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.LOLLIPOP_MR1)
     @SuppressLint("ObsoleteSdkInt")
     internal fun isAndroidVersionLollipopAndAbove(): Boolean {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
+    }
+
+    internal fun isAndroidVersionNAndAbove(): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
     }
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -7,8 +7,8 @@ import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.storage.KeyValueStorage
 
 internal class SharedPrefsStore(
-    context: Context,
-    prefsName: String,
+    private val context: Context,
+    private val prefsName: String,
 ) : KeyValueStorage {
 
     private val preferences: SharedPreferences = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
@@ -43,6 +43,16 @@ internal class SharedPrefsStore(
 
     override fun save(key: String, value: Long) {
         put(key, value)
+    }
+
+    override fun deletePrefs() {
+        if (CheckBuildVersionUseCase.isAndroidVersionNAndAbove()) {
+            context.deleteSharedPreferences(prefsName)
+        } else {
+            // TODO: Test this
+            context.deleteFile(context.applicationInfo.dataDir + "/shared_prefs/$prefsName.xml")
+        }
+        LoggerAnalytics.info("SharedPrefsStore: Preference cleared.")
     }
 
     override fun clear(key: String) {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -65,7 +65,7 @@ internal class SharedPrefsStore(
                         }
                 }
         }
-        LoggerAnalytics.info("SharedPrefsStore: Preference cleared.")
+        LoggerAnalytics.info("Preference cleared.")
     }
 
     override fun clear(key: String) {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -54,15 +54,13 @@ internal class SharedPrefsStore(
         } else {
             File(context.getSharedPreferencesFilePath(prefsName))
                 .takeIf { file -> file.exists() }
-                ?.let { file ->
-                    file.delete()
-                        .let { isDeleted ->
-                            LoggerAnalytics.debug(
-                                "SharedPrefsStore: Path: " +
-                                    "${context.getSharedPreferencesFilePath(prefsName)} " +
-                                    "delete status: $isDeleted"
-                            )
-                        }
+                ?.delete()
+                ?.let { isDeleted ->
+                    LoggerAnalytics.debug(
+                        "SharedPrefsStore: Attempted to delete shared preferences at path: " +
+                            "${context.getSharedPreferencesFilePath(prefsName)}. " +
+                            "Deletion successful: $isDeleted"
+                    )
                 }
         }
         LoggerAnalytics.info("Preference cleared.")

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -48,7 +48,7 @@ internal class SharedPrefsStore(
     }
 
     @UseWithCaution
-    override fun deletePrefs() {
+    override fun delete() {
         if (CheckBuildVersionUseCase.isAndroidVersionNAndAbove()) {
             context.deleteSharedPreferences(prefsName)
         } else {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -49,21 +49,14 @@ internal class SharedPrefsStore(
 
     @UseWithCaution
     override fun delete() {
-        if (CheckBuildVersionUseCase.isAndroidVersionNAndAbove()) {
+        val isDeleted = if (CheckBuildVersionUseCase.isAndroidVersionNAndAbove()) {
             context.deleteSharedPreferences(prefsName)
         } else {
             File(context.getSharedPreferencesFilePath(prefsName))
                 .takeIf { file -> file.exists() }
-                ?.delete()
-                ?.let { isDeleted ->
-                    LoggerAnalytics.debug(
-                        "SharedPrefsStore: Attempted to delete shared preferences at path: " +
-                            "${context.getSharedPreferencesFilePath(prefsName)}. " +
-                            "Deletion successful: $isDeleted"
-                    )
-                }
+                ?.delete() ?: false
         }
-        LoggerAnalytics.info("Preference cleared.")
+        LoggerAnalytics.debug("Attempt to delete shared preferences successful: $isDeleted")
     }
 
     override fun clear(key: String) {

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
@@ -134,7 +134,7 @@ class SharedPrefsStoreTest {
     fun `given android version is N and above, when deletePrefs is called, then verify that shared preference is deleted`() {
         every { CheckBuildVersionUseCase.isAndroidVersionNAndAbove() } returns true
 
-        sharedPrefsStore.deletePrefs()
+        sharedPrefsStore.delete()
 
         verify { mockContext.deleteSharedPreferences(prefsName) }
     }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
@@ -2,6 +2,7 @@ package com.rudderstack.sdk.kotlin.android.storage
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -128,6 +129,7 @@ class SharedPrefsStoreTest {
         }
     }
 
+    @OptIn(UseWithCaution::class)
     @Test
     fun `given android version is N and above, when deletePrefs is called, then verify that shared preference is deleted`() {
         every { CheckBuildVersionUseCase.isAndroidVersionNAndAbove() } returns true
@@ -135,14 +137,5 @@ class SharedPrefsStoreTest {
         sharedPrefsStore.deletePrefs()
 
         verify { mockContext.deleteSharedPreferences(prefsName) }
-    }
-
-    @Test
-    fun `given android version is below N, when deletePrefs is called, then verify that shared preferences is deleted`() {
-        every { CheckBuildVersionUseCase.isAndroidVersionNAndAbove() } returns false
-
-        sharedPrefsStore.deletePrefs()
-
-        verify { mockContext.deleteFile("null/shared_prefs/${prefsName}.xml") }
     }
 }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
@@ -86,7 +86,7 @@ internal class MockMemoryStorage : Storage {
     }
 
     @UseWithCaution
-    override fun deleteStorageAndPreferences() {
+    override fun delete() {
         messageBatchMap.clear()
     }
 }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/MockMemoryStorage.kt
@@ -3,6 +3,7 @@ package com.rudderstack.sdk.kotlin.android.utils
 import com.rudderstack.sdk.kotlin.core.internals.storage.LibraryVersion
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 
 internal class MockMemoryStorage : Storage {
 
@@ -82,5 +83,10 @@ internal class MockMemoryStorage : Storage {
 
             override fun getVersionName() = "1.0.0"
         }
+    }
+
+    @UseWithCaution
+    override fun deleteStorageAndPreferences() {
+        messageBatchMap.clear()
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -321,10 +321,10 @@ open class Analytics protected constructor(
     @OptIn(UseWithCaution::class)
     private fun shutdownHook() {
         analyticsJob.invokeOnCompletion {
-            this@Analytics.storage
-                .takeIf { isInvalidWriteKey }
-                ?.delete()
-            this@Analytics.storage.close()
+            if (isInvalidWriteKey) {
+                storage.delete()
+            }
+            storage.close()
             LoggerAnalytics.info("Analytics shutdown completed.")
         }
         analyticsScope.launch {

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -318,19 +318,25 @@ open class Analytics protected constructor(
         }
     }
 
-    @OptIn(UseWithCaution::class)
     private fun shutdownHook() {
         analyticsJob.invokeOnCompletion {
-            storage.close()
-            if (isInvalidWriteKey) {
-                storage.delete()
-            }
+            closeAndCleanupStorage()
             LoggerAnalytics.info("Analytics shutdown completed.")
         }
         analyticsScope.launch {
             this@Analytics.pluginChain.removeAll()
         }.invokeOnCompletion {
             analyticsScope.cancel()
+        }
+    }
+
+    @OptIn(UseWithCaution::class)
+    private fun closeAndCleanupStorage() {
+        storage.run {
+            close()
+            if (isInvalidWriteKey) {
+                delete()
+            }
         }
     }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -321,10 +321,10 @@ open class Analytics protected constructor(
     @OptIn(UseWithCaution::class)
     private fun shutdownHook() {
         analyticsJob.invokeOnCompletion {
+            storage.close()
             if (isInvalidWriteKey) {
                 storage.delete()
             }
-            storage.close()
             LoggerAnalytics.info("Analytics shutdown completed.")
         }
         analyticsScope.launch {

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -29,6 +29,7 @@ import com.rudderstack.sdk.kotlin.core.internals.plugins.PluginChain
 import com.rudderstack.sdk.kotlin.core.internals.statemanagement.State
 import com.rudderstack.sdk.kotlin.core.internals.storage.provideBasicStorage
 import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.addNameAndCategoryToProperties
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import com.rudderstack.sdk.kotlin.core.internals.utils.isAnalyticsActive
@@ -317,8 +318,12 @@ open class Analytics protected constructor(
         }
     }
 
+    @OptIn(UseWithCaution::class)
     private fun shutdownHook() {
         analyticsJob.invokeOnCompletion {
+            this@Analytics.storage
+                .takeIf { isInvalidWriteKey }
+                ?.delete()
             this@Analytics.storage.close()
             LoggerAnalytics.info("Analytics shutdown completed.")
         }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsConfiguration.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsConfiguration.kt
@@ -63,6 +63,15 @@ interface AnalyticsConfiguration {
      * Source config manager.
      */
     var sourceConfigManager: SourceConfigManager
+
+    /**
+     * Indicates whether the configured write key is invalid.
+     *
+     * This property helps determine the validity of the write key used by the analytics module.
+     * When set to true, it means an invalid write key has been detected, which may halt or restrict analytics operations.
+     * Defaults to false.
+     */
+    var isInvalidWriteKey: Boolean
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -85,6 +94,8 @@ private class AnalyticsConfigurationImpl(
     override val connectivityState: State<Boolean> = State(initialState = ConnectivityState.INITIAL_STATE)
 
     override lateinit var sourceConfigManager: SourceConfigManager
+
+    override var isInvalidWriteKey: Boolean = false
 }
 
 /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventUpload.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventUpload.kt
@@ -16,6 +16,7 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.createUnlimitedCapacityCh
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import com.rudderstack.sdk.kotlin.core.internals.utils.encodeToBase64
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
+import com.rudderstack.sdk.kotlin.core.internals.utils.handleInvalidWriteKey
 import com.rudderstack.sdk.kotlin.core.internals.utils.parseFilePaths
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -159,9 +160,9 @@ internal class EventUpload(
             }
 
             NetworkErrorStatus.ERROR_401 -> {
-                // TODO: Log the error
-                // TODO: Delete all the files related to this writeKey
-//                analytics.shutdown()
+                LoggerAnalytics.error("Invalid write key. Ensure the write key is valid.")
+                cancel()
+                analytics.handleInvalidWriteKey()
             }
 
             NetworkErrorStatus.ERROR_404 -> {

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventUpload.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventUpload.kt
@@ -10,6 +10,7 @@ import com.rudderstack.sdk.kotlin.core.internals.network.NetworkResult
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.JsonSentAtUpdater
 import com.rudderstack.sdk.kotlin.core.internals.utils.Result
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.createIfInactive
 import com.rudderstack.sdk.kotlin.core.internals.utils.createNewIfClosed
 import com.rudderstack.sdk.kotlin.core.internals.utils.createUnlimitedCapacityChannel
@@ -147,6 +148,7 @@ internal class EventUpload(
         }
     }
 
+    @OptIn(UseWithCaution::class)
     @VisibleForTesting
     internal fun handleFailure(status: NetworkErrorStatus, filePath: String) {
         // TODO: Implement the step to reset the backoff logic

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -133,7 +133,7 @@ internal class BasicStorage(writeKey: String) : Storage {
 
     @UseWithCaution
     override fun deleteStorageAndPreferences() {
-        propertiesFile.deletePrefs()
+        propertiesFile.delete()
         storageDirectory.deleteRecursively()
         LoggerAnalytics.info("Storage deleted successfully.")
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -135,7 +135,7 @@ internal class BasicStorage(writeKey: String) : Storage {
     override fun delete() {
         propertiesFile.delete()
         storageDirectory.deleteRecursively()
-        LoggerAnalytics.info("Storage deleted successfully.")
+        LoggerAnalytics.info("Storage cleared.")
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -132,7 +132,7 @@ internal class BasicStorage(writeKey: String) : Storage {
     }
 
     @UseWithCaution
-    override fun deleteStorageAndPreferences() {
+    override fun delete() {
         propertiesFile.delete()
         storageDirectory.deleteRecursively()
         LoggerAnalytics.info("Storage deleted successfully.")

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -133,13 +133,9 @@ internal class BasicStorage(writeKey: String) : Storage {
 
     @UseWithCaution
     override fun delete() {
-        runCatching {
-            propertiesFile.delete()
-            storageDirectory.deleteRecursively().let { isDeleted ->
-                LoggerAnalytics.info("Storage directory deleted: $isDeleted")
-            }
-        }.onFailure {
-            LoggerAnalytics.error("Error while clearing storage: ${it.stackTraceToString()}")
+        propertiesFile.delete()
+        storageDirectory.deleteRecursively().let { isDeleted ->
+            LoggerAnalytics.info("Storage directory deleted: $isDeleted")
         }
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -10,7 +10,7 @@ import java.io.File
 /**
  * The directory where the event files are stored.
  * */
-private const val FILE_DIRECTORY = "/tmp/rudderstack-analytics-kotlin"
+internal const val FILE_DIRECTORY = "/tmp/rudderstack-analytics-kotlin"
 private const val FILE_NAME = "events"
 
 /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -1,14 +1,14 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.storage.exception.PayloadTooLargeException
-import com.rudderstack.sdk.kotlin.core.internals.utils.toFileDirectory
+import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKey
 import source.version.VersionConstants
 import java.io.File
 
 /**
  * The directory where the event files are stored.
  * */
-const val FILE_DIRECTORY = "/tmp/rudderstack-analytics-kotlin/"
+private const val FILE_DIRECTORY = "/tmp/rudderstack-analytics-kotlin"
 private const val FILE_NAME = "events"
 
 /**
@@ -23,9 +23,9 @@ private const val FILE_NAME = "events"
 internal class BasicStorage(writeKey: String) : Storage {
 
     /**
-     * The directory where the storage files are kept, determined by the provided [writeKey].
+     * The directory where the storage files are kept, determined by the provided `writeKey`.
      */
-    private val storageDirectory = File(writeKey.toFileDirectory(FILE_DIRECTORY))
+    private val storageDirectory = File(FILE_DIRECTORY.appendWriteKey(writeKey))
 
     /**
      * The subdirectory within [storageDirectory] where event files are stored.

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -97,6 +97,7 @@ internal class BasicStorage(writeKey: String) : Storage {
 
     override fun close() {
         eventsFile.closeAndReset()
+        LoggerAnalytics.info("Storage closed")
     }
 
     override fun readInt(key: StorageKeys, defaultVal: Int): Int {

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -133,9 +133,14 @@ internal class BasicStorage(writeKey: String) : Storage {
 
     @UseWithCaution
     override fun delete() {
-        propertiesFile.delete()
-        storageDirectory.deleteRecursively()
-        LoggerAnalytics.info("Storage cleared.")
+        runCatching {
+            propertiesFile.delete()
+            storageDirectory.deleteRecursively().let { isDeleted ->
+                LoggerAnalytics.info("Storage directory deleted: $isDeleted")
+            }
+        }.onFailure {
+            LoggerAnalytics.error("Error while clearing storage: ${it.stackTraceToString()}")
+        }
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/BasicStorage.kt
@@ -1,6 +1,8 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.storage.exception.PayloadTooLargeException
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKey
 import source.version.VersionConstants
 import java.io.File
@@ -127,6 +129,13 @@ internal class BasicStorage(writeKey: String) : Storage {
 
             override fun getVersionName(): String = VersionConstants.VERSION_NAME
         }
+    }
+
+    @UseWithCaution
+    override fun deleteStorageAndPreferences() {
+        propertiesFile.deletePrefs()
+        storageDirectory.deleteRecursively()
+        LoggerAnalytics.info("Storage deleted successfully.")
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/EventBatchFileManager.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/EventBatchFileManager.kt
@@ -92,7 +92,7 @@ class EventBatchFileManager(
      */
     fun read(): List<String> {
         val files = directory.listFiles { _, name ->
-            name.contains(writeKey) && !name.endsWith(TMP_SUFFIX)
+            !name.endsWith(TMP_SUFFIX)
         } ?: emptyArray()
         return files.map { it.absolutePath }
     }
@@ -155,7 +155,7 @@ class EventBatchFileManager(
     private fun currentFile(): File {
         if (curFile == null) {
             val index = keyValueStorage.getInt(fileIndexKey, 0)
-            curFile = File(directory, "$writeKey-$index$TMP_SUFFIX")
+            curFile = File(directory, "$index$TMP_SUFFIX")
         }
         return curFile!!
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
@@ -1,6 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 
 /**
  * Interface defining a basic key-value storage mechanism.
@@ -107,11 +108,10 @@ interface KeyValueStorage {
     fun clear(key: String)
 
     /**
-     * Deletes all the preferences stored in the storage.
+     * Deletes all stored preferences from the storage mechanism.
      *
-     * This method clears all preferences stored in the shared preferences file. If the Android system version is
-     * Nougat or above, it removes the entire preferences file. For older versions, it manually deletes the
-     * underlying shared preferences file.
+     * This method deletes the shared preferences file entirely to ensure a clean state.
      */
+    @UseWithCaution
     fun deletePrefs()
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
@@ -108,10 +108,10 @@ interface KeyValueStorage {
     fun clear(key: String)
 
     /**
-     * Deletes all stored preferences from the storage mechanism.
-     *
      * This method deletes the shared preferences file entirely to ensure a clean state.
+     *
+     * **Note**: It is recommended to use this API during shutdown to ensure the file is not removed abruptly, which could lead to unexpected errors.
      */
     @UseWithCaution
-    fun deletePrefs()
+    fun delete()
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/KeyValueStorage.kt
@@ -105,4 +105,13 @@ interface KeyValueStorage {
      * @param key The key used to identify the storage location to be cleared.
      */
     fun clear(key: String)
+
+    /**
+     * Deletes all the preferences stored in the storage.
+     *
+     * This method clears all preferences stored in the shared preferences file. If the Android system version is
+     * Nougat or above, it removes the entire preferences file. For older versions, it manually deletes the
+     * underlying shared preferences file.
+     */
+    fun deletePrefs()
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
@@ -110,7 +110,7 @@ internal class PropertiesFile(
     }
 
     @UseWithCaution
-    override fun deletePrefs() {
+    override fun delete() {
         propsFile.deleteRecursively()
         LoggerAnalytics.info("Preferences deleted successfully.")
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
@@ -111,7 +111,8 @@ internal class PropertiesFile(
 
     @UseWithCaution
     override fun delete() {
-        propsFile.deleteRecursively()
-        LoggerAnalytics.info("Preference cleared.")
+        propsFile.deleteRecursively().let { isDeleted ->
+            LoggerAnalytics.info("Attempt to delete properties file successful: $isDeleted")
+        }
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
@@ -1,6 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.toPropertiesFileName
 import java.io.File
 import java.io.FileInputStream
@@ -106,5 +107,11 @@ internal class PropertiesFile(
         properties.remove(key)
         save()
         return true
+    }
+
+    @UseWithCaution
+    override fun deletePrefs() {
+        propsFile.deleteRecursively()
+        LoggerAnalytics.info("Preferences deleted successfully.")
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/PropertiesFile.kt
@@ -112,6 +112,6 @@ internal class PropertiesFile(
     @UseWithCaution
     override fun delete() {
         propsFile.deleteRecursively()
-        LoggerAnalytics.info("Preferences deleted successfully.")
+        LoggerAnalytics.info("Preference cleared.")
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
@@ -136,18 +136,16 @@ interface Storage {
     fun getLibraryVersion(): LibraryVersion
 
     /**
-     * Deletes the directory currently being used by the storage implementation, along with the
-     * shared preferences file.
+     * Deletes the storage being used by the implementation, along with any associated configuration.
      *
-     * This operation permanently removes the current directory and its contents, as well as the
-     * shared preferences file.
+     * This operation permanently removes all stored data.
      *
-     * Use this method with caution, as any files or data within these locations will be irretrievably lost.
+     * Use this method with caution, as any data within the storage will be irretrievably lost.
      *
-     * **Note**: It is recommended to call the shutdown API after invoking this method to ensure the SDK is in a consistent state.
+     * **Note**: It is recommended to use this API during shutdown to ensure storage is not removed abruptly, which could lead to unexpected errors.
      */
     @UseWithCaution
-    fun deleteStorageAndPreferences()
+    fun delete()
 }
 
 /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/Storage.kt
@@ -1,6 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 
 /**
@@ -133,6 +134,20 @@ interface Storage {
      * @return An instance of [LibraryVersion] containing version details.
      */
     fun getLibraryVersion(): LibraryVersion
+
+    /**
+     * Deletes the directory currently being used by the storage implementation, along with the
+     * shared preferences file.
+     *
+     * This operation permanently removes the current directory and its contents, as well as the
+     * shared preferences file.
+     *
+     * Use this method with caution, as any files or data within these locations will be irretrievably lost.
+     *
+     * **Note**: It is recommended to call the shutdown API after invoking this method to ensure the SDK is in a consistent state.
+     */
+    @UseWithCaution
+    fun deleteStorageAndPreferences()
 }
 
 /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/AnalyticsUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/AnalyticsUtils.kt
@@ -31,8 +31,11 @@ fun Analytics.isSourceEnabled(): Boolean {
  * Marks the current write key as invalid and shuts down the analytics instance.
  * This method is typically invoked when the system determines that the write key cannot be used anymore.
  *
- * It deletes the stored events and preferences associated with the `writeKey`, and shuts down the SDK.
+ * **NOTE: It deletes the stored events and preferences associated with the `writeKey`, and shuts down the SDK.**
+ *
+ * Treat this as a terminal operation, as once the SDK is shutdown no further operation will be allowed.
  */
+@UseWithCaution
 internal fun Analytics.handleInvalidWriteKey() {
     isInvalidWriteKey = true
     shutdown()

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/AnalyticsUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/AnalyticsUtils.kt
@@ -26,3 +26,14 @@ fun Analytics.isSourceEnabled(): Boolean {
     }
     return true
 }
+
+/**
+ * Marks the current write key as invalid and shuts down the analytics instance.
+ * This method is typically invoked when the system determines that the write key cannot be used anymore.
+ *
+ * It deletes the stored events and preferences associated with the `writeKey`, and shuts down the SDK.
+ */
+internal fun Analytics.handleInvalidWriteKey() {
+    isInvalidWriteKey = true
+    shutdown()
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/CustomAnnotations.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/CustomAnnotations.kt
@@ -33,3 +33,32 @@ package com.rudderstack.sdk.kotlin.core.internals.utils
  * ```
  */
 annotation class InternalRudderApi
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This method should be used with caution. Read the API documentation for more details."
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.PROPERTY_GETTER
+)
+/**
+ * This annotation should be applied to methods, classes, or properties that require careful usage
+ * due to potential risks or limited guarantees. APIs annotated with this indicate that additional
+ * attention or understanding is required before use, as misuse may lead to unintended consequences.
+ *
+ * Example usage:
+ * ```
+ * import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
+ *
+ * @UseWithCaution
+ * fun riskyFunction() {
+ *     // Implementation of a cautious function
+ *     ...
+ * }
+ * ```
+ */
+annotation class UseWithCaution

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
@@ -125,6 +125,6 @@ fun generateUUID(): String {
  * @return The formatted directory name.
  */
 @InternalRudderApi
-fun String.appendWriteKeyToDirectoryName(writeKey: String): String {
+fun String.appendWriteKey(writeKey: String): String {
     return "$this${String.underscoreSeparator()}$writeKey"
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
@@ -114,3 +114,17 @@ internal val String.validatedBaseUrl
 fun generateUUID(): String {
     return UUID.randomUUID().toString()
 }
+
+/**
+ * Appends the provided write key to the directory name using an underscore separator (`_`).
+ *
+ * This extension function formats the directory name by appending the given
+ * write key using an underscore separator.
+ *
+ * @param writeKey The write key to be appended to the directory name.
+ * @return The formatted directory name.
+ */
+@InternalRudderApi
+fun String.appendWriteKeyToDirectoryName(writeKey: String): String {
+    return "$this${String.underscoreSeparator()}$writeKey"
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/StringUtils.kt
@@ -5,6 +5,7 @@ import java.util.Locale
 import java.util.UUID
 
 private const val EMPTY_STRING = ""
+private const val UNDERSCORE_SEPARATOR = "_"
 
 /**
  * Encodes the string to a Base64 encoded string.
@@ -85,6 +86,16 @@ internal fun String?.parseFilePaths(): List<String> {
  */
 @InternalRudderApi
 fun String.Companion.empty(): String = EMPTY_STRING
+
+/**
+ * Provides an underscore separator constant.
+ *
+ * This companion object extension function returns an underscore separator (`"_"`).
+ *
+ * @return An underscore separator as a string.
+ */
+@InternalRudderApi
+fun String.Companion.underscoreSeparator(): String = UNDERSCORE_SEPARATOR
 
 /**
  * Validates and formats a base URL by ensuring it ends with a slash (`/`).

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -508,6 +508,24 @@ class AnalyticsTest {
             verify(exactly = 1) { mockStorage.close() }
         }
 
+    @OptIn(ExperimentalCoroutinesApi::class, UseWithCaution::class)
+    @Test
+    fun `given writeKey is not proper, when shutdown is called, then storage is deleted and closed`() =
+        runTest(testDispatcher) {
+            every { mockAnalyticsConfiguration.isInvalidWriteKey } returns true
+
+            analytics.shutdown()
+            advanceUntilIdle()
+            // Call this to execute invokeOnCompletion block
+            mockAnalyticsJob.cancel()
+
+            assertTrue(analytics.isAnalyticsShutdown)
+            verify(exactly = 1) {
+                mockStorage.close()
+                mockStorage.delete()
+            }
+        }
+
     @Test
     fun `when custom plugin is dynamically added, then it should intercept the message and process event`() = runTest(testDispatcher) {
         val customPlugin = provideCustomPlugin()

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -17,6 +17,7 @@ import com.rudderstack.sdk.kotlin.core.internals.storage.LibraryVersion
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.DateTimeUtils
+import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
 import io.mockk.MockKAnnotations
@@ -29,8 +30,12 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -82,6 +87,7 @@ class AnalyticsTest {
     private val testScope = TestScope(testDispatcher)
 
     private val configuration = provideConfiguration()
+    private lateinit var mockAnalyticsJob: CompletableJob
     private lateinit var analytics: Analytics
 
     @BeforeEach
@@ -90,6 +96,9 @@ class AnalyticsTest {
 
         // Mock LoggerAnalytics
         mockkObject(LoggerAnalytics)
+
+        // This is needed to trigger analyticsJob.invokeOnCompletion()
+        mockAnalyticsJob = SupervisorJob()
 
         // Mock Analytics Configuration
         mockkStatic(::provideAnalyticsConfiguration)
@@ -107,6 +116,7 @@ class AnalyticsTest {
 
             every { storage } returns mockStorage
             every { connectivityState } returns mockConnectivityState
+            every { analyticsJob } returns mockAnalyticsJob
         }
 
         // Mocking persisted values and assigning default values
@@ -371,7 +381,7 @@ class AnalyticsTest {
             mockStorage.write(StorageKeys.EVENT, any<String>())
         }
     }
-    
+
     @ParameterizedTest
     @MethodSource("groupEventTestCases")
     fun `given SDK is ready to process any new events, when group events are made, then they are stored in storage`(
@@ -391,7 +401,7 @@ class AnalyticsTest {
             mockStorage.write(StorageKeys.EVENT, any<String>())
         }
     }
-    
+
     @ParameterizedTest
     @MethodSource("identifyEventTestCases")
     fun `given SDK is ready to process any new events, when identify events are made, then they are stored in storage`(
@@ -411,7 +421,7 @@ class AnalyticsTest {
             mockStorage.write(StorageKeys.EVENT, any<String>())
         }
     }
-    
+
     @ParameterizedTest
     @MethodSource("aliasEventTestCases")
     fun `given SDK is ready to process any new events, when alias events are made, then they are stored in storage`(
@@ -482,6 +492,22 @@ class AnalyticsTest {
             }
         }
 
+    @OptIn(ExperimentalCoroutinesApi::class, UseWithCaution::class)
+    @Test
+    fun `given writeKey is proper, when shutdown is called, then storage is closed but not deleted`() =
+        runTest(testDispatcher) {
+            every { mockAnalyticsConfiguration.isInvalidWriteKey } returns false
+
+            analytics.shutdown()
+            advanceUntilIdle()
+            // Call this to execute invokeOnCompletion block
+            mockAnalyticsJob.cancel()
+
+            assertTrue(analytics.isAnalyticsShutdown)
+            verify(exactly = 0) { mockStorage.delete() }
+            verify(exactly = 1) { mockStorage.close() }
+        }
+
     @Test
     fun `when custom plugin is dynamically added, then it should intercept the message and process event`() = runTest(testDispatcher) {
         val customPlugin = provideCustomPlugin()
@@ -532,7 +558,7 @@ class AnalyticsTest {
             Arguments.of(TRACK_EVENT_NAME, provideSampleJsonPayload(), RudderOption()),
             Arguments.of(TRACK_EVENT_NAME, emptyJsonObject, provideRudderOption()),
         )
-        
+
         @JvmStatic
         fun screenEventTestCases(): Stream<Arguments> = Stream.of(
             Arguments.of(SCREEN_EVENT_NAME, String.empty(), emptyJsonObject, RudderOption()),
@@ -541,14 +567,14 @@ class AnalyticsTest {
             Arguments.of(SCREEN_EVENT_NAME, String.empty(), provideSampleJsonPayload(), RudderOption()),
             Arguments.of(SCREEN_EVENT_NAME, String.empty(), emptyJsonObject, provideRudderOption()),
         )
-        
+
         @JvmStatic
         fun groupEventTestCases(): Stream<Arguments> = Stream.of(
             Arguments.of(GROUP_ID, emptyJsonObject, RudderOption()),
             Arguments.of(GROUP_ID, provideSampleJsonPayload(), RudderOption()),
             Arguments.of(GROUP_ID, emptyJsonObject, provideRudderOption()),
         )
-        
+
         @JvmStatic
         fun identifyEventTestCases(): Stream<Arguments> = Stream.of(
             Arguments.of(String.empty(), emptyJsonObject, RudderOption()),
@@ -556,7 +582,7 @@ class AnalyticsTest {
             Arguments.of(USER_ID, provideSampleJsonPayload(), RudderOption()),
             Arguments.of(USER_ID, emptyJsonObject, provideRudderOption()),
         )
-        
+
         @JvmStatic
         fun aliasEventTestCases(): Stream<Arguments> = Stream.of(
             Arguments.of(ALIAS_ID, String.empty(), RudderOption()),

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -30,6 +30,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
@@ -521,6 +522,10 @@ class AnalyticsTest {
 
             assertTrue(analytics.isAnalyticsShutdown)
             verify(exactly = 1) {
+                mockStorage.close()
+                mockStorage.delete()
+            }
+            verifyOrder {
                 mockStorage.close()
                 mockStorage.delete()
             }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventUploadTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventUploadTest.kt
@@ -13,6 +13,7 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.Result
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import com.rudderstack.sdk.kotlin.core.internals.utils.encodeToBase64
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
+import com.rudderstack.sdk.kotlin.core.internals.utils.handleInvalidWriteKey
 import com.rudderstack.sdk.kotlin.core.mockAnalytics
 import com.rudderstack.sdk.kotlin.core.readFileTrimmed
 import com.rudderstack.sdk.kotlin.core.setupLogger
@@ -291,6 +292,24 @@ class EventUploadTest {
         processMessage()
 
         verify(exactly = 1) { mockStorage.remove(singleFilePath) }
+    }
+
+    @Test
+    fun `given server returns 401, when flush is called, then the invalid write key process is initiated`() = runTest {
+        val unprocessedBatch = readFileTrimmed(unprocessedBatchWithTwoEvents)
+        every { mockStorage.readString(StorageKeys.EVENT, String.empty()) } returns singleFilePath
+        every { doesFileExist(singleFilePath) } returns true
+        every { readFileAsString(singleFilePath) } returns unprocessedBatch
+        every { mockHttpClient.sendData(any()) } returns Result.Failure(
+            error = NetworkErrorStatus.ERROR_401,
+        )
+
+        processMessage()
+
+        verify(exactly = 1) {
+            eventUpload.cancel()
+            mockAnalytics.handleInvalidWriteKey()
+        }
     }
 
     private fun prepareMultipleBatch() {

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/EventBatchFileManagerTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/storage/EventBatchFileManagerTest.kt
@@ -1,6 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.internals.storage
 
 import com.rudderstack.sdk.kotlin.core.internals.models.DEFAULT_SENT_AT_TIMESTAMP
+import com.rudderstack.sdk.kotlin.core.internals.utils.appendWriteKey
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -11,14 +12,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File
 
-private const val TEST_WRITE_KEY = "asdf"
+private const val TEST_WRITE_KEY = "writeKey"
 
 class EventBatchFileManagerTest {
 
     private val writeKey = TEST_WRITE_KEY
-    private val fileName = "$writeKey-0"
+    private val fileName = "0"
     private val epochTimestamp = DEFAULT_SENT_AT_TIMESTAMP
-    private val directory = File(FILE_DIRECTORY)
+    private val directory = File(FILE_DIRECTORY.appendWriteKey(writeKey))
     private val keyValueStorage = PropertiesFile(directory.parentFile, writeKey)
 
     private lateinit var eventBatchFileManager: EventBatchFileManager
@@ -86,11 +87,11 @@ class EventBatchFileManagerTest {
         eventBatchFileManager.storeEvent(createLargeString(800))
         eventBatchFileManager.storeEvent(provideMessagePayload())
 
-        assertFalse(File(directory, "$writeKey-0.tmp").exists())
-        assertTrue(File(directory, "$writeKey-0").exists())
+        assertFalse(File(directory, "0.tmp").exists())
+        assertTrue(File(directory, "0").exists())
 
         val expectedContents = """{"batch":[${provideMessagePayload()}"""
-        val newFile = File(directory, "$writeKey-1.tmp")
+        val newFile = File(directory, "1.tmp")
         assertTrue(newFile.exists())
 
         val actualContents = newFile.readText()
@@ -206,8 +207,8 @@ class EventBatchFileManagerTest {
         file1.rollover()
         file2.rollover()
 
-        assertEquals(listOf("$FILE_DIRECTORY$writeKey1-0"), file1.read())
-        assertEquals(listOf("$FILE_DIRECTORY$writeKey2-0"), file2.read())
+        assertEquals(listOf("${FILE_DIRECTORY.appendWriteKey(writeKey)}/0"), file1.read())
+        assertEquals(listOf("${FILE_DIRECTORY.appendWriteKey(writeKey)}/0"), file2.read())
     }
 
     @Test

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/AnalyticsUtilTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/AnalyticsUtilTest.kt
@@ -11,6 +11,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -61,6 +62,10 @@ class AnalyticsUtilTest {
         mockAnalytics.handleInvalidWriteKey()
 
         verify(exactly = 1) {
+            mockAnalyticsConfiguration.isInvalidWriteKey = true
+            mockAnalytics.shutdown()
+        }
+        verifyOrder {
             mockAnalyticsConfiguration.isInvalidWriteKey = true
             mockAnalytics.shutdown()
         }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/AnalyticsUtilTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/AnalyticsUtilTest.kt
@@ -1,0 +1,74 @@
+package com.rudderstack.sdk.kotlin.core.internals.utils
+
+import com.rudderstack.sdk.kotlin.core.Analytics
+import com.rudderstack.sdk.kotlin.core.AnalyticsConfiguration
+import com.rudderstack.sdk.kotlin.core.Configuration
+import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
+import com.rudderstack.sdk.kotlin.core.provideAnalyticsConfiguration
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AnalyticsUtilTest {
+
+    @MockK
+    private lateinit var mockStorage: Storage
+
+    @MockK
+    private lateinit var mockAnalyticsConfiguration: AnalyticsConfiguration
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    private val configuration = provideConfiguration()
+    private lateinit var mockAnalyticsJob: CompletableJob
+    private lateinit var mockAnalytics: Analytics
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        // This is needed to trigger analyticsJob.invokeOnCompletion()
+        mockAnalyticsJob = SupervisorJob()
+
+        // Mock Analytics Configuration
+        mockkStatic(::provideAnalyticsConfiguration)
+        every { provideAnalyticsConfiguration(any()) } returns mockAnalyticsConfiguration
+        mockAnalyticsConfiguration.apply {
+            every { analyticsScope } returns testScope
+            every { analyticsDispatcher } returns testDispatcher
+            every { storageDispatcher } returns testDispatcher
+            every { networkDispatcher } returns testDispatcher
+
+            every { storage } returns mockStorage
+            every { analyticsJob } returns mockAnalyticsJob
+        }
+
+        mockAnalytics = spyk(Analytics(configuration = configuration))
+    }
+
+    @Test
+    fun `when handleInvalidWriteKey is called, then shutdown analytics and set isInvalidWriteKey to true`() {
+        mockAnalytics.handleInvalidWriteKey()
+
+        verify(exactly = 1) {
+            mockAnalyticsConfiguration.isInvalidWriteKey = true
+            mockAnalytics.shutdown()
+        }
+    }
+}
+
+private fun provideConfiguration() =
+    Configuration(
+        writeKey = "<writeKey>",
+        dataPlaneUrl = "<data_plane_url>",
+    )

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
@@ -83,4 +83,9 @@ internal class MockMemoryStorage : Storage {
             override fun getVersionName() = "1.0.0"
         }
     }
+
+    @UseWithCaution
+    override fun deleteStorageAndPreferences() {
+        messageBatchMap.clear()
+    }
 }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/utils/MockMemoryStorage.kt
@@ -85,7 +85,7 @@ internal class MockMemoryStorage : Storage {
     }
 
     @UseWithCaution
-    override fun deleteStorageAndPreferences() {
+    override fun delete() {
         messageBatchMap.clear()
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- In this PR, we handle the 401 error status code. This error code is received when an invalid writeKey is used and an attempt is made to upload the events to the dataplane.
- We stop the upload queue and delete the storage (including event files and shared preferences) associated with that writeKey.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

### AnalyticsConfiguration

- Introduced a new variable named `isInvalidWriteKey`: This is set to `false` by default. When set to `true`, it signifies that the `writeKey` provided by the user is invalid. If it's true, then the shutdown API invocation will delete the `storage`.

### Analytics (core)

- Added an option to delete the storage on `Invalid Write Key` error. This will be triggered as a part of the shutdown process to ensure all the write operations are closed gracefully before deleting the files.

### EventUpload

- Handle Error 401: 
    - Cancel the upload queue after receiving this error: There's no point in making an attempt to send the event to the dataplane on an invalid writeKey.
    - Initiate the process to handle the wrong write key: 
        - **This involves the shutdown of the current analytics instance and deletion of the storage associated with the current writeKey. We will delete both the Event storage and the Preference.** 
        - The deletion happens at the end of the shutdown process to ensure we close the storage operation (if any) gracefully and to avoid any crash.
        - This deletion is needed to ensure we clean up the files associated with the wrong writeKey. (NOTE: We group events based on the writeKey.)

### AnalyticsUtil

- Added a new util method `Analytics.handleInvalidWriteKey()`: 
- This will be responsible for performing two tasks: 
    - Set the `isInvalidWriteKey` to true.
    - Initiate the shutdown process.
- A note to this API user: Use this API with caution, as this deletes the storage.

### Unit test

- Added unit test for the shutdown changes in the Analytics class.
- For EventUpload changes to test the Error 401 status code behaviour.
- Added a new AnlayticsUtils test class to test the new util method.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

1. Use an invalid writeKey, e.g., `qw@` and try to make some events.
2. The SDK will delete the storage and shut down the SDK. No further operation will be allowed until SDK is re-initialised. Any new attempt to make events will be rejected gracefully by the SDK by logging an error.
3. Test the above changes on both Android and core modules and see the storage directory getting deleted.

- You can also test if the correct `writeKey` is used and shutdown is triggered, then the storage is not removed. Only shutdown operation happens.

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

- Now the SDK deletes the storage file on an invalid writeKey and shutdown the SDK.

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

- Android
<img width="680" alt="image" src="https://github.com/user-attachments/assets/f3faad31-32f3-4bdd-9011-7d0115ba0f89" />

- Core
<img width="610" alt="image" src="https://github.com/user-attachments/assets/cb303027-8ac2-4e67-8870-abf0dd2af128" />

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PR's, references, discussions, etc. -->

- We will utilise the `Analytics.handleInvalidWriteKey()` on SourceConfig to handle the same invalid writeKey scenario. We will implement this in future PR's.