### PR TITLE
feat: add Java interoperability support for Kotlin APIs

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -38,9 +38,7 @@ android {
     compileSdk = RudderStackBuildConfig.Android.COMPILE_SDK
 
     buildFeatures {
-        buildFeatures {
-            buildConfig = true
-        }
+        buildConfig = true
     }
 
     defaultConfig {

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -120,6 +120,10 @@ class Analytics(
         integrationsManagementPlugin.reset()
     }
 
+    /**
+     * Flushes all pending events that are currently queued in the plugin chain.
+     * This method specifically targets the `RudderStackDataPlanePlugin` to initiate the flush operation.
+     */
     override fun flush() {
         if (!isAnalyticsActive()) return
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Configuration.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Configuration.kt
@@ -56,10 +56,10 @@ internal const val DEFAULT_SESSION_TIMEOUT_IN_MILLIS = 300_000L
  */
 data class Configuration @JvmOverloads constructor(
     val application: Application,
-    val trackApplicationLifecycleEvents: Boolean = true,
-    val trackDeepLinks: Boolean = true,
-    val trackActivities: Boolean = false,
-    val collectDeviceId: Boolean = true,
+    val trackApplicationLifecycleEvents: Boolean = DEFAULT_TRACK_APPLICATION_LIFECYCLE_EVENTS,
+    val trackDeepLinks: Boolean = DEFAULT_TRACK_DEEP_LINKS,
+    val trackActivities: Boolean = DEFAULT_TRACK_ACTIVITIES,
+    val collectDeviceId: Boolean = DEFAULT_COLLECT_DEVICE_ID,
     val sessionConfiguration: SessionConfiguration = SessionConfiguration(),
     override val writeKey: String,
     override val dataPlaneUrl: String,
@@ -72,7 +72,16 @@ data class Configuration @JvmOverloads constructor(
     dataPlaneUrl = dataPlaneUrl,
     logLevel = logLevel,
     flushPolicies = flushPolicies,
-)
+) {
+
+    companion object {
+
+        internal const val DEFAULT_TRACK_APPLICATION_LIFECYCLE_EVENTS = true
+        internal const val DEFAULT_TRACK_DEEP_LINKS = true
+        internal const val DEFAULT_TRACK_ACTIVITIES = false
+        internal const val DEFAULT_COLLECT_DEVICE_ID = true
+    }
+}
 
 /**
  * Data class for configuring session tracking in analytics.
@@ -88,6 +97,12 @@ data class Configuration @JvmOverloads constructor(
  *
  */
 data class SessionConfiguration(
-    val automaticSessionTracking: Boolean = true,
+    val automaticSessionTracking: Boolean = DEFAULT_AUTOMATIC_SESSION_TRACKING,
     val sessionTimeoutInMillis: Long = DEFAULT_SESSION_TIMEOUT_IN_MILLIS,
-)
+) {
+
+    companion object {
+
+        internal const val DEFAULT_AUTOMATIC_SESSION_TRACKING = true
+    }
+}

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
@@ -100,14 +100,14 @@ class SessionConfigurationBuilder {
     /**
      * Sets whether to enable automatic session tracking.
      */
-    fun withAutomaticSessionTracking(enabled: Boolean) = apply {
+    fun setAutomaticSessionTracking(enabled: Boolean) = apply {
         automaticSessionTracking = enabled
     }
 
     /**
      * Sets the session timeout duration in milliseconds.
      */
-    fun withSessionTimeoutInMillis(timeoutInMillis: Long) = apply {
+    fun setSessionTimeoutInMillis(timeoutInMillis: Long) = apply {
         sessionTimeoutInMillis = timeoutInMillis
     }
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
@@ -1,0 +1,155 @@
+package com.rudderstack.sdk.kotlin.android.javacompat
+
+import android.app.Application
+import com.rudderstack.sdk.kotlin.android.Configuration
+import com.rudderstack.sdk.kotlin.android.Configuration.Companion.DEFAULT_COLLECT_DEVICE_ID
+import com.rudderstack.sdk.kotlin.android.Configuration.Companion.DEFAULT_TRACK_ACTIVITIES
+import com.rudderstack.sdk.kotlin.android.Configuration.Companion.DEFAULT_TRACK_APPLICATION_LIFECYCLE_EVENTS
+import com.rudderstack.sdk.kotlin.android.Configuration.Companion.DEFAULT_TRACK_DEEP_LINKS
+import com.rudderstack.sdk.kotlin.android.DEFAULT_SESSION_TIMEOUT_IN_MILLIS
+import com.rudderstack.sdk.kotlin.android.SessionConfiguration
+import com.rudderstack.sdk.kotlin.android.SessionConfiguration.Companion.DEFAULT_AUTOMATIC_SESSION_TRACKING
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_CONTROL_PLANE_URL
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_FLUSH_POLICIES
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_GZIP_STATUS
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
+
+/**
+ * Builder class for creating Configuration instances with a fluent API.
+ *
+ * This builder provides a convenient way to create Configuration objects step by step,
+ * especially useful in Java code where Kotlin's default arguments aren't available.
+ */
+class ConfigurationBuilder(
+    private val application: Application,
+    private val writeKey: String,
+    private val dataPlaneUrl: String,
+) {
+
+    private var trackApplicationLifecycleEvents: Boolean = DEFAULT_TRACK_APPLICATION_LIFECYCLE_EVENTS
+    private var trackDeepLinks: Boolean = DEFAULT_TRACK_DEEP_LINKS
+    private var trackActivities: Boolean = DEFAULT_TRACK_ACTIVITIES
+    private var collectDeviceId: Boolean = DEFAULT_COLLECT_DEVICE_ID
+    private var sessionConfiguration: SessionConfiguration = SessionConfigurationBuilder().build()
+    private var controlPlaneUrl: String = DEFAULT_CONTROL_PLANE_URL
+    private var logLevel: Logger.LogLevel = Logger.DEFAULT_LOG_LEVEL
+    private var flushPolicies: List<FlushPolicy> = DEFAULT_FLUSH_POLICIES
+    private var gzipEnabled: Boolean = DEFAULT_GZIP_STATUS
+
+    /**
+     * Sets whether to track application lifecycle events.
+     */
+    fun withTrackApplicationLifecycleEvents(track: Boolean) = apply {
+        trackApplicationLifecycleEvents = track
+    }
+
+    /**
+     * Sets whether to track deep links.
+     */
+    fun withTrackDeepLinks(track: Boolean) = apply {
+        trackDeepLinks = track
+    }
+
+    /**
+     * Sets whether to track activities automatically.
+     */
+    fun withTrackActivities(track: Boolean) = apply {
+        trackActivities = track
+    }
+
+    /**
+     * Sets whether to collect device ID.
+     */
+    fun withCollectDeviceId(collect: Boolean) = apply {
+        collectDeviceId = collect
+    }
+
+    /**
+     * Sets the session configuration.
+     */
+    fun withSessionConfiguration(config: SessionConfiguration) = apply {
+        sessionConfiguration = config
+    }
+
+    /**
+     * Sets the control plane URL.
+     */
+    fun withControlPlaneUrl(url: String) = apply {
+        controlPlaneUrl = url
+    }
+
+    /**
+     * Sets the log level.
+     */
+    fun withLogLevel(level: Logger.LogLevel) = apply {
+        logLevel = level
+    }
+
+    /**
+     * Sets the flush policies.
+     */
+    fun withFlushPolicies(policies: List<FlushPolicy>) = apply {
+        flushPolicies = policies
+    }
+
+    /**
+     * Sets whether to enable GZIP compression.
+     */
+    fun withGzipEnabled(enabled: Boolean) = apply {
+        gzipEnabled = enabled
+    }
+
+    /**
+     * Builds the Configuration instance with the configured properties.
+     */
+    fun build(): Configuration {
+        return Configuration(
+            application = application,
+            trackApplicationLifecycleEvents = trackApplicationLifecycleEvents,
+            trackDeepLinks = trackDeepLinks,
+            trackActivities = trackActivities,
+            collectDeviceId = collectDeviceId,
+            sessionConfiguration = sessionConfiguration,
+            writeKey = writeKey,
+            dataPlaneUrl = dataPlaneUrl,
+            controlPlaneUrl = controlPlaneUrl,
+            logLevel = logLevel,
+            flushPolicies = flushPolicies,
+            gzipEnabled = gzipEnabled
+        )
+    }
+}
+
+/**
+ * Builder for SessionConfiguration to enable easy construction from Java code.
+ */
+class SessionConfigurationBuilder {
+
+    private var automaticSessionTracking: Boolean = DEFAULT_AUTOMATIC_SESSION_TRACKING
+    private var sessionTimeoutInMillis: Long = DEFAULT_SESSION_TIMEOUT_IN_MILLIS
+
+    /**
+     * Sets whether to enable automatic session tracking.
+     */
+    fun withAutomaticSessionTracking(enabled: Boolean) = apply {
+        automaticSessionTracking = enabled
+    }
+
+    /**
+     * Sets the session timeout duration in milliseconds.
+     */
+    fun withSessionTimeoutInMillis(timeoutInMillis: Long) = apply {
+        sessionTimeoutInMillis = timeoutInMillis
+    }
+
+    /**
+     * Builds the SessionConfiguration with the configured properties.
+     */
+    fun build(): SessionConfiguration {
+        return SessionConfiguration(
+            automaticSessionTracking = automaticSessionTracking,
+            sessionTimeoutInMillis = sessionTimeoutInMillis
+        )
+    }
+}

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
@@ -9,7 +9,6 @@ import com.rudderstack.sdk.kotlin.android.Configuration.Companion.DEFAULT_TRACK_
 import com.rudderstack.sdk.kotlin.android.DEFAULT_SESSION_TIMEOUT_IN_MILLIS
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration.Companion.DEFAULT_AUTOMATIC_SESSION_TRACKING
-import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
 import com.rudderstack.sdk.kotlin.core.javacompat.ConfigurationBuilder
 
@@ -76,13 +75,6 @@ class ConfigurationBuilder(
     }
 
     /**
-     * Sets the log level.
-     */
-    override fun setLogLevel(level: Logger.LogLevel) = apply {
-        super.setLogLevel(level)
-    }
-
-    /**
      * Sets the flush policies.
      */
     override fun setFlushPolicies(policies: List<FlushPolicy>) = apply {
@@ -112,7 +104,6 @@ class ConfigurationBuilder(
             writeKey = writeKey,
             dataPlaneUrl = dataPlaneUrl,
             controlPlaneUrl = coreConfig.controlPlaneUrl,
-            logLevel = coreConfig.logLevel,
             flushPolicies = coreConfig.flushPolicies,
             gzipEnabled = coreConfig.gzipEnabled,
         )

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
@@ -9,6 +9,8 @@ import com.rudderstack.sdk.kotlin.android.Configuration.Companion.DEFAULT_TRACK_
 import com.rudderstack.sdk.kotlin.android.DEFAULT_SESSION_TIMEOUT_IN_MILLIS
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration.Companion.DEFAULT_AUTOMATIC_SESSION_TRACKING
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
 import com.rudderstack.sdk.kotlin.core.javacompat.ConfigurationBuilder
 
 /**
@@ -64,6 +66,34 @@ class ConfigurationBuilder(
      */
     fun setSessionConfiguration(config: SessionConfiguration) = apply {
         sessionConfiguration = config
+    }
+
+    /**
+     * Sets the control plane URL.
+     */
+    override fun setControlPlaneUrl(url: String) = apply {
+        super.setControlPlaneUrl(url)
+    }
+
+    /**
+     * Sets the log level.
+     */
+    override fun setLogLevel(level: Logger.LogLevel) = apply {
+        super.setLogLevel(level)
+    }
+
+    /**
+     * Sets the flush policies.
+     */
+    override fun setFlushPolicies(policies: List<FlushPolicy>) = apply {
+        super.setFlushPolicies(policies)
+    }
+
+    /**
+     * Sets whether to enable GZIP compression.
+     */
+    override fun setGzipEnabled(enabled: Boolean) = apply {
+        super.setGzipEnabled(enabled)
     }
 
     /**

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
@@ -9,22 +9,20 @@ import com.rudderstack.sdk.kotlin.android.Configuration.Companion.DEFAULT_TRACK_
 import com.rudderstack.sdk.kotlin.android.DEFAULT_SESSION_TIMEOUT_IN_MILLIS
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration.Companion.DEFAULT_AUTOMATIC_SESSION_TRACKING
-import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_CONTROL_PLANE_URL
-import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_FLUSH_POLICIES
-import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_GZIP_STATUS
-import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
-import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
+import com.rudderstack.sdk.kotlin.core.javacompat.ConfigurationBuilder
 
 /**
- * Builder class for creating Configuration instances with a fluent API.
+ * Builder class for creating Configuration instances.
  *
- * This builder provides a convenient way to create Configuration objects step by step,
- * especially useful in Java code where Kotlin's default arguments aren't available.
+ * This builder class provides Java interop support for configuring the SDK's settings.
  */
 class ConfigurationBuilder(
     private val application: Application,
     private val writeKey: String,
     private val dataPlaneUrl: String,
+) : ConfigurationBuilder(
+    writeKey = writeKey,
+    dataPlaneUrl = dataPlaneUrl,
 ) {
 
     private var trackApplicationLifecycleEvents: Boolean = DEFAULT_TRACK_APPLICATION_LIFECYCLE_EVENTS
@@ -32,78 +30,48 @@ class ConfigurationBuilder(
     private var trackActivities: Boolean = DEFAULT_TRACK_ACTIVITIES
     private var collectDeviceId: Boolean = DEFAULT_COLLECT_DEVICE_ID
     private var sessionConfiguration: SessionConfiguration = SessionConfigurationBuilder().build()
-    private var controlPlaneUrl: String = DEFAULT_CONTROL_PLANE_URL
-    private var logLevel: Logger.LogLevel = Logger.DEFAULT_LOG_LEVEL
-    private var flushPolicies: List<FlushPolicy> = DEFAULT_FLUSH_POLICIES
-    private var gzipEnabled: Boolean = DEFAULT_GZIP_STATUS
 
     /**
      * Sets whether to track application lifecycle events.
      */
-    fun withTrackApplicationLifecycleEvents(track: Boolean) = apply {
+    fun setTrackApplicationLifecycleEvents(track: Boolean) = apply {
         trackApplicationLifecycleEvents = track
     }
 
     /**
      * Sets whether to track deep links.
      */
-    fun withTrackDeepLinks(track: Boolean) = apply {
+    fun setTrackDeepLinks(track: Boolean) = apply {
         trackDeepLinks = track
     }
 
     /**
      * Sets whether to track activities automatically.
      */
-    fun withTrackActivities(track: Boolean) = apply {
+    fun setTrackActivities(track: Boolean) = apply {
         trackActivities = track
     }
 
     /**
      * Sets whether to collect device ID.
      */
-    fun withCollectDeviceId(collect: Boolean) = apply {
+    fun setCollectDeviceId(collect: Boolean) = apply {
         collectDeviceId = collect
     }
 
     /**
      * Sets the session configuration.
      */
-    fun withSessionConfiguration(config: SessionConfiguration) = apply {
+    fun setSessionConfiguration(config: SessionConfiguration) = apply {
         sessionConfiguration = config
-    }
-
-    /**
-     * Sets the control plane URL.
-     */
-    fun withControlPlaneUrl(url: String) = apply {
-        controlPlaneUrl = url
-    }
-
-    /**
-     * Sets the log level.
-     */
-    fun withLogLevel(level: Logger.LogLevel) = apply {
-        logLevel = level
-    }
-
-    /**
-     * Sets the flush policies.
-     */
-    fun withFlushPolicies(policies: List<FlushPolicy>) = apply {
-        flushPolicies = policies
-    }
-
-    /**
-     * Sets whether to enable GZIP compression.
-     */
-    fun withGzipEnabled(enabled: Boolean) = apply {
-        gzipEnabled = enabled
     }
 
     /**
      * Builds the Configuration instance with the configured properties.
      */
-    fun build(): Configuration {
+    override fun build(): Configuration {
+        val coreConfig = super.build()
+
         return Configuration(
             application = application,
             trackApplicationLifecycleEvents = trackApplicationLifecycleEvents,
@@ -113,10 +81,10 @@ class ConfigurationBuilder(
             sessionConfiguration = sessionConfiguration,
             writeKey = writeKey,
             dataPlaneUrl = dataPlaneUrl,
-            controlPlaneUrl = controlPlaneUrl,
-            logLevel = logLevel,
-            flushPolicies = flushPolicies,
-            gzipEnabled = gzipEnabled
+            controlPlaneUrl = coreConfig.controlPlaneUrl,
+            logLevel = coreConfig.logLevel,
+            flushPolicies = coreConfig.flushPolicies,
+            gzipEnabled = coreConfig.gzipEnabled,
         )
     }
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilder.kt
@@ -90,7 +90,7 @@ class ConfigurationBuilder(
 }
 
 /**
- * Builder for SessionConfiguration to enable easy construction from Java code.
+ * Builder for SessionConfiguration instances.
  */
 class SessionConfigurationBuilder {
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
@@ -47,14 +47,14 @@ class JavaAnalytics private constructor(
     /**
      * Clears all user data and identifiers from the analytics instance
      */
-    fun reset() {
+    override fun reset() {
         analytics.reset()
     }
 
     /**
      * Forces immediate dispatch of any queued analytics events
      */
-    fun flush() {
+    override fun flush() {
         analytics.flush()
     }
 
@@ -68,14 +68,14 @@ class JavaAnalytics private constructor(
     /**
      * Registers a custom plugin to extend analytics functionality
      */
-    fun add(plugin: Plugin) {
+    override fun add(plugin: Plugin) {
         analytics.add(plugin)
     }
 
     /**
      * Removes a previously registered plugin from the analytics instance
      */
-    fun remove(plugin: Plugin) {
+    override fun remove(plugin: Plugin) {
         analytics.remove(plugin)
     }
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
@@ -18,41 +18,47 @@ class JavaAnalytics private constructor(
     constructor(configuration: Configuration) : this(provideAnalyticsInstance(configuration))
 
     /**
-     * Returns the current session identifier if a session is active, null otherwise
+     * Returns the current session ID.
+     *
+     * @return The current session ID, or null if no session is active.
      */
     val sessionId: Long?
         get() = analytics.sessionId
 
     /**
-     * Starts a new analytics session with an automatically generated session ID
+     * Starts a new session with the given optional session ID.
      */
     fun startSession() {
         analytics.startSession()
     }
 
     /**
-     * Starts a new analytics session with the specified custom session ID
+     * Starts a new session with the specified session ID
+     *
+     * @param sessionId The ID of the session to start.
      */
     fun startSession(sessionId: Long) {
         analytics.startSession(sessionId)
     }
 
     /**
-     * Ends the current analytics session if one is active
+     * Ends the current session.
      */
     fun endSession() {
         analytics.endSession()
     }
 
     /**
-     * Clears all user data and identifiers from the analytics instance
+     * Resets the user identity, clears the existing anonymous ID and
+     * generate a new one, also clears the user ID and traits.
      */
     override fun reset() {
         analytics.reset()
     }
 
     /**
-     * Forces immediate dispatch of any queued analytics events
+     * Flushes all pending events that are currently queued in the plugin chain.
+     * This method specifically targets the `RudderStackDataPlanePlugin` to initiate the flush operation.
      */
     override fun flush() {
         analytics.flush()
@@ -60,20 +66,27 @@ class JavaAnalytics private constructor(
 
     /**
      * Configures automatic screen event tracking for navigation destinations
+     *
+     * @param navController The NavController instance used for navigation.
+     * @param activity The Activity instance where the navigation occurs.
      */
     fun setNavigationDestinationsTracking(navController: NavController, activity: Activity) {
         analytics.setNavigationDestinationsTracking(navController, activity)
     }
 
     /**
-     * Registers a custom plugin to extend analytics functionality
+     * Adds a plugin to the plugin chain.
+     *
+     * @param plugin The plugin to be added to the plugin chain.
      */
     override fun add(plugin: Plugin) {
         analytics.add(plugin)
     }
 
     /**
-     * Removes a previously registered plugin from the analytics instance
+     * Removes a plugin from the plugin chain.
+     *
+     * @param plugin The plugin to be removed from the plugin chain.
      */
     override fun remove(plugin: Plugin) {
         analytics.remove(plugin)

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
@@ -1,0 +1,84 @@
+package com.rudderstack.sdk.kotlin.android.javacompat
+
+import android.app.Activity
+import androidx.navigation.NavController
+import com.rudderstack.sdk.kotlin.android.Analytics
+import com.rudderstack.sdk.kotlin.android.Configuration
+import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
+import com.rudderstack.sdk.kotlin.core.javacompat.JavaAnalytics
+import org.jetbrains.annotations.VisibleForTesting
+
+/**
+ * Java-compatible wrapper for the Android Analytics class.
+ */
+class JavaAnalytics private constructor(
+    private val analytics: Analytics
+) : JavaAnalytics(analytics = analytics) {
+
+    constructor(configuration: Configuration) : this(provideAnalyticsInstance(configuration))
+
+    /**
+     * Returns the current session identifier if a session is active, null otherwise
+     */
+    val sessionId: Long?
+        get() = analytics.sessionId
+
+    /**
+     * Starts a new analytics session with an automatically generated session ID
+     */
+    fun startSession() {
+        analytics.startSession()
+    }
+
+    /**
+     * Starts a new analytics session with the specified custom session ID
+     */
+    fun startSession(sessionId: Long) {
+        analytics.startSession(sessionId)
+    }
+
+    /**
+     * Ends the current analytics session if one is active
+     */
+    fun endSession() {
+        analytics.endSession()
+    }
+
+    /**
+     * Clears all user data and identifiers from the analytics instance
+     */
+    fun reset() {
+        analytics.reset()
+    }
+
+    /**
+     * Forces immediate dispatch of any queued analytics events
+     */
+    fun flush() {
+        analytics.flush()
+    }
+
+    /**
+     * Configures automatic screen event tracking for navigation destinations
+     */
+    fun setNavigationDestinationsTracking(navController: NavController, activity: Activity) {
+        analytics.setNavigationDestinationsTracking(navController, activity)
+    }
+
+    /**
+     * Registers a custom plugin to extend analytics functionality
+     */
+    fun add(plugin: Plugin) {
+        analytics.add(plugin)
+    }
+
+    /**
+     * Removes a previously registered plugin from the analytics instance
+     */
+    fun remove(plugin: Plugin) {
+        analytics.remove(plugin)
+    }
+}
+
+@VisibleForTesting
+internal fun provideAnalyticsInstance(configuration: Configuration) = Analytics(configuration = configuration)

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
@@ -1,6 +1,7 @@
 package com.rudderstack.sdk.kotlin.android.javacompat
 
 import android.app.Application
+import com.rudderstack.sdk.kotlin.android.Configuration
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_CONTROL_PLANE_URL
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_FLUSH_POLICIES
@@ -20,19 +21,19 @@ class ConfigurationBuilderTest {
     @MockK
     private lateinit var mockApplication: Application
 
-    private lateinit var builder: ConfigurationBuilder
+    private lateinit var configurationBuilder: ConfigurationBuilder
     private val testWriteKey = "test-write-key"
     private val testDataPlaneUrl = "https://test-data-plane.com"
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        builder = ConfigurationBuilder(mockApplication, testWriteKey, testDataPlaneUrl)
+        configurationBuilder = ConfigurationBuilder(mockApplication, testWriteKey, testDataPlaneUrl)
     }
 
     @Test
     fun `when Configuration object is created with only default values, then it should have default values`() {
-        val config = builder.build()
+        val config = configurationBuilder.build()
 
         assertEquals(mockApplication, config.application)
         assertEquals(testWriteKey, config.writeKey)
@@ -48,73 +49,44 @@ class ConfigurationBuilderTest {
     }
 
     @Test
-    fun `when withTrackApplicationLifecycleEvents is set to false, then trackApplicationLifecycleEvents should be false`() {
-        val config = builder.withTrackApplicationLifecycleEvents(false).build()
+    fun `when setTrackApplicationLifecycleEvents is set to false, then trackApplicationLifecycleEvents should be false`() {
+        val config = configurationBuilder.setTrackApplicationLifecycleEvents(false).build()
 
         assertFalse(config.trackApplicationLifecycleEvents)
     }
 
     @Test
-    fun `when withTrackDeepLinks is set to false, then trackDeepLinks should be false`() {
-        val config = builder.withTrackDeepLinks(false).build()
+    fun `when setTrackDeepLinks is set to false, then trackDeepLinks should be false`() {
+        val config = configurationBuilder.setTrackDeepLinks(false).build()
 
         assertFalse(config.trackDeepLinks)
     }
 
     @Test
-    fun `when withTrackActivities is set to true, then trackActivities should be true`() {
-        val config = builder.withTrackActivities(true).build()
+    fun `when setTrackActivities is set to true, then trackActivities should be true`() {
+        val config = configurationBuilder.setTrackActivities(true).build()
 
         assertTrue(config.trackActivities)
     }
 
     @Test
-    fun `when withCollectDeviceId is set to false, then collectDeviceId should be false`() {
-        val config = builder.withCollectDeviceId(false).build()
+    fun `when setCollectDeviceId is set to false, then collectDeviceId should be false`() {
+        val config = configurationBuilder.setCollectDeviceId(false).build()
 
         assertFalse(config.collectDeviceId)
     }
 
     @Test
-    fun `when withSessionConfiguration is set with custom values, then sessionConfiguration should be updated`() {
+    fun `when setSessionConfiguration is set with custom values, then sessionConfiguration should be updated`() {
         val customSessionConfig = SessionConfiguration(
             automaticSessionTracking = false,
             sessionTimeoutInMillis = 60000L
         )
-        val config = builder.withSessionConfiguration(customSessionConfig).build()
+        val config = configurationBuilder.setSessionConfiguration(customSessionConfig).build()
 
         assertEquals(customSessionConfig, config.sessionConfiguration)
         assertFalse(config.sessionConfiguration.automaticSessionTracking)
         assertEquals(60000L, config.sessionConfiguration.sessionTimeoutInMillis)
-    }
-
-    @Test
-    fun `when withControlPlaneUrl is set with a custom URL, then controlPlaneUrl should be updated`() {
-        val testControlPlaneUrl = "https://test-control-plane.com"
-        val config = builder.withControlPlaneUrl(testControlPlaneUrl).build()
-
-        assertEquals(testControlPlaneUrl, config.controlPlaneUrl)
-    }
-
-    @Test
-    fun `when withLogLevel is set with a custom level, then logLevel should be updated`() {
-        val config = builder.withLogLevel(Logger.LogLevel.VERBOSE).build()
-        assertEquals(Logger.LogLevel.VERBOSE, config.logLevel)
-    }
-
-    @Test
-    fun `when withFlushPolicies is set with custom policies, then flushPolicies should be updated`() {
-        val customPolicies = listOf<FlushPolicy>()
-        val config = builder.withFlushPolicies(customPolicies).build()
-
-        assertEquals(customPolicies, config.flushPolicies)
-    }
-
-    @Test
-    fun `when withGzipEnabled is set to false, then gzipEnabled should be false`() {
-        val config = builder.withGzipEnabled(false).build()
-
-        assertFalse(config.gzipEnabled)
     }
 
     @Test
@@ -126,29 +98,32 @@ class ConfigurationBuilderTest {
         val customPolicies = listOf<FlushPolicy>()
         val testControlPlaneUrl = "https://test-control-plane.com"
 
-        val config = builder
-            .withTrackApplicationLifecycleEvents(false)
-            .withTrackDeepLinks(false)
-            .withTrackActivities(true)
-            .withCollectDeviceId(false)
-            .withSessionConfiguration(customSessionConfig)
-            .withControlPlaneUrl(testControlPlaneUrl)
-            .withLogLevel(Logger.LogLevel.NONE)
-            .withFlushPolicies(customPolicies)
-            .withGzipEnabled(false)
+        val actualConfiguration = configurationBuilder
+            .setTrackApplicationLifecycleEvents(false)
+            .setTrackDeepLinks(false)
+            .setTrackActivities(true)
+            .setCollectDeviceId(false)
+            .setSessionConfiguration(customSessionConfig)
+            .setControlPlaneUrl(testControlPlaneUrl)
+            .setLogLevel(Logger.LogLevel.NONE)
+            .setFlushPolicies(customPolicies)
+            .setGzipEnabled(false)
             .build()
 
-        assertEquals(mockApplication, config.application)
-        assertEquals(testWriteKey, config.writeKey)
-        assertEquals(testDataPlaneUrl, config.dataPlaneUrl)
-        assertEquals(testControlPlaneUrl, config.controlPlaneUrl)
-        assertFalse(config.trackApplicationLifecycleEvents)
-        assertFalse(config.trackDeepLinks)
-        assertTrue(config.trackActivities)
-        assertFalse(config.collectDeviceId)
-        assertEquals(Logger.LogLevel.NONE, config.logLevel)
-        assertEquals(customPolicies, config.flushPolicies)
-        assertFalse(config.gzipEnabled)
-        assertEquals(customSessionConfig, config.sessionConfiguration)
+        val expectedConfiguration = Configuration(
+            application = mockApplication,
+            trackApplicationLifecycleEvents = false,
+            trackDeepLinks = false,
+            trackActivities = true,
+            collectDeviceId = false,
+            sessionConfiguration = customSessionConfig,
+            writeKey = testWriteKey,
+            dataPlaneUrl = testDataPlaneUrl,
+            controlPlaneUrl = testControlPlaneUrl,
+            logLevel = Logger.LogLevel.NONE,
+            flushPolicies = customPolicies,
+            gzipEnabled = false,
+        )
+        assertEquals(expectedConfiguration, actualConfiguration)
     }
 }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
@@ -1,0 +1,154 @@
+package com.rudderstack.sdk.kotlin.android.javacompat
+
+import android.app.Application
+import com.rudderstack.sdk.kotlin.android.SessionConfiguration
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_CONTROL_PLANE_URL
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_FLUSH_POLICIES
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_GZIP_STATUS
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ConfigurationBuilderTest {
+
+    @MockK
+    private lateinit var mockApplication: Application
+
+    private lateinit var builder: ConfigurationBuilder
+    private val testWriteKey = "test-write-key"
+    private val testDataPlaneUrl = "https://test-data-plane.com"
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+        builder = ConfigurationBuilder(mockApplication, testWriteKey, testDataPlaneUrl)
+    }
+
+    @Test
+    fun `when Configuration object is created with only default values, then it should have default values`() {
+        val config = builder.build()
+
+        assertEquals(mockApplication, config.application)
+        assertEquals(testWriteKey, config.writeKey)
+        assertEquals(testDataPlaneUrl, config.dataPlaneUrl)
+        assertEquals(DEFAULT_CONTROL_PLANE_URL, config.controlPlaneUrl)
+        assertTrue(config.trackApplicationLifecycleEvents)
+        assertTrue(config.trackDeepLinks)
+        assertFalse(config.trackActivities)
+        assertTrue(config.collectDeviceId)
+        assertEquals(Logger.DEFAULT_LOG_LEVEL, config.logLevel)
+        assertEquals(DEFAULT_FLUSH_POLICIES, config.flushPolicies)
+        assertEquals(DEFAULT_GZIP_STATUS, config.gzipEnabled)
+    }
+
+    @Test
+    fun `when withTrackApplicationLifecycleEvents is set to false, then trackApplicationLifecycleEvents should be false`() {
+        val config = builder.withTrackApplicationLifecycleEvents(false).build()
+
+        assertFalse(config.trackApplicationLifecycleEvents)
+    }
+
+    @Test
+    fun `when withTrackDeepLinks is set to false, then trackDeepLinks should be false`() {
+        val config = builder.withTrackDeepLinks(false).build()
+
+        assertFalse(config.trackDeepLinks)
+    }
+
+    @Test
+    fun `when withTrackActivities is set to true, then trackActivities should be true`() {
+        val config = builder.withTrackActivities(true).build()
+
+        assertTrue(config.trackActivities)
+    }
+
+    @Test
+    fun `when withCollectDeviceId is set to false, then collectDeviceId should be false`() {
+        val config = builder.withCollectDeviceId(false).build()
+
+        assertFalse(config.collectDeviceId)
+    }
+
+    @Test
+    fun `when withSessionConfiguration is set with custom values, then sessionConfiguration should be updated`() {
+        val customSessionConfig = SessionConfiguration(
+            automaticSessionTracking = false,
+            sessionTimeoutInMillis = 60000L
+        )
+        val config = builder.withSessionConfiguration(customSessionConfig).build()
+
+        assertEquals(customSessionConfig, config.sessionConfiguration)
+        assertFalse(config.sessionConfiguration.automaticSessionTracking)
+        assertEquals(60000L, config.sessionConfiguration.sessionTimeoutInMillis)
+    }
+
+    @Test
+    fun `when withControlPlaneUrl is set with a custom URL, then controlPlaneUrl should be updated`() {
+        val testControlPlaneUrl = "https://test-control-plane.com"
+        val config = builder.withControlPlaneUrl(testControlPlaneUrl).build()
+
+        assertEquals(testControlPlaneUrl, config.controlPlaneUrl)
+    }
+
+    @Test
+    fun `when withLogLevel is set with a custom level, then logLevel should be updated`() {
+        val config = builder.withLogLevel(Logger.LogLevel.VERBOSE).build()
+        assertEquals(Logger.LogLevel.VERBOSE, config.logLevel)
+    }
+
+    @Test
+    fun `when withFlushPolicies is set with custom policies, then flushPolicies should be updated`() {
+        val customPolicies = listOf<FlushPolicy>()
+        val config = builder.withFlushPolicies(customPolicies).build()
+
+        assertEquals(customPolicies, config.flushPolicies)
+    }
+
+    @Test
+    fun `when withGzipEnabled is set to false, then gzipEnabled should be false`() {
+        val config = builder.withGzipEnabled(false).build()
+
+        assertFalse(config.gzipEnabled)
+    }
+
+    @Test
+    fun `when all custom configurations are set, then the Configuration object should reflect those values`() {
+        val customSessionConfig = SessionConfiguration(
+            automaticSessionTracking = false,
+            sessionTimeoutInMillis = 30000L
+        )
+        val customPolicies = listOf<FlushPolicy>()
+        val testControlPlaneUrl = "https://test-control-plane.com"
+
+        val config = builder
+            .withTrackApplicationLifecycleEvents(false)
+            .withTrackDeepLinks(false)
+            .withTrackActivities(true)
+            .withCollectDeviceId(false)
+            .withSessionConfiguration(customSessionConfig)
+            .withControlPlaneUrl(testControlPlaneUrl)
+            .withLogLevel(Logger.LogLevel.NONE)
+            .withFlushPolicies(customPolicies)
+            .withGzipEnabled(false)
+            .build()
+
+        assertEquals(mockApplication, config.application)
+        assertEquals(testWriteKey, config.writeKey)
+        assertEquals(testDataPlaneUrl, config.dataPlaneUrl)
+        assertEquals(testControlPlaneUrl, config.controlPlaneUrl)
+        assertFalse(config.trackApplicationLifecycleEvents)
+        assertFalse(config.trackDeepLinks)
+        assertTrue(config.trackActivities)
+        assertFalse(config.collectDeviceId)
+        assertEquals(Logger.LogLevel.NONE, config.logLevel)
+        assertEquals(customPolicies, config.flushPolicies)
+        assertFalse(config.gzipEnabled)
+        assertEquals(customSessionConfig, config.sessionConfiguration)
+    }
+}

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.rudderstack.sdk.kotlin.android.Configuration
 import com.rudderstack.sdk.kotlin.android.utils.provideSessionConfiguration
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
-import com.rudderstack.sdk.kotlin.core.provideListOfFlushPolicies
+import com.rudderstack.sdk.kotlin.core.provideDefaultFlushPolicies
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -35,7 +35,7 @@ class ConfigurationBuilderTest {
         MockKAnnotations.init(this, relaxed = true)
 
         mockkStatic("com.rudderstack.sdk.kotlin.core.ConfigurationKt")
-        every { provideListOfFlushPolicies() } returns mockPolicies
+        every { provideDefaultFlushPolicies() } returns mockPolicies
 
         configurationBuilder = ConfigurationBuilder(
             mockApplication,

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
@@ -99,7 +99,6 @@ class ConfigurationBuilderTest {
             .setCollectDeviceId(false)
             .setSessionConfiguration(customSessionConfig)
             .setControlPlaneUrl(TEST_CONTROL_PLANE_URL)
-            .setLogLevel(Logger.LogLevel.NONE)
             .setFlushPolicies(customPolicies)
             .setGzipEnabled(false)
             .build()
@@ -114,7 +113,6 @@ class ConfigurationBuilderTest {
             writeKey = TEST_WRITE_KEY,
             dataPlaneUrl = TEST_DATA_PLANE_URL,
             controlPlaneUrl = TEST_CONTROL_PLANE_URL,
-            logLevel = Logger.LogLevel.NONE,
             flushPolicies = customPolicies,
             gzipEnabled = false,
         )

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ConfigurationBuilderTest.kt
@@ -3,10 +3,12 @@ package com.rudderstack.sdk.kotlin.android.javacompat
 import android.app.Application
 import com.rudderstack.sdk.kotlin.android.Configuration
 import com.rudderstack.sdk.kotlin.android.utils.provideSessionConfiguration
-import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
+import com.rudderstack.sdk.kotlin.core.provideListOfFlushPolicies
 import io.mockk.MockKAnnotations
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockkStatic
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -23,11 +25,17 @@ class ConfigurationBuilderTest {
     @MockK
     private lateinit var mockApplication: Application
 
+    @MockK
+    private lateinit var mockPolicies: List<FlushPolicy>
+
     private lateinit var configurationBuilder: ConfigurationBuilder
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+
+        mockkStatic("com.rudderstack.sdk.kotlin.core.ConfigurationKt")
+        every { provideListOfFlushPolicies() } returns mockPolicies
 
         configurationBuilder = ConfigurationBuilder(
             mockApplication,

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
@@ -1,0 +1,116 @@
+package com.rudderstack.sdk.kotlin.android.javacompat
+
+import android.app.Activity
+import androidx.navigation.NavController
+import com.rudderstack.sdk.kotlin.android.Configuration
+import com.rudderstack.sdk.kotlin.android.Analytics
+import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
+import io.mockk.MockKAnnotations
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+private const val SESSION_ID = 1234567890L
+
+class JavaAnalyticsTest {
+
+    @MockK
+    private lateinit var mockConfiguration: Configuration
+
+    @MockK
+    private lateinit var mockAnalytics: Analytics
+
+    private lateinit var javaAnalytics: JavaAnalytics
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        mockkStatic(::provideAnalyticsInstance)
+        every { provideAnalyticsInstance(any()) } returns mockAnalytics
+
+        javaAnalytics = JavaAnalytics(mockConfiguration)
+    }
+
+    @Test
+    fun `when session is fetched, then it should return the value`() {
+        every { mockAnalytics.sessionId } returns SESSION_ID
+
+        val actualSessionId = javaAnalytics.sessionId
+
+        assertEquals(SESSION_ID, actualSessionId)
+    }
+
+    @Test
+    fun `when startSession is called, then it should call the corresponding method on Analytics`() {
+        javaAnalytics.startSession()
+        javaAnalytics.startSession(sessionId = SESSION_ID)
+
+        verify {
+            mockAnalytics.startSession()
+            mockAnalytics.startSession(sessionId = SESSION_ID)
+        }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when endSession is called, then it should call the corresponding method on Analytics`() {
+        javaAnalytics.endSession()
+
+        verify { mockAnalytics.endSession() }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when reset is called, then it should call the corresponding method on Analytics`() {
+        javaAnalytics.reset()
+
+        verify { mockAnalytics.reset() }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when flush is called, then it should call the corresponding method on Analytics`() {
+        javaAnalytics.flush()
+
+        verify { mockAnalytics.flush() }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when setNavigationDestinationsTracking is called, then it should call the corresponding method on Analytics`() {
+        val navController = mockk<NavController>(relaxed = true)
+        val activity = mockk<Activity>(relaxed = true)
+
+        javaAnalytics.setNavigationDestinationsTracking(navController, activity)
+
+        verify { mockAnalytics.setNavigationDestinationsTracking(navController, activity) }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when plugin is added, then it should call the corresponding method on Analytics`() {
+        val plugin = mockk<Plugin>(relaxed = true)
+
+        javaAnalytics.add(plugin)
+
+        verify { mockAnalytics.add(plugin) }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when plugin is removed, then it should call the corresponding method on Analytics`() {
+        val plugin = mockk<Plugin>(relaxed = true)
+
+        javaAnalytics.remove(plugin)
+
+        verify { mockAnalytics.remove(plugin) }
+        confirmVerified(mockAnalytics)
+    }
+}

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
@@ -55,7 +55,7 @@ class JavaAnalyticsTest {
     }
 
     @Test
-    fun `when startSession is called, then it should call the corresponding method on Analytics`() {
+    fun `when session is started, then it should call the corresponding method on Analytics`() {
         javaAnalytics.startSession()
         javaAnalytics.startSession(sessionId = SESSION_ID)
 
@@ -67,7 +67,7 @@ class JavaAnalyticsTest {
     }
 
     @Test
-    fun `when endSession is called, then it should call the corresponding method on Analytics`() {
+    fun `when session is ended, then it should call the corresponding method on Analytics`() {
         javaAnalytics.endSession()
 
         verify { mockAnalytics.endSession() }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
@@ -11,7 +11,9 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,6 +38,11 @@ class JavaAnalyticsTest {
         every { provideAnalyticsInstance(any()) } returns mockAnalytics
 
         javaAnalytics = JavaAnalytics(mockConfiguration)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(::provideAnalyticsInstance)
     }
 
     @Test

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/SessionConfigurationBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/SessionConfigurationBuilderTest.kt
@@ -1,0 +1,53 @@
+package com.rudderstack.sdk.kotlin.android.javacompat
+
+import com.rudderstack.sdk.kotlin.android.DEFAULT_SESSION_TIMEOUT_IN_MILLIS
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SessionConfigurationBuilderTest {
+
+    private lateinit var builder: SessionConfigurationBuilder
+
+    @BeforeEach
+    fun setUp() {
+        builder = SessionConfigurationBuilder()
+    }
+
+    @Test
+    fun `when SessionConfiguration object is created with only default values, then it should have default values`() {
+        val config = builder.build()
+
+        assertTrue(config.automaticSessionTracking)
+        assertEquals(DEFAULT_SESSION_TIMEOUT_IN_MILLIS, config.sessionTimeoutInMillis)
+    }
+
+    @Test
+    fun `when withAutomaticSessionTracking is set to false, then automaticSessionTracking should be false`() {
+        val config = builder.withAutomaticSessionTracking(false).build()
+
+        assertFalse(config.automaticSessionTracking)
+    }
+
+    @Test
+    fun `when withSessionTimeoutInMillis is set with custom value, then sessionTimeoutInMillis should be updated`() {
+        val customTimeout = 30000L
+        val config = builder.withSessionTimeoutInMillis(customTimeout).build()
+
+        assertEquals(customTimeout, config.sessionTimeoutInMillis)
+    }
+
+    @Test
+    fun `when all custom configurations are set, then SessionConfiguration should reflect those values`() {
+        val customTimeout = 45000L
+        val config = builder
+            .withAutomaticSessionTracking(false)
+            .withSessionTimeoutInMillis(customTimeout)
+            .build()
+
+        assertFalse(config.automaticSessionTracking)
+        assertEquals(customTimeout, config.sessionTimeoutInMillis)
+    }
+}

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/SessionConfigurationBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/SessionConfigurationBuilderTest.kt
@@ -1,53 +1,65 @@
 package com.rudderstack.sdk.kotlin.android.javacompat
 
 import com.rudderstack.sdk.kotlin.android.DEFAULT_SESSION_TIMEOUT_IN_MILLIS
+import com.rudderstack.sdk.kotlin.android.SessionConfiguration
+import com.rudderstack.sdk.kotlin.android.SessionConfiguration.Companion.DEFAULT_AUTOMATIC_SESSION_TRACKING
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+private const val CUSTOM_TIME_IN_MILLIS = 45000L
+
 class SessionConfigurationBuilderTest {
 
-    private lateinit var builder: SessionConfigurationBuilder
+    private lateinit var sessionConfigurationBuilder: SessionConfigurationBuilder
 
     @BeforeEach
     fun setUp() {
-        builder = SessionConfigurationBuilder()
+        sessionConfigurationBuilder = SessionConfigurationBuilder()
     }
 
     @Test
     fun `when SessionConfiguration object is created with only default values, then it should have default values`() {
-        val config = builder.build()
+        val sessionConfiguration = sessionConfigurationBuilder.build()
 
-        assertTrue(config.automaticSessionTracking)
-        assertEquals(DEFAULT_SESSION_TIMEOUT_IN_MILLIS, config.sessionTimeoutInMillis)
+        val expected = provideSessionConfiguration()
+        assertEquals(expected, sessionConfiguration)
     }
 
     @Test
-    fun `when withAutomaticSessionTracking is set to false, then automaticSessionTracking should be false`() {
-        val config = builder.withAutomaticSessionTracking(false).build()
+    fun `when setAutomaticSessionTracking is set to false, then automaticSessionTracking should be false`() {
+        val sessionConfiguration = sessionConfigurationBuilder.setAutomaticSessionTracking(false).build()
 
-        assertFalse(config.automaticSessionTracking)
+        assertFalse(sessionConfiguration.automaticSessionTracking)
     }
 
     @Test
-    fun `when withSessionTimeoutInMillis is set with custom value, then sessionTimeoutInMillis should be updated`() {
-        val customTimeout = 30000L
-        val config = builder.withSessionTimeoutInMillis(customTimeout).build()
+    fun `when setSessionTimeoutInMillis is set with custom value, then sessionTimeoutInMillis should be updated`() {
+        val sessionConfiguration = sessionConfigurationBuilder.setSessionTimeoutInMillis(CUSTOM_TIME_IN_MILLIS).build()
 
-        assertEquals(customTimeout, config.sessionTimeoutInMillis)
+        assertEquals(CUSTOM_TIME_IN_MILLIS, sessionConfiguration.sessionTimeoutInMillis)
     }
 
     @Test
     fun `when all custom configurations are set, then SessionConfiguration should reflect those values`() {
-        val customTimeout = 45000L
-        val config = builder
-            .withAutomaticSessionTracking(false)
-            .withSessionTimeoutInMillis(customTimeout)
+        val config = sessionConfigurationBuilder
+            .setAutomaticSessionTracking(false)
+            .setSessionTimeoutInMillis(CUSTOM_TIME_IN_MILLIS)
             .build()
 
-        assertFalse(config.automaticSessionTracking)
-        assertEquals(customTimeout, config.sessionTimeoutInMillis)
+        val expected =
+            provideSessionConfiguration(sessionTimeoutInMillis = CUSTOM_TIME_IN_MILLIS, automaticSessionTracking = false)
+        assertEquals(expected, config)
     }
+}
+
+private fun provideSessionConfiguration(
+    automaticSessionTracking: Boolean = DEFAULT_AUTOMATIC_SESSION_TRACKING,
+    sessionTimeoutInMillis: Long = DEFAULT_SESSION_TIMEOUT_IN_MILLIS,
+): SessionConfiguration {
+    return SessionConfiguration(
+        automaticSessionTracking = automaticSessionTracking,
+        sessionTimeoutInMillis = sessionTimeoutInMillis
+    )
 }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/SessionConfigurationBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/SessionConfigurationBuilderTest.kt
@@ -1,8 +1,6 @@
 package com.rudderstack.sdk.kotlin.android.javacompat
 
-import com.rudderstack.sdk.kotlin.android.DEFAULT_SESSION_TIMEOUT_IN_MILLIS
-import com.rudderstack.sdk.kotlin.android.SessionConfiguration
-import com.rudderstack.sdk.kotlin.android.SessionConfiguration.Companion.DEFAULT_AUTOMATIC_SESSION_TRACKING
+import com.rudderstack.sdk.kotlin.android.utils.provideSessionConfiguration
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
@@ -52,14 +50,4 @@ class SessionConfigurationBuilderTest {
             provideSessionConfiguration(sessionTimeoutInMillis = CUSTOM_TIME_IN_MILLIS, automaticSessionTracking = false)
         assertEquals(expected, config)
     }
-}
-
-private fun provideSessionConfiguration(
-    automaticSessionTracking: Boolean = DEFAULT_AUTOMATIC_SESSION_TRACKING,
-    sessionTimeoutInMillis: Long = DEFAULT_SESSION_TIMEOUT_IN_MILLIS,
-): SessionConfiguration {
-    return SessionConfiguration(
-        automaticSessionTracking = automaticSessionTracking,
-        sessionTimeoutInMillis = sessionTimeoutInMillis
-    )
 }

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/Utils.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/Utils.kt
@@ -1,6 +1,9 @@
 package com.rudderstack.sdk.kotlin.android.utils
 
 import android.net.Uri
+import com.rudderstack.sdk.kotlin.android.DEFAULT_SESSION_TIMEOUT_IN_MILLIS
+import com.rudderstack.sdk.kotlin.android.SessionConfiguration
+import com.rudderstack.sdk.kotlin.android.SessionConfiguration.Companion.DEFAULT_AUTOMATIC_SESSION_TRACKING
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
@@ -86,4 +89,14 @@ fun provideSpyBlock(): Block {
 fun Any.readFileAsString(fileName: String): String {
     val inputStream = this::class.java.classLoader?.getResourceAsStream(fileName)
     return inputStream?.bufferedReader()?.use(BufferedReader::readText) ?: ""
+}
+
+fun provideSessionConfiguration(
+    automaticSessionTracking: Boolean = DEFAULT_AUTOMATIC_SESSION_TRACKING,
+    sessionTimeoutInMillis: Long = DEFAULT_SESSION_TIMEOUT_IN_MILLIS,
+): SessionConfiguration {
+    return SessionConfiguration(
+        automaticSessionTracking = automaticSessionTracking,
+        sessionTimeoutInMillis = sessionTimeoutInMillis
+    )
 }

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/customplugins/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/customplugins/JavaCompat.java
@@ -13,6 +13,7 @@ import com.rudderstack.sdk.kotlin.android.javacompat.SessionConfigurationBuilder
 import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId;
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
 import com.rudderstack.sdk.kotlin.core.javacompat.JavaAnalytics;
+import com.rudderstack.sdk.kotlin.core.javacompat.RudderOptionBuilder;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -74,7 +75,7 @@ public class JavaCompat {
      */
     public static void track(@NonNull JavaAnalytics analytics) {
         String name = "Sample track event";
-        JsonObject properties = getJsonObject();
+        Map<String, Object> properties = getMap();
         RudderOption option = getRudderOption();
 
         analytics.track(name);
@@ -84,7 +85,7 @@ public class JavaCompat {
     }
 
     @NonNull
-    private static JsonObject getJsonObject() {
+    private static Map<String, Object> getMap() {
         Map<String, Object> value = new HashMap<>();
         value.put("key-1", "value-1");
         value.put("age", 30);
@@ -92,23 +93,27 @@ public class JavaCompat {
         value.put("scores", Arrays.asList(10, 20, 30));
         value.put("details", Map.of("city", "Delhi", "zip", 12345));
 
-        return fromMap(value);
+        return value;
     }
 
     @NonNull
     private static RudderOption getRudderOption() {
-        JsonObject integrations = getIntegrations();
+        Map<String, Object> integrations = getIntegrations();
         List<ExternalId> externalIds = getExternalIds();
-        JsonObject customContext = getJsonObject();
-        return new RudderOption(integrations, externalIds, customContext);
+        Map<String, Object> customContext = getMap();
+        return new RudderOptionBuilder()
+                .setIntegrations(integrations)
+                .setExternalId(externalIds)
+                .setCustomContext(customContext)
+                .build();
     }
 
     @NonNull
-    private static JsonObject getIntegrations() {
+    private static Map<String, Object> getIntegrations() {
         Map<String, Object> integrations = new LinkedHashMap<>();
         integrations.put("All", true);
         integrations.put("Google Analytics", false);
-        return fromMap(integrations);
+        return integrations;
     }
 
     @NonNull
@@ -116,5 +121,11 @@ public class JavaCompat {
         ExternalId externalId1 = new ExternalId("externalId1", "value1");
         ExternalId externalId2 = new ExternalId("externalId2", "value2");
         return Arrays.asList(externalId1, externalId2);
+    }
+
+    @NonNull
+    private static JsonObject getJsonObject() {
+        Map<String, Object> value = getMap();
+        return fromMap(value);
     }
 }

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/customplugins/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/customplugins/JavaCompat.java
@@ -1,0 +1,120 @@
+package com.rudderstack.sampleapp.analytics.customplugins;
+
+import static com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromMap;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+
+import com.rudderstack.sdk.kotlin.android.Configuration;
+import com.rudderstack.sdk.kotlin.android.SessionConfiguration;
+import com.rudderstack.sdk.kotlin.android.javacompat.ConfigurationBuilder;
+import com.rudderstack.sdk.kotlin.android.javacompat.SessionConfigurationBuilder;
+import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId;
+import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
+import com.rudderstack.sdk.kotlin.core.javacompat.JavaAnalytics;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import kotlinx.serialization.json.JsonObject;
+
+public class JavaCompat {
+
+    private JavaCompat() {
+    }
+
+    /**
+     * Initialize the JavaAnalytics instance with the given parameters.
+     * <p>
+     * This method sets up the analytics instance with the provided write key and data plane URL.
+     * Code:
+     *
+     * <pre>{@code
+     * JavaAnalytics analytics = JavaCompat.initAnalytics(application, writeKey, dataPlaneUrl);
+     * }</pre>
+     *
+     * @param application  The application context.
+     * @param writeKey     The write key for the analytics service.
+     * @param dataPlaneUrl The data plane URL for the analytics service.
+     * @return A JavaAnalytics instance configured with the provided parameters.
+     */
+    @NonNull
+    public static JavaAnalytics initAnalytics(@NonNull Application application, @NonNull String writeKey, @NonNull String dataPlaneUrl) {
+        SessionConfiguration sessionConfiguration = new SessionConfigurationBuilder()
+                .withAutomaticSessionTracking(true)
+                .withSessionTimeoutInMillis(30)
+                .build();
+
+        Configuration configuration = new ConfigurationBuilder(application, writeKey, dataPlaneUrl)
+                .withTrackApplicationLifecycleEvents(true)
+                .withSessionConfiguration(sessionConfiguration)
+                .withGzipEnabled(true)
+                .build();
+
+        JavaAnalytics javaAnalytics = new JavaAnalytics(configuration);
+        JavaCompat.track(javaAnalytics);
+        return javaAnalytics;
+    }
+
+    /**
+     * Track an event using the provided JavaAnalytics instance.
+     * <p>
+     * This method demonstrates how to track events with different parameters.
+     * Code:
+     *
+     * <pre>{@code
+     * JavaCompat.track(analytics);
+     * }</pre>
+     *
+     * @param analytics The JavaAnalytics instance to use for tracking events.
+     */
+    public static void track(@NonNull JavaAnalytics analytics) {
+        String name = "Sample track event";
+        JsonObject properties = getJsonObject();
+        RudderOption option = getRudderOption();
+
+        analytics.track(name);
+        analytics.track(name, properties);
+        analytics.track(name, option);
+        analytics.track(name, properties, option);
+    }
+
+    @NonNull
+    private static JsonObject getJsonObject() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("key-1", "value-1");
+        value.put("age", 30);
+        value.put("isActive", true);
+        value.put("scores", Arrays.asList(10, 20, 30));
+        value.put("details", Map.of("city", "Delhi", "zip", 12345));
+
+        return fromMap(value);
+    }
+
+    @NonNull
+    private static RudderOption getRudderOption() {
+        JsonObject integrations = getIntegrations();
+        List<ExternalId> externalIds = getExternalIds();
+        JsonObject customContext = getJsonObject();
+        return new RudderOption(integrations, externalIds, customContext);
+    }
+
+    @NonNull
+    private static JsonObject getIntegrations() {
+        Map<String, Object> integrations = new LinkedHashMap<>();
+        integrations.put("All", true);
+        integrations.put("Google Analytics", false);
+        return fromMap(integrations);
+    }
+
+    @NonNull
+    private static List<ExternalId> getExternalIds() {
+        ExternalId externalId1 = new ExternalId("externalId1", "value1");
+        ExternalId externalId2 = new ExternalId("externalId2", "value2");
+        return Arrays.asList(externalId1, externalId2);
+    }
+}

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/CustomJavaPlugin.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/CustomJavaPlugin.java
@@ -1,0 +1,53 @@
+package com.rudderstack.sampleapp.analytics.javacompat;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.rudderstack.sdk.kotlin.core.Analytics;
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics;
+import com.rudderstack.sdk.kotlin.core.internals.models.Event;
+import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin;
+
+import kotlin.coroutines.Continuation;
+
+/**
+ * A custom Java Plugin demonstrating how to implement a plugin in Java.
+ */
+public class CustomJavaPlugin implements Plugin {
+    private Analytics analytics;
+    private static final Plugin.PluginType pluginType = Plugin.PluginType.OnProcess;
+
+    @Override
+    public void setAnalytics(@NonNull Analytics analytics) {
+        this.analytics = analytics;
+    }
+
+    @Override
+    public void setup(@NonNull Analytics analytics) {
+        this.analytics = analytics;
+    }
+
+    @Nullable
+    @Override
+    public Object intercept(@NonNull Event event, @NonNull Continuation<? super Event> $completion) {
+        LoggerAnalytics.INSTANCE.verbose("CustomJavaPlugin: Intercepting event: " + event);
+        return event;
+    }
+
+    @NonNull
+    @Override
+    public Analytics getAnalytics() {
+        return this.analytics;
+    }
+
+    @NonNull
+    @Override
+    public Plugin.PluginType getPluginType() {
+        return pluginType;
+    }
+
+    @Override
+    public void teardown() {
+        // Perform any necessary cleanup here
+    }
+}

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -1,7 +1,5 @@
 package com.rudderstack.sampleapp.analytics.javacompat;
 
-import static com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromMap;
-
 import android.app.Application;
 
 import androidx.annotation.NonNull;
@@ -21,8 +19,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import kotlinx.serialization.json.JsonObject;
 
 public class JavaCompat {
 
@@ -213,11 +209,5 @@ public class JavaCompat {
         ExternalId externalId1 = new ExternalId("externalId1", "value1");
         ExternalId externalId2 = new ExternalId("externalId2", "value2");
         return Arrays.asList(externalId1, externalId2);
-    }
-
-    @NonNull
-    private static JsonObject getJsonObject() {
-        Map<String, Object> value = getMap();
-        return fromMap(value);
     }
 }

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -13,6 +13,7 @@ import com.rudderstack.sdk.kotlin.android.SessionConfiguration;
 import com.rudderstack.sdk.kotlin.android.javacompat.ConfigurationBuilder;
 import com.rudderstack.sdk.kotlin.android.javacompat.SessionConfigurationBuilder;
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger;
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics;
 import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId;
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
 import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics;
@@ -55,6 +56,8 @@ public class JavaCompat {
 
     @NonNull
     private static JavaAnalytics analyticsFactory(@NonNull Application application, @NonNull String writeKey, @NonNull String dataPlaneUrl) {
+        LoggerAnalytics.INSTANCE.setLogLevel(Logger.LogLevel.VERBOSE);
+
         SessionConfiguration sessionConfiguration = new SessionConfigurationBuilder()
                 .setAutomaticSessionTracking(true)
                 .setSessionTimeoutInMillis(30)
@@ -63,11 +66,14 @@ public class JavaCompat {
         Configuration configuration = new ConfigurationBuilder(application, writeKey, dataPlaneUrl)
                 .setTrackApplicationLifecycleEvents(true)
                 .setSessionConfiguration(sessionConfiguration)
-                .setLogLevel(Logger.LogLevel.VERBOSE)
                 .setGzipEnabled(true)
                 .build();
 
-        return new JavaAnalytics(configuration);
+
+        JavaAnalytics javaAnalytics = new JavaAnalytics(configuration);
+        LoggerAnalytics.INSTANCE.verbose("SampleApp: Initializing JavaAnalytics with writeKey: " + writeKey + " and dataPlaneUrl: " + dataPlaneUrl);
+
+        return javaAnalytics;
     }
 
     // Android

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -25,8 +25,7 @@ import kotlinx.serialization.json.JsonObject;
 
 public class JavaCompat {
 
-    private JavaCompat() {
-    }
+    private JavaCompat() {}
 
     /**
      * Initialize the JavaAnalytics instance with the given parameters.
@@ -82,6 +81,34 @@ public class JavaCompat {
         analytics.track(name, properties);
         analytics.track(name, option);
         analytics.track(name, properties, option);
+    }
+
+    /**
+     * Identify a user using the provided JavaAnalytics instance.
+     * <p>
+     * This method demonstrates how to identify users with different parameters.
+     * Code:
+     *
+     * <pre>{@code
+     * JavaCompat.screen(analytics);
+     * }</pre>
+     *
+     * @param analytics The JavaAnalytics instance to use for identifying users.
+     */
+    public static void screen(@NonNull JavaAnalytics analytics) {
+        String name = "Sample screen event";
+        String category = "Sample screen category";
+        Map<String, Object> properties = getMap();
+        RudderOption option = getRudderOption();
+
+        analytics.screen(name);
+        analytics.screen(name, category);
+        analytics.screen(name, properties);
+        analytics.screen(name, option);
+        analytics.screen(name, properties, option);
+        analytics.screen(name, category, properties);
+        analytics.screen(name, category, option);
+        analytics.screen(name, category, properties, option);
     }
 
     @NonNull

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -99,19 +99,19 @@ public class JavaCompat {
      * }</pre>
      */
     public void screen() {
-        String name = "Sample screen event";
+        String screenName = "Sample screen event";
         String category = "Sample screen category";
         Map<String, Object> properties = getMap();
         RudderOption option = getRudderOption();
 
-        analytics.screen(name);
-        analytics.screen(name, category);
-        analytics.screen(name, properties);
-        analytics.screen(name, option);
-        analytics.screen(name, properties, option);
-        analytics.screen(name, category, properties);
-        analytics.screen(name, category, option);
-        analytics.screen(name, category, properties, option);
+        analytics.screen(screenName);
+        analytics.screen(screenName, category);
+        analytics.screen(screenName, properties);
+        analytics.screen(screenName, option);
+        analytics.screen(screenName, properties, option);
+        analytics.screen(screenName, category, properties);
+        analytics.screen(screenName, category, option);
+        analytics.screen(screenName, category, properties, option);
     }
 
     /**

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -11,7 +11,7 @@ import com.rudderstack.sdk.kotlin.android.javacompat.ConfigurationBuilder;
 import com.rudderstack.sdk.kotlin.android.javacompat.SessionConfigurationBuilder;
 import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId;
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
-import com.rudderstack.sdk.kotlin.core.javacompat.JavaAnalytics;
+import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics;
 import com.rudderstack.sdk.kotlin.core.javacompat.RudderOptionBuilder;
 
 import java.util.Arrays;
@@ -49,18 +49,17 @@ public class JavaCompat {
         this.analytics = analytics;
     }
 
-    @VisibleForTesting
     @NonNull
-    public static JavaAnalytics analyticsFactory(@NonNull Application application, @NonNull String writeKey, @NonNull String dataPlaneUrl) {
+    private static JavaAnalytics analyticsFactory(@NonNull Application application, @NonNull String writeKey, @NonNull String dataPlaneUrl) {
         SessionConfiguration sessionConfiguration = new SessionConfigurationBuilder()
-                .withAutomaticSessionTracking(true)
-                .withSessionTimeoutInMillis(30)
+                .setAutomaticSessionTracking(true)
+                .setSessionTimeoutInMillis(30)
                 .build();
 
-        Configuration configuration = new ConfigurationBuilder(application, writeKey, dataPlaneUrl)
-                .withTrackApplicationLifecycleEvents(true)
-                .withSessionConfiguration(sessionConfiguration)
-                .withGzipEnabled(true)
+        Configuration configuration = (Configuration) new ConfigurationBuilder(application, writeKey, dataPlaneUrl)
+                .setTrackApplicationLifecycleEvents(true)
+                .setSessionConfiguration(sessionConfiguration)
+                .setGzipEnabled(true)
                 .build();
 
         return new JavaAnalytics(configuration);

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -1,4 +1,4 @@
-package com.rudderstack.sampleapp.analytics.customplugins;
+package com.rudderstack.sampleapp.analytics.javacompat;
 
 import static com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromMap;
 

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.navigation.NavController;
 
@@ -148,6 +149,7 @@ public class JavaCompat {
      *
      * @return The session ID.
      */
+    @Nullable
     public Long getSessionId() {
         return analytics.getSessionId();
     }
@@ -246,6 +248,36 @@ public class JavaCompat {
      */
     public void shutdown() {
         analytics.shutdown();
+    }
+
+    /**
+     * Get the anonymous ID.
+     *
+     * @return The anonymous ID.
+     */
+    @Nullable
+    public String getAnonymousId() {
+        return analytics.getAnonymousId();
+    }
+
+    /**
+     * Get the user ID.
+     *
+     * @return The user ID.
+     */
+    @Nullable
+    public String getUserId() {
+        return analytics.getUserId();
+    }
+
+    /**
+     * Get the user traits.
+     *
+     * @return The user traits.
+     */
+    @Nullable
+    public Map<String, Object> getTraits() {
+        return analytics.getTraits();
     }
 
     @NonNull

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -286,6 +286,10 @@ public class JavaCompat {
         return analytics.getTraits();
     }
 
+    public void setCustomLogger(Logger customLogger) {
+        LoggerAnalytics.INSTANCE.setLogger(customLogger);
+    }
+
     @NonNull
     private static Map<String, Object> getMap() {
         Map<String, Object> value = new HashMap<>();

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -321,7 +321,7 @@ public class JavaCompat {
 
     @NonNull
     private static Plugin getPlugin() {
-        return new CustomJavaPlugin();
+        return new JavaEventFilteringPlugin();
     }
 }
 

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -60,7 +60,7 @@ public class JavaCompat {
                 .setSessionTimeoutInMillis(30)
                 .build();
 
-        Configuration configuration = (Configuration) new ConfigurationBuilder(application, writeKey, dataPlaneUrl)
+        Configuration configuration = new ConfigurationBuilder(application, writeKey, dataPlaneUrl)
                 .setTrackApplicationLifecycleEvents(true)
                 .setSessionConfiguration(sessionConfiguration)
                 .setLogLevel(Logger.LogLevel.VERBOSE)

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -1,17 +1,21 @@
 package com.rudderstack.sampleapp.analytics.javacompat;
 
+import android.app.Activity;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import androidx.navigation.NavController;
 
 import com.rudderstack.sdk.kotlin.android.Configuration;
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration;
 import com.rudderstack.sdk.kotlin.android.javacompat.ConfigurationBuilder;
 import com.rudderstack.sdk.kotlin.android.javacompat.SessionConfigurationBuilder;
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger;
 import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId;
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
 import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics;
+import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin;
 import com.rudderstack.sdk.kotlin.core.javacompat.RudderOptionBuilder;
 
 import java.util.Arrays;
@@ -23,7 +27,6 @@ import java.util.Map;
 /**
  * This class provides a compatibility layer for Java analytics events.
  * <p>
- *
  * Sample code:
  * <pre>{@code
  * JavaCompat javaCompat = new JavaCompat(application, writeKey, dataPlaneUrl);
@@ -59,20 +62,110 @@ public class JavaCompat {
         Configuration configuration = (Configuration) new ConfigurationBuilder(application, writeKey, dataPlaneUrl)
                 .setTrackApplicationLifecycleEvents(true)
                 .setSessionConfiguration(sessionConfiguration)
+                .setLogLevel(Logger.LogLevel.VERBOSE)
                 .setGzipEnabled(true)
                 .build();
 
         return new JavaAnalytics(configuration);
     }
 
+    // Android
+
+    /**
+     * Start a session.
+     */
+    public void startSession() {
+        analytics.startSession();
+    }
+
+    /**
+     * Start a session with a specific session ID.
+     *
+     * @param sessionId The session ID to start.
+     */
+    public void startSession(Long sessionId) {
+        analytics.startSession(sessionId);
+    }
+
+    /**
+     * End the current session.
+     */
+    public void endSession() {
+        analytics.endSession();
+    }
+
+    /**
+     * Make a RESET call.
+     */
+    public void reset() {
+        analytics.reset();
+    }
+
+    /**
+     * Make a flush call.
+     */
+    public void flush() {
+        analytics.flush();
+    }
+
+    /**
+     * Add a custom plugin to the analytics instance.
+     */
+    @VisibleForTesting
+    public void add() {
+        Plugin customPlugin = getPlugin();
+
+        this.add(customPlugin);
+    }
+
+    /**
+     * Add a custom plugin to the analytics instance.
+     */
+    public void add(Plugin plugin) {
+        analytics.add(plugin);
+    }
+
+    /**
+     * Remove a custom plugin from the analytics instance.
+     */
+    @VisibleForTesting
+    public void remove() {
+        Plugin customPlugin = getPlugin();
+        this.add(customPlugin);
+
+        this.remove(customPlugin);
+    }
+
+    /**
+     * Remove a custom plugin from the analytics instance.
+     */
+    public void remove(Plugin plugin) {
+        analytics.remove(plugin);
+    }
+
+    /**
+     * Get the session ID.
+     *
+     * @return The session ID.
+     */
+    public Long getSessionId() {
+        return analytics.getSessionId();
+    }
+
+    /**
+     * Set the navigation destinations tracking.
+     *
+     * @param navController The NavController instance.
+     * @param activity      The activity instance.
+     */
+    public void setNavigationDestinationsTracking(NavController navController, Activity activity) {
+        analytics.setNavigationDestinationsTracking(navController, activity);
+    }
+
+    // Core
+
     /**
      * Make a track event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * javaCompat.track();
-     * }</pre>
      */
     public void track() {
         String name = "Sample track event";
@@ -87,12 +180,6 @@ public class JavaCompat {
 
     /**
      * Make a screen event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * javaCompat.screen();
-     * }</pre>
      */
     public void screen() {
         String screenName = "Sample screen event";
@@ -112,12 +199,6 @@ public class JavaCompat {
 
     /**
      * Make a group event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * javaCompat.group();
-     * }</pre>
      */
     public void group() {
         String groupId = "Sample group ID";
@@ -132,12 +213,6 @@ public class JavaCompat {
 
     /**
      * Make an identify event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * javaCompat.identify();
-     * }</pre>
      */
     public void identify() {
         String userId = "Sample user ID";
@@ -154,12 +229,6 @@ public class JavaCompat {
 
     /**
      * Make an alias event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * javaCompat.alias();
-     * }</pre>
      */
     public void alias() {
         String newId = "Sample alias";
@@ -170,6 +239,13 @@ public class JavaCompat {
         analytics.alias(newId, option);
         analytics.alias(newId, previousId);
         analytics.alias(newId, previousId, option);
+    }
+
+    /**
+     * Make the analytics instance shutdown.
+     */
+    public void shutdown() {
+        analytics.shutdown();
     }
 
     @NonNull
@@ -210,4 +286,10 @@ public class JavaCompat {
         ExternalId externalId2 = new ExternalId("externalId2", "value2");
         return Arrays.asList(externalId1, externalId2);
     }
+
+    @NonNull
+    private static Plugin getPlugin() {
+        return new CustomJavaPlugin();
+    }
 }
+

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -70,10 +70,9 @@ public class JavaCompat {
     }
 
     /**
-     * Track an event using the provided JavaAnalytics instance.
+     * Make a track event.
      * <p>
-     * This method demonstrates how to track events with different parameters.
-     * Code:
+     * Sample code:
      *
      * <pre>{@code
      * JavaCompat.track();
@@ -91,10 +90,9 @@ public class JavaCompat {
     }
 
     /**
-     * Identify a user using the provided JavaAnalytics instance.
+     * Make a screen event.
      * <p>
-     * This method demonstrates how to identify users with different parameters.
-     * Code:
+     * Sample code:
      *
      * <pre>{@code
      * JavaCompat.screen();
@@ -116,6 +114,15 @@ public class JavaCompat {
         analytics.screen(name, category, properties, option);
     }
 
+    /**
+     * Make a group event.
+     * <p>
+     * Sample code:
+     *
+     * <pre>{@code
+     * JavaCompat.group();
+     * }</pre>
+     */
     public void group() {
         String groupId = "Sample group ID";
         Map<String, Object> traits = getMap();
@@ -125,6 +132,28 @@ public class JavaCompat {
         analytics.group(groupId, traits);
         analytics.group(groupId, option);
         analytics.group(groupId, traits, option);
+    }
+
+    /**
+     * Make an identify event.
+     * <p>
+     * Sample code:
+     *
+     * <pre>{@code
+     * JavaCompat.identify();
+     * }</pre>
+     */
+    public void identify() {
+        String userId = "Sample user ID";
+        Map<String, Object> traits = getMap();
+        RudderOption option = getRudderOption();
+
+        analytics.identify(userId);
+        analytics.identify(traits);
+        analytics.identify(userId, traits);
+        analytics.identify(userId, option);
+        analytics.identify(traits, option);
+        analytics.identify(userId, traits, option);
     }
 
     @NonNull

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -20,10 +20,26 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * This class provides a compatibility layer for Java analytics events.
+ * <p>
+ *
+ * Sample code:
+ * <pre>{@code
+ * JavaCompat javaCompat = new JavaCompat(application, writeKey, dataPlaneUrl);
+ * }</pre>
+ */
 public class JavaCompat {
 
     private final JavaAnalytics analytics;
 
+    /**
+     * Constructor to initialize the JavaCompat instance with the given parameters.
+     *
+     * @param application  The application context.
+     * @param writeKey     The write key for the analytics service.
+     * @param dataPlaneUrl The data plane URL for the analytics service.
+     */
     public JavaCompat(@NonNull Application application, @NonNull String writeKey, @NonNull String dataPlaneUrl) {
         analytics = analyticsFactory(application, writeKey, dataPlaneUrl);
     }
@@ -33,21 +49,6 @@ public class JavaCompat {
         this.analytics = analytics;
     }
 
-    /**
-     * Initialize the JavaAnalytics instance with the given parameters.
-     * <p>
-     * This method sets up the analytics instance with the provided write key and data plane URL.
-     * Code:
-     *
-     * <pre>{@code
-     * JavaAnalytics analytics = JavaCompat.initAnalytics(application, writeKey, dataPlaneUrl);
-     * }</pre>
-     *
-     * @param application  The application context.
-     * @param writeKey     The write key for the analytics service.
-     * @param dataPlaneUrl The data plane URL for the analytics service.
-     * @return A JavaAnalytics instance configured with the provided parameters.
-     */
     @VisibleForTesting
     @NonNull
     public static JavaAnalytics analyticsFactory(@NonNull Application application, @NonNull String writeKey, @NonNull String dataPlaneUrl) {
@@ -71,7 +72,7 @@ public class JavaCompat {
      * Sample code:
      *
      * <pre>{@code
-     * JavaCompat.track();
+     * javaCompat.track();
      * }</pre>
      */
     public void track() {
@@ -91,7 +92,7 @@ public class JavaCompat {
      * Sample code:
      *
      * <pre>{@code
-     * JavaCompat.screen();
+     * javaCompat.screen();
      * }</pre>
      */
     public void screen() {
@@ -116,7 +117,7 @@ public class JavaCompat {
      * Sample code:
      *
      * <pre>{@code
-     * JavaCompat.group();
+     * javaCompat.group();
      * }</pre>
      */
     public void group() {
@@ -136,7 +137,7 @@ public class JavaCompat {
      * Sample code:
      *
      * <pre>{@code
-     * JavaCompat.identify();
+     * javaCompat.identify();
      * }</pre>
      */
     public void identify() {
@@ -158,7 +159,7 @@ public class JavaCompat {
      * Sample code:
      *
      * <pre>{@code
-     * JavaCompat.alias();
+     * javaCompat.alias();
      * }</pre>
      */
     public void alias() {

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -156,6 +156,26 @@ public class JavaCompat {
         analytics.identify(userId, traits, option);
     }
 
+    /**
+     * Make an alias event.
+     * <p>
+     * Sample code:
+     *
+     * <pre>{@code
+     * JavaCompat.alias();
+     * }</pre>
+     */
+    public void alias() {
+        String newId = "Sample alias";
+        String previousId = "Sample previous ID";
+        RudderOption option = getRudderOption();
+
+        analytics.alias(newId);
+        analytics.alias(newId, option);
+        analytics.alias(newId, previousId);
+        analytics.alias(newId, previousId, option);
+    }
+
     @NonNull
     private static Map<String, Object> getMap() {
         Map<String, Object> value = new HashMap<>();

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -116,6 +116,17 @@ public class JavaCompat {
         analytics.screen(name, category, properties, option);
     }
 
+    public void group() {
+        String groupId = "Sample group ID";
+        Map<String, Object> traits = getMap();
+        RudderOption option = getRudderOption();
+
+        analytics.group(groupId);
+        analytics.group(groupId, traits);
+        analytics.group(groupId, option);
+        analytics.group(groupId, traits, option);
+    }
+
     @NonNull
     private static Map<String, Object> getMap() {
         Map<String, Object> value = new HashMap<>();

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -5,6 +5,7 @@ import static com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromM
 import android.app.Application;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 import com.rudderstack.sdk.kotlin.android.Configuration;
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration;
@@ -25,7 +26,16 @@ import kotlinx.serialization.json.JsonObject;
 
 public class JavaCompat {
 
-    private JavaCompat() {}
+    private final JavaAnalytics analytics;
+
+    public JavaCompat(@NonNull Application application, @NonNull String writeKey, @NonNull String dataPlaneUrl) {
+        analytics = analyticsFactory(application, writeKey, dataPlaneUrl);
+    }
+
+    @VisibleForTesting
+    public JavaCompat(JavaAnalytics analytics) {
+        this.analytics = analytics;
+    }
 
     /**
      * Initialize the JavaAnalytics instance with the given parameters.
@@ -42,8 +52,9 @@ public class JavaCompat {
      * @param dataPlaneUrl The data plane URL for the analytics service.
      * @return A JavaAnalytics instance configured with the provided parameters.
      */
+    @VisibleForTesting
     @NonNull
-    public static JavaAnalytics initAnalytics(@NonNull Application application, @NonNull String writeKey, @NonNull String dataPlaneUrl) {
+    public static JavaAnalytics analyticsFactory(@NonNull Application application, @NonNull String writeKey, @NonNull String dataPlaneUrl) {
         SessionConfiguration sessionConfiguration = new SessionConfigurationBuilder()
                 .withAutomaticSessionTracking(true)
                 .withSessionTimeoutInMillis(30)
@@ -55,9 +66,7 @@ public class JavaCompat {
                 .withGzipEnabled(true)
                 .build();
 
-        JavaAnalytics javaAnalytics = new JavaAnalytics(configuration);
-        JavaCompat.track(javaAnalytics);
-        return javaAnalytics;
+        return new JavaAnalytics(configuration);
     }
 
     /**
@@ -67,12 +76,10 @@ public class JavaCompat {
      * Code:
      *
      * <pre>{@code
-     * JavaCompat.track(analytics);
+     * JavaCompat.track();
      * }</pre>
-     *
-     * @param analytics The JavaAnalytics instance to use for tracking events.
      */
-    public static void track(@NonNull JavaAnalytics analytics) {
+    public void track() {
         String name = "Sample track event";
         Map<String, Object> properties = getMap();
         RudderOption option = getRudderOption();
@@ -90,12 +97,10 @@ public class JavaCompat {
      * Code:
      *
      * <pre>{@code
-     * JavaCompat.screen(analytics);
+     * JavaCompat.screen();
      * }</pre>
-     *
-     * @param analytics The JavaAnalytics instance to use for identifying users.
      */
-    public static void screen(@NonNull JavaAnalytics analytics) {
+    public void screen() {
         String name = "Sample screen event";
         String category = "Sample screen category";
         Map<String, Object> properties = getMap();

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCustomLogger.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCustomLogger.java
@@ -1,0 +1,38 @@
+package com.rudderstack.sampleapp.analytics.javacompat;
+
+import androidx.annotation.NonNull;
+
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger;
+
+/**
+ * Custom logger implementation for Java analytics.
+ * This class implements the Logger interface and provides custom logging methods.
+ */
+public class JavaCustomLogger implements Logger {
+    private final String TAG = "MyCustomTag";
+
+    @Override
+    public void verbose(@NonNull String log) {
+        System.out.println(TAG + ": Verbose: " + log);
+    }
+
+    @Override
+    public void debug(@NonNull String log) {
+        System.out.println(TAG + ": Debug: " + log);
+    }
+
+    @Override
+    public void info(@NonNull String log) {
+        System.out.println(TAG + ": Info: " + log);
+    }
+
+    @Override
+    public void warn(@NonNull String log) {
+        System.out.println(TAG + ": Warn: " + log);
+    }
+
+    @Override
+    public void error(@NonNull String log, Throwable throwable) {
+        System.out.println(TAG + ": Error: " + log);
+    }
+}

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaEventFilteringPlugin.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaEventFilteringPlugin.java
@@ -6,16 +6,21 @@ import androidx.annotation.Nullable;
 import com.rudderstack.sdk.kotlin.core.Analytics;
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics;
 import com.rudderstack.sdk.kotlin.core.internals.models.Event;
+import com.rudderstack.sdk.kotlin.core.internals.models.TrackEvent;
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin;
+
+import java.util.List;
 
 import kotlin.coroutines.Continuation;
 
 /**
- * A custom Java Plugin demonstrating how to implement a plugin in Java.
+ * A custom Java Plugin demonstrating how to perform event filtering in Java.
  */
-public class CustomJavaPlugin implements Plugin {
+public class JavaEventFilteringPlugin implements Plugin {
     private Analytics analytics;
     private static final Plugin.PluginType pluginType = Plugin.PluginType.OnProcess;
+
+    List<String> listOfEventsToBeFiltered;
 
     @Override
     public void setAnalytics(@NonNull Analytics analytics) {
@@ -25,12 +30,17 @@ public class CustomJavaPlugin implements Plugin {
     @Override
     public void setup(@NonNull Analytics analytics) {
         this.analytics = analytics;
+        listOfEventsToBeFiltered = List.of("Application Opened", "Application Backgrounded");
     }
 
     @Nullable
     @Override
     public Object intercept(@NonNull Event event, @NonNull Continuation<? super Event> $completion) {
-        LoggerAnalytics.INSTANCE.verbose("CustomJavaPlugin: Intercepting event: " + event);
+        if (event instanceof TrackEvent && listOfEventsToBeFiltered.contains(((TrackEvent) event).getEvent())) {
+            LoggerAnalytics.INSTANCE.verbose("EventFilteringPlugin: Event " + ((TrackEvent) event).getEvent() + " is filtered out");
+            return null;
+        }
+
         return event;
     }
 
@@ -48,6 +58,6 @@ public class CustomJavaPlugin implements Plugin {
 
     @Override
     public void teardown() {
-        // Perform any necessary cleanup here
+        listOfEventsToBeFiltered = null;
     }
 }

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -1,41 +1,26 @@
 package com.rudderstack.sampleapp.analytics.javacompat
 
-import android.app.Application
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
-import com.rudderstack.sdk.kotlin.core.javacompat.JavaAnalytics
+import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics
 import io.mockk.MockKAnnotations
 import io.mockk.confirmVerified
 import io.mockk.impl.annotations.MockK
-import io.mockk.spyk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-
-private const val WRITE_KEY = "test_write_key"
-private const val DATA_PLANE_URL = "https://test.rudderstack.com"
 
 class JavaCompatTest {
 
     @MockK
-    private lateinit var mockApplication: Application
+    private lateinit var mockJavaAnalytics: JavaAnalytics
 
-    private lateinit var javaAnalytics: JavaAnalytics
     private lateinit var javaCompat: JavaCompat
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
 
-        javaAnalytics = spyk(JavaCompat.analyticsFactory(mockApplication, WRITE_KEY, DATA_PLANE_URL))
-        javaCompat = JavaCompat(javaAnalytics)
-    }
-
-    @Test
-    fun `when analytics is initialized, then it should be created with the correct parameters`() {
-        javaCompat = JavaCompat(mockApplication, WRITE_KEY, DATA_PLANE_URL)
-
-        assertNotNull(javaCompat)
+        javaCompat = JavaCompat(mockJavaAnalytics)
     }
 
     @Test
@@ -43,12 +28,12 @@ class JavaCompatTest {
         javaCompat.track()
 
         verify(exactly = 1) {
-            javaAnalytics.track(name = any<String>())
-            javaAnalytics.track(name = any<String>(), properties = any<Map<String, Any>>())
-            javaAnalytics.track(name = any<String>(), options = any<RudderOption>())
-            javaAnalytics.track(name = any<String>(), properties = any<Map<String, Any>>(), options = any<RudderOption>())
+            mockJavaAnalytics.track(name = any<String>())
+            mockJavaAnalytics.track(name = any<String>(), properties = any<Map<String, Any>>())
+            mockJavaAnalytics.track(name = any<String>(), options = any<RudderOption>())
+            mockJavaAnalytics.track(name = any<String>(), properties = any<Map<String, Any>>(), options = any<RudderOption>())
         }
-        confirmVerified(javaAnalytics)
+        confirmVerified(mockJavaAnalytics)
     }
 
     @Test
@@ -56,25 +41,25 @@ class JavaCompatTest {
         javaCompat.screen()
 
         verify(exactly = 1) {
-            javaAnalytics.screen(screenName = any<String>())
-            javaAnalytics.screen(screenName = any<String>(), category = any<String>())
-            javaAnalytics.screen(screenName = any<String>(), properties = any<Map<String, Any>>())
-            javaAnalytics.screen(screenName = any<String>(), options = any<RudderOption>())
-            javaAnalytics.screen(
+            mockJavaAnalytics.screen(screenName = any<String>())
+            mockJavaAnalytics.screen(screenName = any<String>(), category = any<String>())
+            mockJavaAnalytics.screen(screenName = any<String>(), properties = any<Map<String, Any>>())
+            mockJavaAnalytics.screen(screenName = any<String>(), options = any<RudderOption>())
+            mockJavaAnalytics.screen(
                 screenName = any<String>(),
                 properties = any<Map<String, Any>>(),
                 options = any<RudderOption>()
             )
-            javaAnalytics.screen(screenName = any<String>(), category = any<String>(), properties = any<Map<String, Any>>())
-            javaAnalytics.screen(screenName = any<String>(), category = any<String>(), options = any<RudderOption>())
-            javaAnalytics.screen(
+            mockJavaAnalytics.screen(screenName = any<String>(), category = any<String>(), properties = any<Map<String, Any>>())
+            mockJavaAnalytics.screen(screenName = any<String>(), category = any<String>(), options = any<RudderOption>())
+            mockJavaAnalytics.screen(
                 screenName = any<String>(),
                 category = any<String>(),
                 properties = any<Map<String, Any>>(),
                 options = any<RudderOption>()
             )
         }
-        confirmVerified(javaAnalytics)
+        confirmVerified(mockJavaAnalytics)
     }
 
     @Test
@@ -82,12 +67,12 @@ class JavaCompatTest {
         javaCompat.group()
 
         verify(exactly = 1) {
-            javaAnalytics.group(groupId = any<String>())
-            javaAnalytics.group(groupId = any<String>(), traits = any<Map<String, Any>>())
-            javaAnalytics.group(groupId = any<String>(), options = any<RudderOption>())
-            javaAnalytics.group(groupId = any<String>(), traits = any<Map<String, Any>>(), options = any<RudderOption>())
+            mockJavaAnalytics.group(groupId = any<String>())
+            mockJavaAnalytics.group(groupId = any<String>(), traits = any<Map<String, Any>>())
+            mockJavaAnalytics.group(groupId = any<String>(), options = any<RudderOption>())
+            mockJavaAnalytics.group(groupId = any<String>(), traits = any<Map<String, Any>>(), options = any<RudderOption>())
         }
-        confirmVerified(javaAnalytics)
+        confirmVerified(mockJavaAnalytics)
     }
 
     @Test
@@ -95,14 +80,14 @@ class JavaCompatTest {
         javaCompat.identify()
 
         verify(exactly = 1) {
-            javaAnalytics.identify(userId = any<String>())
-            javaAnalytics.identify(traits = any<Map<String, Any>>())
-            javaAnalytics.identify(userId = any<String>(), traits = any<Map<String, Any>>())
-            javaAnalytics.identify(userId = any<String>(), options = any<RudderOption>())
-            javaAnalytics.identify(traits = any<Map<String, Any>>(), options = any<RudderOption>())
-            javaAnalytics.identify(userId = any<String>(), traits = any<Map<String, Any>>(), options = any<RudderOption>())
+            mockJavaAnalytics.identify(userId = any<String>())
+            mockJavaAnalytics.identify(traits = any<Map<String, Any>>())
+            mockJavaAnalytics.identify(userId = any<String>(), traits = any<Map<String, Any>>())
+            mockJavaAnalytics.identify(userId = any<String>(), options = any<RudderOption>())
+            mockJavaAnalytics.identify(traits = any<Map<String, Any>>(), options = any<RudderOption>())
+            mockJavaAnalytics.identify(userId = any<String>(), traits = any<Map<String, Any>>(), options = any<RudderOption>())
         }
-        confirmVerified(javaAnalytics)
+        confirmVerified(mockJavaAnalytics)
     }
 
     @Test
@@ -110,11 +95,11 @@ class JavaCompatTest {
         javaCompat.alias()
 
         verify(exactly = 1) {
-            javaAnalytics.alias(newId = any<String>())
-            javaAnalytics.alias(newId = any<String>(), options = any<RudderOption>())
-            javaAnalytics.alias(newId = any<String>(), previousId = any<String>())
-            javaAnalytics.alias(newId = any<String>(), previousId = any<String>(), options = any<RudderOption>())
+            mockJavaAnalytics.alias(newId = any<String>())
+            mockJavaAnalytics.alias(newId = any<String>(), options = any<RudderOption>())
+            mockJavaAnalytics.alias(newId = any<String>(), previousId = any<String>())
+            mockJavaAnalytics.alias(newId = any<String>(), previousId = any<String>(), options = any<RudderOption>())
         }
-        confirmVerified(javaAnalytics)
+        confirmVerified(mockJavaAnalytics)
     }
 }

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -4,12 +4,15 @@ import android.app.Activity
 import androidx.navigation.NavController
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import io.mockk.MockKAnnotations
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -124,7 +127,11 @@ class JavaCompatTest {
             mockJavaAnalytics.track(name = any<String>())
             mockJavaAnalytics.track(name = any<String>(), properties = any<Map<String, Any>>())
             mockJavaAnalytics.track(name = any<String>(), options = any<RudderOption>())
-            mockJavaAnalytics.track(name = any<String>(), properties = any<Map<String, Any>>(), options = any<RudderOption>())
+            mockJavaAnalytics.track(
+                name = any<String>(),
+                properties = any<Map<String, Any>>(),
+                options = any<RudderOption>()
+            )
         }
         confirmVerified(mockJavaAnalytics)
     }
@@ -143,7 +150,11 @@ class JavaCompatTest {
                 properties = any<Map<String, Any>>(),
                 options = any<RudderOption>()
             )
-            mockJavaAnalytics.screen(screenName = any<String>(), category = any<String>(), properties = any<Map<String, Any>>())
+            mockJavaAnalytics.screen(
+                screenName = any<String>(),
+                category = any<String>(),
+                properties = any<Map<String, Any>>()
+            )
             mockJavaAnalytics.screen(screenName = any<String>(), category = any<String>(), options = any<RudderOption>())
             mockJavaAnalytics.screen(
                 screenName = any<String>(),
@@ -178,7 +189,11 @@ class JavaCompatTest {
             mockJavaAnalytics.identify(userId = any<String>(), traits = any<Map<String, Any>>())
             mockJavaAnalytics.identify(userId = any<String>(), options = any<RudderOption>())
             mockJavaAnalytics.identify(traits = any<Map<String, Any>>(), options = any<RudderOption>())
-            mockJavaAnalytics.identify(userId = any<String>(), traits = any<Map<String, Any>>(), options = any<RudderOption>())
+            mockJavaAnalytics.identify(
+                userId = any<String>(),
+                traits = any<Map<String, Any>>(),
+                options = any<RudderOption>()
+            )
         }
         confirmVerified(mockJavaAnalytics)
     }
@@ -234,5 +249,27 @@ class JavaCompatTest {
         val actualTraits = javaCompat.traits
 
         assertEquals(traits, actualTraits)
+    }
+
+    @Test
+    fun `given log level is verbose, when custom logger is set, then all logs should be tracked using custom logger`() {
+        LoggerAnalytics.logLevel = Logger.LogLevel.VERBOSE
+        val customJavaLogger = spyk(JavaCustomLogger())
+        val msg = "Test message"
+        
+        javaCompat.setCustomLogger(customJavaLogger)
+        LoggerAnalytics.verbose(msg)
+        LoggerAnalytics.debug(msg)
+        LoggerAnalytics.info(msg)
+        LoggerAnalytics.warn(msg)
+        LoggerAnalytics.error(msg)
+
+        verify(exactly = 1) {
+            customJavaLogger.verbose(msg)
+            customJavaLogger.debug(msg)
+            customJavaLogger.info(msg)
+            customJavaLogger.warn(msg)
+            customJavaLogger.error(msg)
+        }
     }
 }

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -104,4 +104,17 @@ class JavaCompatTest {
         }
         confirmVerified(javaAnalytics)
     }
+
+    @Test
+    fun `when alias event is made, then it should be tracked`() {
+        javaCompat.alias()
+
+        verify(exactly = 1) {
+            javaAnalytics.alias(newId = any<String>())
+            javaAnalytics.alias(newId = any<String>(), options = any<RudderOption>())
+            javaAnalytics.alias(newId = any<String>(), previousId = any<String>())
+            javaAnalytics.alias(newId = any<String>(), previousId = any<String>(), options = any<RudderOption>())
+        }
+        confirmVerified(javaAnalytics)
+    }
 }

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -1,11 +1,17 @@
 package com.rudderstack.sampleapp.analytics.javacompat
 
+import android.app.Activity
+import androidx.navigation.NavController
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics
+import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import io.mockk.MockKAnnotations
 import io.mockk.confirmVerified
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -22,6 +28,93 @@ class JavaCompatTest {
 
         javaCompat = JavaCompat(mockJavaAnalytics)
     }
+
+    // Android specific tests
+
+    @Test
+    fun `when startSession is called, then it should be tracked`() {
+        javaCompat.startSession()
+        javaCompat.startSession(1234567890L)
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.startSession()
+            mockJavaAnalytics.startSession(sessionId = any<Long>())
+        }
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when endSession is called, then it should be tracked`() {
+        javaCompat.endSession()
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.endSession()
+        }
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when reset is called, then it should be tracked`() {
+        javaCompat.reset()
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.reset()
+        }
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when flush is called, then it should be tracked`() {
+        javaCompat.flush()
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.flush()
+        }
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when plugin is added, then it should be tracked`() {
+        javaCompat.add()
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.add(plugin = any<Plugin>())
+        }
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when plugin is removed, then it should be tracked`() {
+        javaCompat.remove()
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.add(plugin = any<Plugin>())
+            mockJavaAnalytics.remove(plugin = any<Plugin>())
+        }
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when setNavigationDestinationsTracking is called, then it should be tracked`() {
+        val mockNavController = mockk<NavController>(relaxed = true)
+        val mockActivity = mockk<Activity>(relaxed = true)
+        javaCompat.setNavigationDestinationsTracking(mockNavController, mockActivity)
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.setNavigationDestinationsTracking(navController = mockNavController, activity = mockActivity)
+        }
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when sessionId is fetched, then it should be returned`() {
+        val sessionId = 1234567890L
+        every { mockJavaAnalytics.sessionId } returns sessionId
+
+        assertEquals(sessionId, javaCompat.sessionId)
+    }
+
+    // Core specific tests
 
     @Test
     fun `when track event is made, then it should be tracked`() {
@@ -99,6 +192,16 @@ class JavaCompatTest {
             mockJavaAnalytics.alias(newId = any<String>(), options = any<RudderOption>())
             mockJavaAnalytics.alias(newId = any<String>(), previousId = any<String>())
             mockJavaAnalytics.alias(newId = any<String>(), previousId = any<String>(), options = any<RudderOption>())
+        }
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when shutdown is called, then it should be tracked`() {
+        javaCompat.shutdown()
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.shutdown()
         }
         confirmVerified(mockJavaAnalytics)
     }

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -89,4 +89,19 @@ class JavaCompatTest {
         }
         confirmVerified(javaAnalytics)
     }
+
+    @Test
+    fun `when identify event is made, then it should be tracked`() {
+        javaCompat.identify()
+
+        verify(exactly = 1) {
+            javaAnalytics.identify(userId = any<String>())
+            javaAnalytics.identify(traits = any<Map<String, Any>>())
+            javaAnalytics.identify(userId = any<String>(), traits = any<Map<String, Any>>())
+            javaAnalytics.identify(userId = any<String>(), options = any<RudderOption>())
+            javaAnalytics.identify(traits = any<Map<String, Any>>(), options = any<RudderOption>())
+            javaAnalytics.identify(userId = any<String>(), traits = any<Map<String, Any>>(), options = any<RudderOption>())
+        }
+        confirmVerified(javaAnalytics)
+    }
 }

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -1,0 +1,60 @@
+package com.rudderstack.sampleapp.analytics.javacompat
+
+import android.app.Application
+import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
+import com.rudderstack.sdk.kotlin.core.javacompat.JavaAnalytics
+import io.mockk.MockKAnnotations
+import io.mockk.confirmVerified
+import io.mockk.impl.annotations.MockK
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+private const val WRITE_KEY = "test_write_key"
+private const val DATA_PLANE_URL = "https://test.rudderstack.com"
+
+class JavaCompatTest {
+
+    @MockK
+    private lateinit var application: Application
+
+    private lateinit var javaAnalytics: JavaAnalytics
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        javaAnalytics = spyk(JavaCompat.initAnalytics(application, WRITE_KEY, DATA_PLANE_URL))
+    }
+
+    @Test
+    fun `when track event is made, then it should be tracked`() {
+        JavaCompat.track(javaAnalytics)
+
+        verify(exactly = 1) {
+            javaAnalytics.track(name = any<String>())
+            javaAnalytics.track(name = any<String>(), properties = any<Map<String, Any>>())
+            javaAnalytics.track(name = any<String>(), options = any<RudderOption>())
+            javaAnalytics.track(name = any<String>(), properties = any<Map<String, Any>>(), options = any<RudderOption>())
+        }
+        confirmVerified(javaAnalytics)
+    }
+
+    @Test
+    fun `when screen event is made, then it should be tracked`() {
+        JavaCompat.screen(javaAnalytics)
+
+        verify(exactly = 1) {
+            javaAnalytics.screen(screenName = any<String>())
+            javaAnalytics.screen(screenName = any<String>(), category = any<String>())
+            javaAnalytics.screen(screenName = any<String>(), properties = any<Map<String, Any>>())
+            javaAnalytics.screen(screenName = any<String>(), options = any<RudderOption>())
+            javaAnalytics.screen(screenName = any<String>(), properties = any<Map<String, Any>>(), options = any<RudderOption>())
+            javaAnalytics.screen(screenName = any<String>(), category = any<String>(), properties = any<Map<String, Any>>())
+            javaAnalytics.screen(screenName = any<String>(), category = any<String>(), options = any<RudderOption>())
+            javaAnalytics.screen(screenName = any<String>(), category = any<String>(), properties = any<Map<String, Any>>(), options = any<RudderOption>())
+        }
+        confirmVerified(javaAnalytics)
+    }
+}

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -76,4 +76,17 @@ class JavaCompatTest {
         }
         confirmVerified(javaAnalytics)
     }
+
+    @Test
+    fun `when group event is made, then it should be tracked`() {
+        javaCompat.group()
+
+        verify(exactly = 1) {
+            javaAnalytics.group(groupId = any<String>())
+            javaAnalytics.group(groupId = any<String>(), traits = any<Map<String, Any>>())
+            javaAnalytics.group(groupId = any<String>(), options = any<RudderOption>())
+            javaAnalytics.group(groupId = any<String>(), traits = any<Map<String, Any>>(), options = any<RudderOption>())
+        }
+        confirmVerified(javaAnalytics)
+    }
 }

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -8,6 +8,7 @@ import io.mockk.confirmVerified
 import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -17,20 +18,29 @@ private const val DATA_PLANE_URL = "https://test.rudderstack.com"
 class JavaCompatTest {
 
     @MockK
-    private lateinit var application: Application
+    private lateinit var mockApplication: Application
 
     private lateinit var javaAnalytics: JavaAnalytics
+    private lateinit var javaCompat: JavaCompat
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
 
-        javaAnalytics = spyk(JavaCompat.initAnalytics(application, WRITE_KEY, DATA_PLANE_URL))
+        javaAnalytics = spyk(JavaCompat.analyticsFactory(mockApplication, WRITE_KEY, DATA_PLANE_URL))
+        javaCompat = JavaCompat(javaAnalytics)
+    }
+
+    @Test
+    fun `when analytics is initialized, then it should be created with the correct parameters`() {
+        javaCompat = JavaCompat(mockApplication, WRITE_KEY, DATA_PLANE_URL)
+
+        assertNotNull(javaCompat)
     }
 
     @Test
     fun `when track event is made, then it should be tracked`() {
-        JavaCompat.track(javaAnalytics)
+        javaCompat.track()
 
         verify(exactly = 1) {
             javaAnalytics.track(name = any<String>())
@@ -43,17 +53,26 @@ class JavaCompatTest {
 
     @Test
     fun `when screen event is made, then it should be tracked`() {
-        JavaCompat.screen(javaAnalytics)
+        javaCompat.screen()
 
         verify(exactly = 1) {
             javaAnalytics.screen(screenName = any<String>())
             javaAnalytics.screen(screenName = any<String>(), category = any<String>())
             javaAnalytics.screen(screenName = any<String>(), properties = any<Map<String, Any>>())
             javaAnalytics.screen(screenName = any<String>(), options = any<RudderOption>())
-            javaAnalytics.screen(screenName = any<String>(), properties = any<Map<String, Any>>(), options = any<RudderOption>())
+            javaAnalytics.screen(
+                screenName = any<String>(),
+                properties = any<Map<String, Any>>(),
+                options = any<RudderOption>()
+            )
             javaAnalytics.screen(screenName = any<String>(), category = any<String>(), properties = any<Map<String, Any>>())
             javaAnalytics.screen(screenName = any<String>(), category = any<String>(), options = any<RudderOption>())
-            javaAnalytics.screen(screenName = any<String>(), category = any<String>(), properties = any<Map<String, Any>>(), options = any<RudderOption>())
+            javaAnalytics.screen(
+                screenName = any<String>(),
+                category = any<String>(),
+                properties = any<Map<String, Any>>(),
+                options = any<RudderOption>()
+            )
         }
         confirmVerified(javaAnalytics)
     }

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -205,4 +205,34 @@ class JavaCompatTest {
         }
         confirmVerified(mockJavaAnalytics)
     }
+
+    @Test
+    fun `when anonymousId is fetched, then it should be returned`() {
+        val anonymousId = "anonymousId"
+        every { mockJavaAnalytics.anonymousId } returns anonymousId
+
+        val actualAnonymousId = javaCompat.anonymousId
+
+        assertEquals(anonymousId, actualAnonymousId)
+    }
+
+    @Test
+    fun `when userId is fetched, then it should be returned`() {
+        val userId = "userId"
+        every { mockJavaAnalytics.userId } returns userId
+
+        val actualUserId = javaCompat.userId
+
+        assertEquals(userId, actualUserId)
+    }
+
+    @Test
+    fun `when traits is fetched, then it should be returned`() {
+        val traits: Map<String, Any> = mapOf("key-1" to "value-1")
+        every { mockJavaAnalytics.traits } returns traits
+
+        val actualTraits = javaCompat.traits
+
+        assertEquals(traits, actualTraits)
+    }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Configuration.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Configuration.kt
@@ -7,6 +7,7 @@ import com.rudderstack.sdk.kotlin.core.internals.policies.CountFlushPolicy
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
 import com.rudderstack.sdk.kotlin.core.internals.policies.FrequencyFlushPolicy
 import com.rudderstack.sdk.kotlin.core.internals.policies.StartupFlushPolicy
+import org.jetbrains.annotations.VisibleForTesting
 
 /**
  * The `Configuration` class is used to configure the SDK's settings for network communication, logging, data storage, and more.
@@ -44,10 +45,18 @@ open class Configuration @JvmOverloads constructor(
          * which define the conditions under which events are flushed to the server.
          */
         val DEFAULT_FLUSH_POLICIES: List<FlushPolicy>
-            get() = listOf(
-                CountFlushPolicy(),
-                FrequencyFlushPolicy(),
-                StartupFlushPolicy(),
-            )
+            get() = provideListOfFlushPolicies()
     }
 }
+
+/**
+ * Provides a list of default flush policies used for sending events to the data plane.
+ *
+ * @return A list of flush policies, including `CountFlushPolicy`, `FrequencyFlushPolicy`, and `StartupFlushPolicy`.
+ */
+@VisibleForTesting
+fun provideListOfFlushPolicies() = listOf(
+    CountFlushPolicy(),
+    FrequencyFlushPolicy(),
+    StartupFlushPolicy(),
+)

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Configuration.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Configuration.kt
@@ -45,7 +45,7 @@ open class Configuration @JvmOverloads constructor(
          * which define the conditions under which events are flushed to the server.
          */
         val DEFAULT_FLUSH_POLICIES: List<FlushPolicy>
-            get() = provideListOfFlushPolicies()
+            get() = provideDefaultFlushPolicies()
     }
 }
 
@@ -55,7 +55,7 @@ open class Configuration @JvmOverloads constructor(
  * @return A list of flush policies, including `CountFlushPolicy`, `FrequencyFlushPolicy`, and `StartupFlushPolicy`.
  */
 @VisibleForTesting
-fun provideListOfFlushPolicies() = listOf(
+fun provideDefaultFlushPolicies() = listOf(
     CountFlushPolicy(),
     FrequencyFlushPolicy(),
     StartupFlushPolicy(),

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilder.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilder.kt
@@ -4,7 +4,6 @@ import com.rudderstack.sdk.kotlin.core.Configuration
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_CONTROL_PLANE_URL
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_FLUSH_POLICIES
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_GZIP_STATUS
-import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
 
 /**
@@ -18,7 +17,6 @@ open class ConfigurationBuilder(
 ) {
 
     private var controlPlaneUrl: String = DEFAULT_CONTROL_PLANE_URL
-    private var logLevel: Logger.LogLevel = Logger.DEFAULT_LOG_LEVEL
     private var gzipEnabled: Boolean = DEFAULT_GZIP_STATUS
     private var flushPolicies: List<FlushPolicy> = DEFAULT_FLUSH_POLICIES
 
@@ -27,13 +25,6 @@ open class ConfigurationBuilder(
      */
     open fun setControlPlaneUrl(url: String) = apply {
         controlPlaneUrl = url
-    }
-
-    /**
-     * Sets the log level.
-     */
-    open fun setLogLevel(level: Logger.LogLevel) = apply {
-        logLevel = level
     }
 
     /**
@@ -58,7 +49,6 @@ open class ConfigurationBuilder(
             writeKey = writeKey,
             dataPlaneUrl = dataPlaneUrl,
             controlPlaneUrl = controlPlaneUrl,
-            logLevel = logLevel,
             flushPolicies = flushPolicies,
             gzipEnabled = gzipEnabled
         )

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilder.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilder.kt
@@ -1,0 +1,66 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.Configuration
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_CONTROL_PLANE_URL
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_FLUSH_POLICIES
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_GZIP_STATUS
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
+
+/**
+ * Builder class for creating Configuration instances.
+ *
+ * This builder class provides Java interop support for configuring the SDK's settings.
+ */
+open class ConfigurationBuilder(
+    private val writeKey: String,
+    private val dataPlaneUrl: String,
+) {
+
+    private var controlPlaneUrl: String = DEFAULT_CONTROL_PLANE_URL
+    private var logLevel: Logger.LogLevel = Logger.DEFAULT_LOG_LEVEL
+    private var gzipEnabled: Boolean = DEFAULT_GZIP_STATUS
+    private var flushPolicies: List<FlushPolicy> = DEFAULT_FLUSH_POLICIES
+
+    /**
+     * Sets the control plane URL.
+     */
+    fun setControlPlaneUrl(url: String) = apply {
+        controlPlaneUrl = url
+    }
+
+    /**
+     * Sets the log level.
+     */
+    fun setLogLevel(level: Logger.LogLevel) = apply {
+        logLevel = level
+    }
+
+    /**
+     * Sets the flush policies.
+     */
+    fun setFlushPolicies(policies: List<FlushPolicy>) = apply {
+        flushPolicies = policies
+    }
+
+    /**
+     * Sets whether to enable GZIP compression.
+     */
+    fun setGzipEnabled(enabled: Boolean) = apply {
+        gzipEnabled = enabled
+    }
+
+    /**
+     * Builds the Configuration instance with the configured properties.
+     */
+    open fun build(): Configuration {
+        return Configuration(
+            writeKey = writeKey,
+            dataPlaneUrl = dataPlaneUrl,
+            controlPlaneUrl = controlPlaneUrl,
+            logLevel = logLevel,
+            flushPolicies = flushPolicies,
+            gzipEnabled = gzipEnabled
+        )
+    }
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilder.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilder.kt
@@ -25,28 +25,28 @@ open class ConfigurationBuilder(
     /**
      * Sets the control plane URL.
      */
-    fun setControlPlaneUrl(url: String) = apply {
+    open fun setControlPlaneUrl(url: String) = apply {
         controlPlaneUrl = url
     }
 
     /**
      * Sets the log level.
      */
-    fun setLogLevel(level: Logger.LogLevel) = apply {
+    open fun setLogLevel(level: Logger.LogLevel) = apply {
         logLevel = level
     }
 
     /**
      * Sets the flush policies.
      */
-    fun setFlushPolicies(policies: List<FlushPolicy>) = apply {
+    open fun setFlushPolicies(policies: List<FlushPolicy>) = apply {
         flushPolicies = policies
     }
 
     /**
      * Sets whether to enable GZIP compression.
      */
-    fun setGzipEnabled(enabled: Boolean) = apply {
+    open fun setGzipEnabled(enabled: Boolean) = apply {
         gzipEnabled = enabled
     }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -42,6 +42,16 @@ open class JavaAnalytics protected constructor(
     }
 
     /**
+     * Tracks an event with the specified name and options.
+     *
+     * @param name The name of the event to track.
+     * @param options Additional options for tracking the event.
+     */
+    fun track(name: String, options: RudderOption) {
+        analytics.track(name = name, options = options)
+    }
+
+    /**
      * Tracks an event with the specified name, properties, and options.
      *
      * @param name The name of the event to track.
@@ -50,15 +60,5 @@ open class JavaAnalytics protected constructor(
      */
     fun track(name: String, properties: Map<String, Any>, options: RudderOption) {
         analytics.track(name = name, properties = fromMap(properties), options = options)
-    }
-
-    /**
-     * Tracks an event with the specified name and options.
-     *
-     * @param name The name of the event to track.
-     * @param options Additional options for tracking the event.
-     */
-    fun track(name: String, options: RudderOption) {
-        analytics.track(name = name, options = options)
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -29,7 +29,7 @@ open class JavaAnalytics protected constructor(
      *
      * @param name The name of the event to track.
      */
-    fun track(name: String,) {
+    fun track(name: String) {
         analytics.track(name = name)
     }
 
@@ -249,6 +249,46 @@ open class JavaAnalytics protected constructor(
      */
     fun identify(userId: String, traits: Map<String, Any>, options: RudderOption) {
         analytics.identify(userId = userId, traits = fromMap(traits), options = options)
+    }
+
+    /**
+     * The `alias` event allows merging multiple identities of a known user into a single unified profile.
+     *
+     * @param newId The new identifier to be associated with the user, representing the updated or primary user ID.
+     */
+    fun alias(newId: String) {
+        analytics.alias(newId = newId)
+    }
+
+    /**
+     * The `alias` event allows merging multiple identities of a known user into a single unified profile.
+     *
+     * @param newId The new identifier to be associated with the user, representing the updated or primary user ID.
+     * @param options A [RudderOption] object to specify additional event options.
+     */
+    fun alias(newId: String, options: RudderOption) {
+        analytics.alias(newId = newId, options = options)
+    }
+
+    /**
+     * The `alias` event allows merging multiple identities of a known user into a single unified profile.
+     *
+     * @param newId The new identifier to be associated with the user, representing the updated or primary user ID.
+     * @param previousId The previous ID tied to the user, which may be a user-provided value or fall back on prior identifiers.
+     */
+    fun alias(newId: String, previousId: String) {
+        analytics.alias(newId = newId, previousId = previousId)
+    }
+
+    /**
+     * The `alias` event allows merging multiple identities of a known user into a single unified profile.
+     *
+     * @param newId The new identifier to be associated with the user, representing the updated or primary user ID.
+     * @param previousId The previous ID tied to the user, which may be a user-provided value or fall back on prior identifiers.
+     * @param options A [RudderOption] object to specify additional event options.
+     */
+    fun alias(newId: String, previousId: String, options: RudderOption) {
+        analytics.alias(newId = newId, previousId = previousId, options = options)
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.VisibleForTesting
  * This class provides method overloads to ensure Java compatibility with the Kotlin Analytics API.
  * It delegates all operations to the underlying Analytics implementation.
  */
+@Suppress("TooManyFunctions")
 open class JavaAnalytics protected constructor(
     private val analytics: Analytics
 ) {
@@ -46,7 +47,7 @@ open class JavaAnalytics protected constructor(
      * Tracks an event with the specified name and options.
      *
      * @param name The name of the event to track.
-     * @param options Additional options for tracking the event.
+     * @param options A [RudderOption] object to specify additional event options.
      */
     fun track(name: String, options: RudderOption) {
         analytics.track(name = name, options = options)
@@ -57,7 +58,7 @@ open class JavaAnalytics protected constructor(
      *
      * @param name The name of the event to track.
      * @param properties A map of properties associated with the event.
-     * @param options Additional options for tracking the event.
+     * @param options A [RudderOption] object to specify additional event options.
      */
     fun track(name: String, properties: Map<String, Any>, options: RudderOption) {
         analytics.track(name = name, properties = fromMap(properties), options = options)
@@ -96,7 +97,7 @@ open class JavaAnalytics protected constructor(
      * Tracks a screen view event with the specified screen name and options.
      *
      * @param screenName The name of the screen being viewed.
-     * @param options Additional options for tracking the screen view event.
+     * @param options A [RudderOption] object to specify additional event options.
      */
     fun screen(screenName: String, options: RudderOption) {
         analytics.screen(screenName = screenName, options = options)
@@ -118,7 +119,7 @@ open class JavaAnalytics protected constructor(
      *
      * @param screenName The name of the screen being viewed.
      * @param category The category of the screen.
-     * @param options Additional options for tracking the screen view event.
+     * @param options A [RudderOption] object to specify additional event options.
      */
     fun screen(screenName: String, category: String, options: RudderOption) {
         analytics.screen(screenName = screenName, category = category, options = options)
@@ -129,7 +130,7 @@ open class JavaAnalytics protected constructor(
      *
      * @param screenName The name of the screen being viewed.
      * @param properties A map of additional properties associated with the screen view.
-     * @param options Additional options for tracking the screen view event.
+     * @param options A [RudderOption] object to specify additional event options.
      */
     fun screen(screenName: String, properties: Map<String, Any>, options: RudderOption) {
         analytics.screen(screenName = screenName, properties = fromMap(properties), options = options)
@@ -141,10 +142,50 @@ open class JavaAnalytics protected constructor(
      * @param screenName The name of the screen being viewed.
      * @param category The category of the screen.
      * @param properties A map of additional properties associated with the screen view.
-     * @param options Additional options for tracking the screen view event.
+     * @param options A [RudderOption] object to specify additional event options.
      */
     fun screen(screenName: String, category: String, properties: Map<String, Any>, options: RudderOption) {
         analytics.screen(screenName = screenName, category = category, properties = fromMap(properties), options = options)
+    }
+
+    /**
+     * Add the user to a group.
+     *
+     * @param groupId The unique identifier for the group.
+     */
+    fun group(groupId: String) {
+        analytics.group(groupId = groupId)
+    }
+
+    /**
+     * Add the user to a group.
+     *
+     * @param groupId The unique identifier for the group.
+     * @param traits A [RudderOption] object to specify additional event options.
+     */
+    fun group(groupId: String, traits: Map<String, Any>) {
+        analytics.group(groupId = groupId, traits = fromMap(traits))
+    }
+
+    /**
+     * Add the user to a group.
+     *
+     * @param groupId The unique identifier for the group.
+     * @param options A [RudderOption] object to specify additional event options.
+     */
+    fun group(groupId: String, options: RudderOption) {
+        analytics.group(groupId = groupId, options = options)
+    }
+
+    /**
+     * Add the user to a group.
+     *
+     * @param groupId The unique identifier for the group.
+     * @param traits A map containing additional information about the group.
+     * @param options A [RudderOption] object to specify additional event options.
+     */
+    fun group(groupId: String, traits: Map<String, Any>, options: RudderOption) {
+        analytics.group(groupId = groupId, traits = fromMap(traits), options = options)
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -40,7 +40,7 @@ open class JavaAnalytics protected constructor(
     /**
      * Get the user traits.
      */
-    val traits: Map<String, Any>?
+    val traits: Map<String, Any?>?
         get() = analytics.traits?.toMap()
 
     /**
@@ -58,7 +58,7 @@ open class JavaAnalytics protected constructor(
      * @param name The name of the event to track.
      * @param properties A map of properties associated with the event.
      */
-    fun track(name: String, properties: Map<String, Any>) {
+    fun track(name: String, properties: Map<String, Any?>) {
         analytics.track(name = name, properties = fromMap(properties))
     }
 
@@ -79,7 +79,7 @@ open class JavaAnalytics protected constructor(
      * @param properties A map of properties associated with the event.
      * @param options A [RudderOption] object to specify additional event options.
      */
-    fun track(name: String, properties: Map<String, Any>, options: RudderOption) {
+    fun track(name: String, properties: Map<String, Any?>, options: RudderOption) {
         analytics.track(name = name, properties = fromMap(properties), options = options)
     }
 
@@ -108,7 +108,7 @@ open class JavaAnalytics protected constructor(
      * @param screenName The name of the screen being viewed.
      * @param properties A map of additional properties associated with the screen view.
      */
-    fun screen(screenName: String, properties: Map<String, Any>) {
+    fun screen(screenName: String, properties: Map<String, Any?>) {
         analytics.screen(screenName = screenName, properties = fromMap(properties))
     }
 
@@ -129,7 +129,7 @@ open class JavaAnalytics protected constructor(
      * @param category The category of the screen.
      * @param properties A map of additional properties associated with the screen view.
      */
-    fun screen(screenName: String, category: String, properties: Map<String, Any>) {
+    fun screen(screenName: String, category: String, properties: Map<String, Any?>) {
         analytics.screen(screenName = screenName, category = category, properties = fromMap(properties))
     }
 
@@ -151,7 +151,7 @@ open class JavaAnalytics protected constructor(
      * @param properties A map of additional properties associated with the screen view.
      * @param options A [RudderOption] object to specify additional event options.
      */
-    fun screen(screenName: String, properties: Map<String, Any>, options: RudderOption) {
+    fun screen(screenName: String, properties: Map<String, Any?>, options: RudderOption) {
         analytics.screen(screenName = screenName, properties = fromMap(properties), options = options)
     }
 
@@ -163,7 +163,7 @@ open class JavaAnalytics protected constructor(
      * @param properties A map of additional properties associated with the screen view.
      * @param options A [RudderOption] object to specify additional event options.
      */
-    fun screen(screenName: String, category: String, properties: Map<String, Any>, options: RudderOption) {
+    fun screen(screenName: String, category: String, properties: Map<String, Any?>, options: RudderOption) {
         analytics.screen(screenName = screenName, category = category, properties = fromMap(properties), options = options)
     }
 
@@ -182,7 +182,7 @@ open class JavaAnalytics protected constructor(
      * @param groupId The unique identifier for the group.
      * @param traits A [RudderOption] object to specify additional event options.
      */
-    fun group(groupId: String, traits: Map<String, Any>) {
+    fun group(groupId: String, traits: Map<String, Any?>) {
         analytics.group(groupId = groupId, traits = fromMap(traits))
     }
 
@@ -203,7 +203,7 @@ open class JavaAnalytics protected constructor(
      * @param traits A map containing additional information about the group.
      * @param options A [RudderOption] object to specify additional event options.
      */
-    fun group(groupId: String, traits: Map<String, Any>, options: RudderOption) {
+    fun group(groupId: String, traits: Map<String, Any?>, options: RudderOption) {
         analytics.group(groupId = groupId, traits = fromMap(traits), options = options)
     }
 
@@ -221,7 +221,7 @@ open class JavaAnalytics protected constructor(
      *
      * @param traits A map of properties or characteristics associated with the current user.
      */
-    fun identify(traits: Map<String, Any>) {
+    fun identify(traits: Map<String, Any?>) {
         analytics.identify(traits = fromMap(traits))
     }
 
@@ -232,7 +232,7 @@ open class JavaAnalytics protected constructor(
      * @param userId The unique identifier for the user.
      * @param traits A map of properties or characteristics associated with the user.
      */
-    fun identify(userId: String, traits: Map<String, Any>) {
+    fun identify(userId: String, traits: Map<String, Any?>) {
         analytics.identify(userId = userId, traits = fromMap(traits))
     }
 
@@ -254,7 +254,7 @@ open class JavaAnalytics protected constructor(
      * @param traits A map of properties or characteristics associated with the current user.
      * @param options A [RudderOption] object to specify additional event options.
      */
-    fun identify(traits: Map<String, Any>, options: RudderOption) {
+    fun identify(traits: Map<String, Any?>, options: RudderOption) {
         analytics.identify(traits = fromMap(traits), options = options)
     }
 
@@ -266,7 +266,7 @@ open class JavaAnalytics protected constructor(
      * @param traits A map of properties or characteristics associated with the user.
      * @param options A [RudderOption] object to specify additional event options.
      */
-    fun identify(userId: String, traits: Map<String, Any>, options: RudderOption) {
+    fun identify(userId: String, traits: Map<String, Any?>, options: RudderOption) {
         analytics.identify(userId = userId, traits = fromMap(traits), options = options)
     }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -187,6 +187,69 @@ open class JavaAnalytics protected constructor(
     fun group(groupId: String, traits: Map<String, Any>, options: RudderOption) {
         analytics.group(groupId = groupId, traits = fromMap(traits), options = options)
     }
+
+    /**
+     * Identifies a user with the specified user ID.
+     *
+     * @param userId The unique identifier for the user.
+     */
+    fun identify(userId: String) {
+        analytics.identify(userId = userId)
+    }
+
+    /**
+     * Identifies a user with the specified traits.
+     *
+     * @param traits A map of properties or characteristics associated with the current user.
+     */
+    fun identify(traits: Map<String, Any>) {
+        analytics.identify(traits = fromMap(traits))
+    }
+
+    /**
+     * The `identify` event allows you to identify a visiting user and associate their actions to that `userId`.
+     * It also lets you record traits about the user like their name, email address, etc.
+     *
+     * @param userId The unique identifier for the user.
+     * @param traits A map of properties or characteristics associated with the user.
+     */
+    fun identify(userId: String, traits: Map<String, Any>) {
+        analytics.identify(userId = userId, traits = fromMap(traits))
+    }
+
+    /**
+     * The `identify` event allows you to identify a visiting user and associate their actions to that `userId`.
+     * It also lets you record traits about the user like their name, email address, etc.
+     *
+     * @param userId The unique identifier for the user.
+     * @param options A [RudderOption] object to specify additional event options.
+     */
+    fun identify(userId: String, options: RudderOption) {
+        analytics.identify(userId = userId, options = options)
+    }
+
+    /**
+     * The `identify` event allows you to identify a visiting user and associate their actions to that `userId`.
+     * It also lets you record traits about the user like their name, email address, etc.
+     *
+     * @param traits A map of properties or characteristics associated with the current user.
+     * @param options A [RudderOption] object to specify additional event options.
+     */
+    fun identify(traits: Map<String, Any>, options: RudderOption) {
+        analytics.identify(traits = fromMap(traits), options = options)
+    }
+
+    /**
+     * The `identify` event allows you to identify a visiting user and associate their actions to that `userId`.
+     * It also lets you record traits about the user like their name, email address, etc.
+     *
+     * @param userId The unique identifier for the user.
+     * @param traits A map of properties or characteristics associated with the user.
+     * @param options A [RudderOption] object to specify additional event options.
+     */
+    fun identify(userId: String, traits: Map<String, Any>, options: RudderOption) {
+        analytics.identify(userId = userId, traits = fromMap(traits), options = options)
+    }
 }
 
 @VisibleForTesting

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -1,0 +1,64 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.Analytics
+import com.rudderstack.sdk.kotlin.core.Configuration
+import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
+import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromMap
+
+/**
+ * JavaAnalytics is a Java-compatible wrapper around the Analytics class.
+ *
+ * This class provides method overloads to ensure Java compatibility with the Kotlin Analytics API.
+ * It delegates all operations to the underlying Analytics implementation.
+ */
+open class JavaAnalytics protected constructor(
+    private val analytics: Analytics
+) {
+
+    /**
+     * Creates a JavaAnalytics instance with the provided configuration.
+     *
+     * @param configuration The configuration to initialize the Analytics instance with.
+     */
+    constructor(configuration: Configuration) : this(Analytics(configuration = configuration))
+
+    /**
+     * Tracks an event with the specified name.
+     *
+     * @param name The name of the event to track.
+     */
+    fun track(name: String,) {
+        analytics.track(name = name)
+    }
+
+    /**
+     * Tracks an event with the specified name and properties.
+     *
+     * @param name The name of the event to track.
+     * @param properties A map of properties associated with the event.
+     */
+    fun track(name: String, properties: Map<String, Any>) {
+        analytics.track(name = name, properties = fromMap(properties))
+    }
+
+    /**
+     * Tracks an event with the specified name, properties, and options.
+     *
+     * @param name The name of the event to track.
+     * @param properties A map of properties associated with the event.
+     * @param options Additional options for tracking the event.
+     */
+    fun track(name: String, properties: Map<String, Any>, options: RudderOption) {
+        analytics.track(name = name, properties = fromMap(properties), options = options)
+    }
+
+    /**
+     * Tracks an event with the specified name and options.
+     *
+     * @param name The name of the event to track.
+     * @param options Additional options for tracking the event.
+     */
+    fun track(name: String, options: RudderOption) {
+        analytics.track(name = name, options = options)
+    }
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -3,6 +3,7 @@ package com.rudderstack.sdk.kotlin.core.javacompat
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.Configuration
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
+import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromMap
 import org.jetbrains.annotations.VisibleForTesting
 
@@ -23,6 +24,24 @@ open class JavaAnalytics protected constructor(
      * @param configuration The configuration to initialize the Analytics instance with.
      */
     constructor(configuration: Configuration) : this(provideAnalyticsInstance(configuration))
+
+    /**
+     * Get the anonymous ID.
+     */
+    val anonymousId: String?
+        get() = analytics.anonymousId
+
+    /**
+     * Get the user ID.
+     */
+    val userId: String?
+        get() = analytics.userId
+
+    /**
+     * Get the user traits.
+     */
+    val traits: Map<String, Any>?
+        get() = analytics.traits?.toMap()
 
     /**
      * Tracks an event with the specified name.
@@ -292,10 +311,38 @@ open class JavaAnalytics protected constructor(
     }
 
     /**
+     * Forces immediate dispatch of any queued analytics events
+     */
+    open fun flush() {
+        analytics.flush()
+    }
+
+    /**
      * Shuts down the analytics instance, releasing any resources and stopping event processing.
      */
     fun shutdown() {
         analytics.shutdown()
+    }
+
+    /**
+     * Registers a custom plugin to extend analytics functionality
+     */
+    open fun add(plugin: Plugin) {
+        analytics.add(plugin)
+    }
+
+    /**
+     * Removes a previously registered plugin from the analytics instance
+     */
+    open fun remove(plugin: Plugin) {
+        analytics.remove(plugin)
+    }
+
+    /**
+     * Clears all user data and identifiers from the analytics instance
+     */
+    open fun reset() {
+        analytics.reset()
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -290,6 +290,13 @@ open class JavaAnalytics protected constructor(
     fun alias(newId: String, previousId: String, options: RudderOption) {
         analytics.alias(newId = newId, previousId = previousId, options = options)
     }
+
+    /**
+     * Shuts down the analytics instance, releasing any resources and stopping event processing.
+     */
+    fun shutdown() {
+        analytics.shutdown()
+    }
 }
 
 @VisibleForTesting

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -4,6 +4,7 @@ import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.Configuration
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromMap
+import org.jetbrains.annotations.VisibleForTesting
 
 /**
  * JavaAnalytics is a Java-compatible wrapper around the Analytics class.
@@ -20,7 +21,7 @@ open class JavaAnalytics protected constructor(
      *
      * @param configuration The configuration to initialize the Analytics instance with.
      */
-    constructor(configuration: Configuration) : this(Analytics(configuration = configuration))
+    constructor(configuration: Configuration) : this(provideAnalyticsInstance(configuration))
 
     /**
      * Tracks an event with the specified name.
@@ -61,4 +62,91 @@ open class JavaAnalytics protected constructor(
     fun track(name: String, properties: Map<String, Any>, options: RudderOption) {
         analytics.track(name = name, properties = fromMap(properties), options = options)
     }
+
+    /**
+     * Tracks a screen view event with the specified screen name.
+     *
+     * @param screenName The name of the screen being viewed.
+     */
+    fun screen(screenName: String) {
+        analytics.screen(screenName = screenName)
+    }
+
+    /**
+     * Tracks a screen view event with the specified screen name and category.
+     *
+     * @param screenName The name of the screen being viewed.
+     * @param category The category of the screen.
+     */
+    fun screen(screenName: String, category: String) {
+        analytics.screen(screenName = screenName, category = category)
+    }
+
+    /**
+     * Tracks a screen view event with the specified screen name and properties.
+     *
+     * @param screenName The name of the screen being viewed.
+     * @param properties A map of additional properties associated with the screen view.
+     */
+    fun screen(screenName: String, properties: Map<String, Any>) {
+        analytics.screen(screenName = screenName, properties = fromMap(properties))
+    }
+
+    /**
+     * Tracks a screen view event with the specified screen name and options.
+     *
+     * @param screenName The name of the screen being viewed.
+     * @param options Additional options for tracking the screen view event.
+     */
+    fun screen(screenName: String, options: RudderOption) {
+        analytics.screen(screenName = screenName, options = options)
+    }
+
+    /**
+     * Tracks a screen view event with the specified screen name, category, and properties.
+     *
+     * @param screenName The name of the screen being viewed.
+     * @param category The category of the screen.
+     * @param properties A map of additional properties associated with the screen view.
+     */
+    fun screen(screenName: String, category: String, properties: Map<String, Any>) {
+        analytics.screen(screenName = screenName, category = category, properties = fromMap(properties))
+    }
+
+    /**
+     * Tracks a screen view event with the specified screen name, category, and options.
+     *
+     * @param screenName The name of the screen being viewed.
+     * @param category The category of the screen.
+     * @param options Additional options for tracking the screen view event.
+     */
+    fun screen(screenName: String, category: String, options: RudderOption) {
+        analytics.screen(screenName = screenName, category = category, options = options)
+    }
+
+    /**
+     * Tracks a screen view event with the specified screen name, properties, and options.
+     *
+     * @param screenName The name of the screen being viewed.
+     * @param properties A map of additional properties associated with the screen view.
+     * @param options Additional options for tracking the screen view event.
+     */
+    fun screen(screenName: String, properties: Map<String, Any>, options: RudderOption) {
+        analytics.screen(screenName = screenName, properties = fromMap(properties), options = options)
+    }
+
+    /**
+     * Tracks a screen view event with the specified screen name, category, properties, and options.
+     *
+     * @param screenName The name of the screen being viewed.
+     * @param category The category of the screen.
+     * @param properties A map of additional properties associated with the screen view.
+     * @param options Additional options for tracking the screen view event.
+     */
+    fun screen(screenName: String, category: String, properties: Map<String, Any>, options: RudderOption) {
+        analytics.screen(screenName = screenName, category = category, properties = fromMap(properties), options = options)
+    }
 }
+
+@VisibleForTesting
+internal fun provideAnalyticsInstance(configuration: Configuration) = Analytics(configuration = configuration)

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -4,7 +4,8 @@ import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.Configuration
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
-import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromMap
+import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.toJsonObject
+import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.toRawMap
 import org.jetbrains.annotations.VisibleForTesting
 
 /**
@@ -41,7 +42,7 @@ open class JavaAnalytics protected constructor(
      * Get the user traits.
      */
     val traits: Map<String, Any?>?
-        get() = analytics.traits?.toMap()
+        get() = analytics.traits?.toRawMap()
 
     /**
      * Tracks an event with the specified name.
@@ -59,7 +60,7 @@ open class JavaAnalytics protected constructor(
      * @param properties A map of properties associated with the event.
      */
     fun track(name: String, properties: Map<String, Any?>) {
-        analytics.track(name = name, properties = fromMap(properties))
+        analytics.track(name = name, properties = properties.toJsonObject())
     }
 
     /**
@@ -80,7 +81,7 @@ open class JavaAnalytics protected constructor(
      * @param options A [RudderOption] object to specify additional event options.
      */
     fun track(name: String, properties: Map<String, Any?>, options: RudderOption) {
-        analytics.track(name = name, properties = fromMap(properties), options = options)
+        analytics.track(name = name, properties = properties.toJsonObject(), options = options)
     }
 
     /**
@@ -109,7 +110,7 @@ open class JavaAnalytics protected constructor(
      * @param properties A map of additional properties associated with the screen view.
      */
     fun screen(screenName: String, properties: Map<String, Any?>) {
-        analytics.screen(screenName = screenName, properties = fromMap(properties))
+        analytics.screen(screenName = screenName, properties = properties.toJsonObject())
     }
 
     /**
@@ -130,7 +131,7 @@ open class JavaAnalytics protected constructor(
      * @param properties A map of additional properties associated with the screen view.
      */
     fun screen(screenName: String, category: String, properties: Map<String, Any?>) {
-        analytics.screen(screenName = screenName, category = category, properties = fromMap(properties))
+        analytics.screen(screenName = screenName, category = category, properties = properties.toJsonObject())
     }
 
     /**
@@ -152,7 +153,7 @@ open class JavaAnalytics protected constructor(
      * @param options A [RudderOption] object to specify additional event options.
      */
     fun screen(screenName: String, properties: Map<String, Any?>, options: RudderOption) {
-        analytics.screen(screenName = screenName, properties = fromMap(properties), options = options)
+        analytics.screen(screenName = screenName, properties = properties.toJsonObject(), options = options)
     }
 
     /**
@@ -164,7 +165,12 @@ open class JavaAnalytics protected constructor(
      * @param options A [RudderOption] object to specify additional event options.
      */
     fun screen(screenName: String, category: String, properties: Map<String, Any?>, options: RudderOption) {
-        analytics.screen(screenName = screenName, category = category, properties = fromMap(properties), options = options)
+        analytics.screen(
+            screenName = screenName,
+            category = category,
+            properties = properties.toJsonObject(),
+            options = options
+        )
     }
 
     /**
@@ -183,7 +189,7 @@ open class JavaAnalytics protected constructor(
      * @param traits A [RudderOption] object to specify additional event options.
      */
     fun group(groupId: String, traits: Map<String, Any?>) {
-        analytics.group(groupId = groupId, traits = fromMap(traits))
+        analytics.group(groupId = groupId, traits = traits.toJsonObject())
     }
 
     /**
@@ -204,7 +210,7 @@ open class JavaAnalytics protected constructor(
      * @param options A [RudderOption] object to specify additional event options.
      */
     fun group(groupId: String, traits: Map<String, Any?>, options: RudderOption) {
-        analytics.group(groupId = groupId, traits = fromMap(traits), options = options)
+        analytics.group(groupId = groupId, traits = traits.toJsonObject(), options = options)
     }
 
     /**
@@ -222,7 +228,7 @@ open class JavaAnalytics protected constructor(
      * @param traits A map of properties or characteristics associated with the current user.
      */
     fun identify(traits: Map<String, Any?>) {
-        analytics.identify(traits = fromMap(traits))
+        analytics.identify(traits = traits.toJsonObject())
     }
 
     /**
@@ -233,7 +239,7 @@ open class JavaAnalytics protected constructor(
      * @param traits A map of properties or characteristics associated with the user.
      */
     fun identify(userId: String, traits: Map<String, Any?>) {
-        analytics.identify(userId = userId, traits = fromMap(traits))
+        analytics.identify(userId = userId, traits = traits.toJsonObject())
     }
 
     /**
@@ -255,7 +261,7 @@ open class JavaAnalytics protected constructor(
      * @param options A [RudderOption] object to specify additional event options.
      */
     fun identify(traits: Map<String, Any?>, options: RudderOption) {
-        analytics.identify(traits = fromMap(traits), options = options)
+        analytics.identify(traits = traits.toJsonObject(), options = options)
     }
 
     /**
@@ -267,7 +273,7 @@ open class JavaAnalytics protected constructor(
      * @param options A [RudderOption] object to specify additional event options.
      */
     fun identify(userId: String, traits: Map<String, Any?>, options: RudderOption) {
-        analytics.identify(userId = userId, traits = fromMap(traits), options = options)
+        analytics.identify(userId = userId, traits = traits.toJsonObject(), options = options)
     }
 
     /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
@@ -16,17 +16,14 @@ import kotlin.jvm.Throws
 internal object JsonInteropHelper {
 
     /**
-     * Converts a Map with String keys and Any values to a JsonObject.
-     *
-     * This static method is accessible from Java code to enable seamless conversion
-     * from Java Map objects to Kotlin's serializable JsonObject type.
+     * Converts a Map with String keys and Any? values to a JsonObject.
      *
      * @param map The map to convert to a JsonObject
      * @return A JsonObject representation of the input map
      */
     @JvmStatic
     @Throws(IllegalArgumentException::class)
-    internal fun fromMap(map: Map<String, Any>): JsonObject {
+    internal fun fromMap(map: Map<String, Any?>): JsonObject {
         val content = map.mapValues { (_, value) -> toJsonElement(value) }
         return JsonObject(content)
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
@@ -43,15 +43,18 @@ internal object JsonInteropHelper {
         is Boolean -> JsonPrimitive(value)
         is Number -> JsonPrimitive(value)
         is String -> JsonPrimitive(value)
+
         is Map<*, *> -> {
             val stringKeyMap = value.entries
                 .filter { it.key is String }
                 .associate { it.key as String to toJsonElement(it.value) }
             JsonObject(stringKeyMap)
         }
+
         is List<*> -> {
             JsonArray(value.map { toJsonElement(it) })
         }
+
         else -> throw IllegalArgumentException("Unsupported type: ${value::class}")
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
@@ -1,0 +1,57 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.jvm.Throws
+
+/**
+ * Helper object for interoperability between Java Maps and Kotlin's JsonObject.
+ *
+ * Provides utility functions to convert between standard Java/Kotlin data structures and
+ * kotlinx.serialization's JSON types.
+ */
+object JsonInteropHelper {
+
+    /**
+     * Converts a Map with String keys and Any values to a JsonObject.
+     *
+     * This static method is accessible from Java code to enable seamless conversion
+     * from Java Map objects to Kotlin's serializable JsonObject type.
+     *
+     * @param map The map to convert to a JsonObject
+     * @return A JsonObject representation of the input map
+     */
+    @JvmStatic
+    @Throws(IllegalArgumentException::class)
+    fun fromMap(map: Map<String, Any>): JsonObject {
+        val content = map.mapValues { (_, value) -> toJsonElement(value) }
+        return JsonObject(content)
+    }
+
+    /**
+     * Recursively converts various types to their appropriate JsonElement representation.
+     *
+     * @param value The value to convert to a JsonElement
+     * @return The corresponding JsonElement for the input value
+     * @throws IllegalArgumentException if the value type is not supported
+     */
+    private fun toJsonElement(value: Any?): JsonElement = when (value) {
+        null -> JsonNull
+        is Boolean -> JsonPrimitive(value)
+        is Number -> JsonPrimitive(value)
+        is String -> JsonPrimitive(value)
+        is Map<*, *> -> {
+            val stringKeyMap = value.entries
+                .filter { it.key is String }
+                .associate { it.key as String to toJsonElement(it.value) }
+            JsonObject(stringKeyMap)
+        }
+        is List<*> -> {
+            JsonArray(value.map { toJsonElement(it) })
+        }
+        else -> throw IllegalArgumentException("Unsupported type: ${value::class}")
+    }
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
@@ -5,6 +5,14 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.longOrNull
 import kotlin.jvm.Throws
 
 /**
@@ -23,8 +31,8 @@ internal object JsonInteropHelper {
      */
     @JvmStatic
     @Throws(IllegalArgumentException::class)
-    internal fun fromMap(map: Map<String, Any?>): JsonObject {
-        val content = map.mapValues { (_, value) -> toJsonElement(value) }
+    internal fun Map<String, Any?>.toJsonObject(): JsonObject {
+        val content = this.mapValues { (_, value) -> toJsonElement(value) }
         return JsonObject(content)
     }
 
@@ -53,5 +61,34 @@ internal object JsonInteropHelper {
         }
 
         else -> throw IllegalArgumentException("Unsupported type: ${value::class}")
+    }
+
+    internal fun JsonObject.toRawMap(): Map<String, Any?> {
+        val result = mutableMapOf<String, Any?>()
+
+        for ((key, jsonElement) in this) {
+            result[key] = extractValue(jsonElement)
+        }
+
+        return result
+    }
+
+    private fun extractValue(element: JsonElement?): Any? {
+        return when (element) {
+            JsonNull, null -> null
+
+            is JsonPrimitive -> when {
+                element.isString -> element.content
+                element.booleanOrNull != null -> element.boolean
+                element.intOrNull != null -> element.int
+                element.longOrNull != null -> element.long
+                element.doubleOrNull != null -> element.double
+                else -> element.content
+            }
+
+            is JsonObject -> element.toRawMap()
+
+            is JsonArray -> element.map { extractValue(it) }
+        }
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelper.kt
@@ -13,7 +13,7 @@ import kotlin.jvm.Throws
  * Provides utility functions to convert between standard Java/Kotlin data structures and
  * kotlinx.serialization's JSON types.
  */
-object JsonInteropHelper {
+internal object JsonInteropHelper {
 
     /**
      * Converts a Map with String keys and Any values to a JsonObject.
@@ -26,7 +26,7 @@ object JsonInteropHelper {
      */
     @JvmStatic
     @Throws(IllegalArgumentException::class)
-    fun fromMap(map: Map<String, Any>): JsonObject {
+    internal fun fromMap(map: Map<String, Any>): JsonObject {
         val content = map.mapValues { (_, value) -> toJsonElement(value) }
         return JsonObject(content)
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/RudderOptionBuilder.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/RudderOptionBuilder.kt
@@ -3,7 +3,7 @@ package com.rudderstack.sdk.kotlin.core.javacompat
 import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
-import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromMap
+import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.toJsonObject
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -25,7 +25,7 @@ class RudderOptionBuilder {
      * @return This RudderOptionBuilder instance for method chaining
      */
     fun setIntegrations(integrations: Map<String, Any>): RudderOptionBuilder {
-        this.integrations = fromMap(integrations)
+        this.integrations = integrations.toJsonObject()
         return this
     }
 
@@ -47,7 +47,7 @@ class RudderOptionBuilder {
      * @return This RudderOptionBuilder instance for method chaining
      */
     fun setCustomContext(customContext: Map<String, Any>): RudderOptionBuilder {
-        this.customContext = fromMap(customContext)
+        this.customContext = customContext.toJsonObject()
         return this
     }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/RudderOptionBuilder.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/RudderOptionBuilder.kt
@@ -1,0 +1,66 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
+import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
+import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
+import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.fromMap
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * A Java-friendly wrapper for constructing RudderOption instances.
+ *
+ * This class provides a builder pattern and Java-compatible methods to construct
+ * and manipulate RudderOption instances from Java code.
+ */
+class RudderOptionBuilder {
+
+    private var integrations: JsonObject = emptyJsonObject
+    private var externalIds: List<ExternalId> = emptyList()
+    private var customContext: JsonObject = emptyJsonObject
+
+    /**
+     * Sets the integrations for this RudderOption.
+     *
+     * @param integrations A map representing the integrations to be set
+     * @return This RudderOptionBuilder instance for method chaining
+     */
+    fun setIntegrations(integrations: Map<String, Any>): RudderOptionBuilder {
+        this.integrations = fromMap(integrations)
+        return this
+    }
+
+    /**
+     * Sets the external IDs for this RudderOption.
+     *
+     * @param externalIds A list of ExternalId objects to be added
+     * @return This RudderOptionBuilder instance for method chaining
+     */
+    fun setExternalId(externalIds: List<ExternalId>): RudderOptionBuilder {
+        this.externalIds = externalIds
+        return this
+    }
+
+    /**
+     * Sets the custom context for this RudderOption.
+     *
+     * @param customContext A map representing the custom context
+     * @return This RudderOptionBuilder instance for method chaining
+     */
+    fun setCustomContext(customContext: Map<String, Any>): RudderOptionBuilder {
+        this.customContext = fromMap(customContext)
+        return this
+    }
+
+    /**
+     * Builds and returns a RudderOption instance with the configured values.
+     *
+     * @return A RudderOption instance
+     */
+    fun build(): RudderOption {
+        return RudderOption(
+            integrations = integrations,
+            externalIds = externalIds,
+            customContext = customContext
+        )
+    }
+}

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
@@ -17,6 +17,12 @@ import io.mockk.spyk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import java.io.BufferedReader
 
 const val ANONYMOUS_ID = "<anonymous-id>"
@@ -98,4 +104,90 @@ internal fun provideRudderOption() = RudderOption(
     integrations = provideSampleIntegrationsPayload(),
     customContext = provideSampleJsonPayload(),
     externalIds = provideSampleExternalIdsPayload(),
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+internal fun provideJsonObject(): JsonObject = buildJsonObject {
+    // Basic primitives
+    put("stringKey", "stringValue")
+    put("intKey", 42)
+    put("doubleKey", 3.14)
+    put("booleanKey", true)
+    put("nullKey", null)
+
+    // Empty values
+    put("emptyString", "")
+    put("emptyArray", buildJsonArray {})
+    put("emptyObject", buildJsonObject {})
+
+    // Existing nested structure
+    put("level1", buildJsonObject {
+        put("level2", buildJsonArray {
+            add(buildJsonObject { put("name1", "item1") })
+            add(buildJsonObject { put("name2", "item2") })
+            add(buildJsonObject { put("name3", null) })
+        })
+    })
+
+    // Additional complex structures
+    put("arrayOfPrimitives", buildJsonArray {
+        add("string")
+        add(123)
+        add(false)
+        add(null)
+    })
+
+    // Deeply nested structure
+    put("deep", buildJsonObject {
+        put("level1", buildJsonObject {
+            put("level2", buildJsonObject {
+                put("level3", buildJsonArray {
+                    add(buildJsonObject {
+                        put("key", "value")
+                        put("number", 999)
+                    })
+                })
+            })
+        })
+    })
+}
+
+internal fun provideMap() = mapOf(
+    // Basic primitives
+    "stringKey" to "stringValue",
+    "intKey" to 42,
+    "doubleKey" to 3.14,
+    "booleanKey" to true,
+    "nullKey" to null,
+
+    // Empty values
+    "emptyString" to "",
+    "emptyArray" to emptyList<Any>(),
+    "emptyObject" to emptyMap<String, Any>(),
+
+    // Existing nested structure
+    "level1" to mapOf(
+        "level2" to listOf(
+            mapOf("name1" to "item1"),
+            mapOf("name2" to "item2"),
+            mapOf("name3" to null)
+        )
+    ),
+
+    // Additional complex structures
+    "arrayOfPrimitives" to listOf("string", 123, false, null),
+
+    // Deeply nested structure
+    "deep" to mapOf(
+        "level1" to mapOf(
+            "level2" to mapOf(
+                "level3" to listOf(
+                    mapOf(
+                        "key" to "value",
+                        "number" to 999
+                    )
+                )
+            )
+        )
+    )
 )

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
@@ -1,0 +1,86 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.Configuration
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
+import io.mockk.MockKAnnotations
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ConfigurationBuilderTest {
+
+    private lateinit var configurationBuilder: ConfigurationBuilder
+    private val testWriteKey = "test-write-key"
+    private val testDataPlaneUrl = "https://test-data-plane.com"
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+        configurationBuilder = ConfigurationBuilder(testWriteKey, testDataPlaneUrl)
+    }
+
+    @Test
+    fun `when setControlPlaneUrl is set with a custom URL, then controlPlaneUrl should be updated`() {
+        val testControlPlaneUrl = "https://test-control-plane.com"
+        val config = configurationBuilder.setControlPlaneUrl(testControlPlaneUrl).build()
+
+        assertEquals(testControlPlaneUrl, config.controlPlaneUrl)
+    }
+
+    @Test
+    fun `when setLogLevel is set with a custom level, then logLevel should be updated`() {
+        val config = configurationBuilder.setLogLevel(Logger.LogLevel.VERBOSE).build()
+
+        assertEquals(Logger.LogLevel.VERBOSE, config.logLevel)
+    }
+
+    @Test
+    fun `when setFlushPolicies is set with custom policies, then flushPolicies should be updated`() {
+        val customPolicies = listOf<FlushPolicy>()
+        val config = configurationBuilder.setFlushPolicies(customPolicies).build()
+
+        assertEquals(customPolicies, config.flushPolicies)
+    }
+
+    @Test
+    fun `when setGzipEnabled is set to false, then gzipEnabled should be false`() {
+        val config = configurationBuilder.setGzipEnabled(false).build()
+
+        assertFalse(config.gzipEnabled)
+    }
+
+    @Test
+    fun `when all custom configurations are set, then the Configuration object should reflect those values`() {
+        val customPolicies = listOf<FlushPolicy>()
+        val testControlPlaneUrl = "https://test-control-plane.com"
+
+        val actualConfiguration = configurationBuilder
+            .setControlPlaneUrl(testControlPlaneUrl)
+            .setLogLevel(Logger.LogLevel.NONE)
+            .setFlushPolicies(customPolicies)
+            .setGzipEnabled(false)
+            .build()
+
+        val expectedConfiguration = Configuration(
+            writeKey = testWriteKey,
+            dataPlaneUrl = testDataPlaneUrl,
+            controlPlaneUrl = testControlPlaneUrl,
+            logLevel = Logger.LogLevel.NONE,
+            flushPolicies = customPolicies,
+            gzipEnabled = false,
+        )
+
+        // As core, Configuration class is not a data class, we cannot use assertEquals directly
+        with(actualConfiguration) {
+            assertEquals(expectedConfiguration.writeKey, writeKey)
+            assertEquals(expectedConfiguration.dataPlaneUrl, dataPlaneUrl)
+            assertEquals(expectedConfiguration.controlPlaneUrl, controlPlaneUrl)
+            assertEquals(expectedConfiguration.logLevel, logLevel)
+            assertEquals(expectedConfiguration.flushPolicies, flushPolicies)
+            assertEquals(expectedConfiguration.gzipEnabled, gzipEnabled)
+        }
+    }
+}
+

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
@@ -1,6 +1,9 @@
 package com.rudderstack.sdk.kotlin.core.javacompat
 
 import com.rudderstack.sdk.kotlin.core.Configuration
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_CONTROL_PLANE_URL
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_FLUSH_POLICIES
+import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_GZIP_STATUS
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
 import io.mockk.MockKAnnotations
@@ -9,24 +12,40 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+private const val TEST_WRITE_KEY = "test-write-key"
+private const val TEST_DATA_PLANE_URL = "https://test-data-plane.com"
+private const val TEST_CONTROL_PLANE_URL = "https://test-control-plane.com"
+
 class ConfigurationBuilderTest {
 
     private lateinit var configurationBuilder: ConfigurationBuilder
-    private val testWriteKey = "test-write-key"
-    private val testDataPlaneUrl = "https://test-data-plane.com"
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        configurationBuilder = ConfigurationBuilder(testWriteKey, testDataPlaneUrl)
+        configurationBuilder = ConfigurationBuilder(TEST_WRITE_KEY, TEST_DATA_PLANE_URL)
+    }
+
+    @Test
+    fun `when Configuration object is created with only default values, then it should have default values`() {
+        val configuration = configurationBuilder.build()
+
+        // As core, Configuration class is not a data class, we cannot use assertEquals directly
+        configuration.also {
+            assertEquals(TEST_WRITE_KEY, it.writeKey)
+            assertEquals(TEST_DATA_PLANE_URL, it.dataPlaneUrl)
+            assertEquals(DEFAULT_CONTROL_PLANE_URL, it.controlPlaneUrl)
+            assertEquals(Logger.DEFAULT_LOG_LEVEL, it.logLevel)
+            assertEquals(DEFAULT_FLUSH_POLICIES, it.flushPolicies)
+            assertEquals(DEFAULT_GZIP_STATUS, it.gzipEnabled)
+        }
     }
 
     @Test
     fun `when setControlPlaneUrl is set with a custom URL, then controlPlaneUrl should be updated`() {
-        val testControlPlaneUrl = "https://test-control-plane.com"
-        val config = configurationBuilder.setControlPlaneUrl(testControlPlaneUrl).build()
+        val config = configurationBuilder.setControlPlaneUrl(TEST_CONTROL_PLANE_URL).build()
 
-        assertEquals(testControlPlaneUrl, config.controlPlaneUrl)
+        assertEquals(TEST_CONTROL_PLANE_URL, config.controlPlaneUrl)
     }
 
     @Test
@@ -39,6 +58,7 @@ class ConfigurationBuilderTest {
     @Test
     fun `when setFlushPolicies is set with custom policies, then flushPolicies should be updated`() {
         val customPolicies = listOf<FlushPolicy>()
+
         val config = configurationBuilder.setFlushPolicies(customPolicies).build()
 
         assertEquals(customPolicies, config.flushPolicies)
@@ -54,24 +74,22 @@ class ConfigurationBuilderTest {
     @Test
     fun `when all custom configurations are set, then the Configuration object should reflect those values`() {
         val customPolicies = listOf<FlushPolicy>()
-        val testControlPlaneUrl = "https://test-control-plane.com"
 
         val actualConfiguration = configurationBuilder
-            .setControlPlaneUrl(testControlPlaneUrl)
+            .setControlPlaneUrl(TEST_CONTROL_PLANE_URL)
             .setLogLevel(Logger.LogLevel.NONE)
             .setFlushPolicies(customPolicies)
             .setGzipEnabled(false)
             .build()
 
         val expectedConfiguration = Configuration(
-            writeKey = testWriteKey,
-            dataPlaneUrl = testDataPlaneUrl,
-            controlPlaneUrl = testControlPlaneUrl,
+            writeKey = TEST_WRITE_KEY,
+            dataPlaneUrl = TEST_DATA_PLANE_URL,
+            controlPlaneUrl = TEST_CONTROL_PLANE_URL,
             logLevel = Logger.LogLevel.NONE,
             flushPolicies = customPolicies,
             gzipEnabled = false,
         )
-
         // As core, Configuration class is not a data class, we cannot use assertEquals directly
         with(actualConfiguration) {
             assertEquals(expectedConfiguration.writeKey, writeKey)

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
@@ -7,6 +7,9 @@ import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_GZIP_STAT
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
 import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
@@ -18,11 +21,17 @@ private const val TEST_CONTROL_PLANE_URL = "https://test-control-plane.com"
 
 class ConfigurationBuilderTest {
 
+    private lateinit var mockPolicies: List<FlushPolicy>
     private lateinit var configurationBuilder: ConfigurationBuilder
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
+        mockkObject(Configuration.Companion)
+
+        mockPolicies = listOf(mockk(), mockk(), mockk())
+        every { DEFAULT_FLUSH_POLICIES } returns mockPolicies
+        
         configurationBuilder = ConfigurationBuilder(TEST_WRITE_KEY, TEST_DATA_PLANE_URL)
     }
 

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
@@ -4,7 +4,6 @@ import com.rudderstack.sdk.kotlin.core.Configuration
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_CONTROL_PLANE_URL
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_FLUSH_POLICIES
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_GZIP_STATUS
-import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
 import io.mockk.MockKAnnotations
 import io.mockk.every

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ConfigurationBuilderTest.kt
@@ -35,7 +35,6 @@ class ConfigurationBuilderTest {
             assertEquals(TEST_WRITE_KEY, it.writeKey)
             assertEquals(TEST_DATA_PLANE_URL, it.dataPlaneUrl)
             assertEquals(DEFAULT_CONTROL_PLANE_URL, it.controlPlaneUrl)
-            assertEquals(Logger.DEFAULT_LOG_LEVEL, it.logLevel)
             assertEquals(DEFAULT_FLUSH_POLICIES, it.flushPolicies)
             assertEquals(DEFAULT_GZIP_STATUS, it.gzipEnabled)
         }
@@ -46,13 +45,6 @@ class ConfigurationBuilderTest {
         val config = configurationBuilder.setControlPlaneUrl(TEST_CONTROL_PLANE_URL).build()
 
         assertEquals(TEST_CONTROL_PLANE_URL, config.controlPlaneUrl)
-    }
-
-    @Test
-    fun `when setLogLevel is set with a custom level, then logLevel should be updated`() {
-        val config = configurationBuilder.setLogLevel(Logger.LogLevel.VERBOSE).build()
-
-        assertEquals(Logger.LogLevel.VERBOSE, config.logLevel)
     }
 
     @Test
@@ -77,7 +69,6 @@ class ConfigurationBuilderTest {
 
         val actualConfiguration = configurationBuilder
             .setControlPlaneUrl(TEST_CONTROL_PLANE_URL)
-            .setLogLevel(Logger.LogLevel.NONE)
             .setFlushPolicies(customPolicies)
             .setGzipEnabled(false)
             .build()
@@ -86,7 +77,6 @@ class ConfigurationBuilderTest {
             writeKey = TEST_WRITE_KEY,
             dataPlaneUrl = TEST_DATA_PLANE_URL,
             controlPlaneUrl = TEST_CONTROL_PLANE_URL,
-            logLevel = Logger.LogLevel.NONE,
             flushPolicies = customPolicies,
             gzipEnabled = false,
         )
@@ -95,7 +85,6 @@ class ConfigurationBuilderTest {
             assertEquals(expectedConfiguration.writeKey, writeKey)
             assertEquals(expectedConfiguration.dataPlaneUrl, dataPlaneUrl)
             assertEquals(expectedConfiguration.controlPlaneUrl, controlPlaneUrl)
-            assertEquals(expectedConfiguration.logLevel, logLevel)
             assertEquals(expectedConfiguration.flushPolicies, flushPolicies)
             assertEquals(expectedConfiguration.gzipEnabled, gzipEnabled)
         }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
@@ -14,8 +14,10 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.serialization.json.JsonObject
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -40,6 +42,11 @@ class JavaAnalyticsTest {
         every { provideAnalyticsInstance(any()) } returns mockAnalytics
 
         javaAnalytics = JavaAnalytics(mockConfiguration)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(::provideAnalyticsInstance)
     }
 
     @Test

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 private const val SOME_STRING = "some-string"
+private const val EMPTY_STRING = ""
 
 class JavaAnalyticsTest {
 
@@ -124,13 +125,19 @@ class JavaAnalyticsTest {
 
         mockAnalytics.apply {
             verify(exactly = 1) {
-                screen(screenName = SOME_STRING)
+                // NOTE: `category = EMPTY_STRING` is added to make the test pass in the terminal (i.e., while performing git push)
+                screen(screenName = SOME_STRING, category = EMPTY_STRING)
                 screen(screenName = SOME_STRING, category = SOME_STRING)
-                screen(screenName = SOME_STRING, properties = provideJsonObject())
-                screen(screenName = SOME_STRING, options = provideRudderOption())
+                screen(screenName = SOME_STRING, properties = provideJsonObject(), category = EMPTY_STRING)
+                screen(screenName = SOME_STRING, options = provideRudderOption(), category = EMPTY_STRING)
                 screen(screenName = SOME_STRING, category = SOME_STRING, properties = provideJsonObject())
                 screen(screenName = SOME_STRING, category = SOME_STRING, options = provideRudderOption())
-                screen(screenName = SOME_STRING, properties = provideJsonObject(), options = provideRudderOption())
+                screen(
+                    screenName = SOME_STRING,
+                    properties = provideJsonObject(),
+                    options = provideRudderOption(),
+                    category = EMPTY_STRING
+                )
                 screen(
                     screenName = SOME_STRING,
                     category = SOME_STRING,
@@ -183,11 +190,12 @@ class JavaAnalyticsTest {
 
         mockAnalytics.apply {
             verify(exactly = 1) {
+                // NOTE: `userId = EMPTY_STRING` is added to make the test pass in the terminal (i.e., while performing git push)
                 identify(userId = SOME_STRING)
-                identify(traits = provideJsonObject())
+                identify(traits = provideJsonObject(), userId = EMPTY_STRING)
                 identify(userId = SOME_STRING, traits = provideJsonObject())
                 identify(userId = SOME_STRING, options = provideRudderOption())
-                identify(traits = provideJsonObject(), options = provideRudderOption())
+                identify(traits = provideJsonObject(), options = provideRudderOption(), userId = EMPTY_STRING)
                 identify(userId = SOME_STRING, traits = provideJsonObject(), options = provideRudderOption())
             }
         }
@@ -209,8 +217,9 @@ class JavaAnalyticsTest {
 
         mockAnalytics.apply {
             verify(exactly = 1) {
-                alias(newId = SOME_STRING)
-                alias(newId = SOME_STRING, options = provideRudderOption())
+                // NOTE: `previousId = EMPTY_STRING` is added to make the test pass in the terminal (i.e., while performing git push)
+                alias(newId = SOME_STRING, previousId = EMPTY_STRING)
+                alias(newId = SOME_STRING, options = provideRudderOption(), previousId = EMPTY_STRING)
                 alias(newId = SOME_STRING, previousId = SOME_STRING)
                 alias(newId = SOME_STRING, previousId = SOME_STRING, options = provideRudderOption())
             }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
@@ -1,0 +1,257 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.Analytics
+import com.rudderstack.sdk.kotlin.core.Configuration
+import com.rudderstack.sdk.kotlin.core.assertMapContents
+import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
+import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
+import com.rudderstack.sdk.kotlin.core.provideJsonObject
+import com.rudderstack.sdk.kotlin.core.provideMap
+import com.rudderstack.sdk.kotlin.core.provideRudderOption
+import io.mockk.MockKAnnotations
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlinx.serialization.json.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+private const val SOME_STRING = "some-string"
+
+class JavaAnalyticsTest {
+
+    @MockK
+    private lateinit var mockConfiguration: Configuration
+
+    @MockK
+    private lateinit var mockAnalytics: Analytics
+
+    private lateinit var javaAnalytics: JavaAnalytics
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        mockkStatic(::provideAnalyticsInstance)
+        every { provideAnalyticsInstance(any()) } returns mockAnalytics
+
+        javaAnalytics = JavaAnalytics(mockConfiguration)
+    }
+
+    @Test
+    fun `when anonymousId is fetched, then it should return the value`() {
+        val anonymousId = "anonymous-id"
+        every { mockAnalytics.anonymousId } returns anonymousId
+
+        val actualAnonymousId: String? = javaAnalytics.anonymousId
+
+        assertEquals(anonymousId, actualAnonymousId)
+    }
+
+    @Test
+    fun `when userId is fetched, then it should return the value`() {
+        val userId = "user-id"
+        every { mockAnalytics.userId } returns userId
+
+        val actualUserId: String? = javaAnalytics.userId
+
+        assertEquals(userId, actualUserId)
+    }
+
+    @Test
+    fun `when traits is fetched, then it should return the traits of type map`() {
+        val traits: JsonObject = provideJsonObject()
+        every { mockAnalytics.traits } returns traits
+
+        val actualTraits: Map<String, Any?>? = javaAnalytics.traits
+
+        val expectedTraits = provideMap()
+        assertMapContents(expectedTraits, actualTraits!!)
+    }
+
+    @Test
+    fun `when track call is made, then it should call the track method on Analytics`() {
+        val name = SOME_STRING
+        val properties: Map<String, Any?> = provideMap()
+        val options: RudderOption = provideRudderOption()
+
+        javaAnalytics.apply {
+            track(name = name)
+            track(name = name, properties = properties)
+            track(name = name, options = options)
+            track(name = name, properties = properties, options = options)
+        }
+
+        mockAnalytics.apply {
+            verify(exactly = 1) {
+                track(name = SOME_STRING)
+                track(name = SOME_STRING, properties = provideJsonObject())
+                track(name = SOME_STRING, options = provideRudderOption())
+                track(name = SOME_STRING, properties = provideJsonObject(), options = provideRudderOption())
+            }
+        }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when screen call is made, then it should call the screen method on Analytics`() {
+        val name = SOME_STRING
+        val category = SOME_STRING
+        val properties: Map<String, Any?> = provideMap()
+        val options: RudderOption = provideRudderOption()
+
+        javaAnalytics.apply {
+            screen(screenName = name)
+            screen(screenName = name, category = category)
+            screen(screenName = name, properties = properties)
+            screen(screenName = name, options = options)
+            screen(screenName = name, category = category, properties = properties)
+            screen(screenName = name, category = category, options = options)
+            screen(screenName = name, properties = properties, options = options)
+            screen(screenName = name, category = category, properties = properties, options = options)
+        }
+
+        mockAnalytics.apply {
+            verify(exactly = 1) {
+                screen(screenName = SOME_STRING)
+                screen(screenName = SOME_STRING, category = SOME_STRING)
+                screen(screenName = SOME_STRING, properties = provideJsonObject())
+                screen(screenName = SOME_STRING, options = provideRudderOption())
+                screen(screenName = SOME_STRING, category = SOME_STRING, properties = provideJsonObject())
+                screen(screenName = SOME_STRING, category = SOME_STRING, options = provideRudderOption())
+                screen(screenName = SOME_STRING, properties = provideJsonObject(), options = provideRudderOption())
+                screen(
+                    screenName = SOME_STRING,
+                    category = SOME_STRING,
+                    properties = provideJsonObject(),
+                    options = provideRudderOption()
+                )
+            }
+        }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when group call is made, then it should call the method on Analytics`() {
+        val groupId = SOME_STRING
+        val traits: Map<String, Any?> = provideMap()
+        val options: RudderOption = provideRudderOption()
+
+        javaAnalytics.apply {
+            group(groupId = groupId)
+            group(groupId = groupId, traits = traits)
+            group(groupId = groupId, options = options)
+            group(groupId = groupId, traits = traits, options = options)
+        }
+
+        mockAnalytics.apply {
+            verify(exactly = 1) {
+                group(groupId = SOME_STRING)
+                group(groupId = SOME_STRING, traits = provideJsonObject())
+                group(groupId = SOME_STRING, options = provideRudderOption())
+                group(groupId = SOME_STRING, traits = provideJsonObject(), options = provideRudderOption())
+            }
+        }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when identify call is made, then it should call the method on Analytics`() {
+        val userId = SOME_STRING
+        val traits: Map<String, Any?> = provideMap()
+        val options: RudderOption = provideRudderOption()
+
+        javaAnalytics.apply {
+            identify(userId = userId)
+            identify(traits = traits)
+            identify(userId = userId, traits = traits)
+            identify(userId = userId, options = options)
+            identify(traits = traits, options = options)
+            identify(userId = userId, traits = traits, options = options)
+        }
+
+        mockAnalytics.apply {
+            verify(exactly = 1) {
+                identify(userId = SOME_STRING)
+                identify(traits = provideJsonObject())
+                identify(userId = SOME_STRING, traits = provideJsonObject())
+                identify(userId = SOME_STRING, options = provideRudderOption())
+                identify(traits = provideJsonObject(), options = provideRudderOption())
+                identify(userId = SOME_STRING, traits = provideJsonObject(), options = provideRudderOption())
+            }
+        }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when alias call is made, then it should call the method on Analytics`() {
+        val newId = SOME_STRING
+        val previousId = SOME_STRING
+        val options: RudderOption = provideRudderOption()
+
+        javaAnalytics.apply {
+            alias(newId = newId)
+            alias(newId = newId, options = options)
+            alias(newId = newId, previousId = previousId)
+            alias(newId = newId, previousId = previousId, options = options)
+        }
+
+        mockAnalytics.apply {
+            verify(exactly = 1) {
+                alias(newId = SOME_STRING)
+                alias(newId = SOME_STRING, options = provideRudderOption())
+                alias(newId = SOME_STRING, previousId = SOME_STRING)
+                alias(newId = SOME_STRING, previousId = SOME_STRING, options = provideRudderOption())
+            }
+        }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when flush is called, then it should call the flush method on Analytics`() {
+        javaAnalytics.flush()
+
+        verify(exactly = 1) { mockAnalytics.flush() }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when shutdown is called, then it should call the shutdown method on Analytics`() {
+        javaAnalytics.shutdown()
+
+        verify(exactly = 1) { mockAnalytics.shutdown() }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when plugin is added, then it should call the add method on Analytics`() {
+        val plugin = mockk<Plugin>(relaxed = true)
+
+        javaAnalytics.add(plugin)
+
+        verify(exactly = 1) { mockAnalytics.add(plugin) }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when plugin is removed, then it should call the remove method on Analytics`() {
+        val plugin = mockk<Plugin>(relaxed = true)
+
+        javaAnalytics.remove(plugin)
+
+        verify(exactly = 1) { mockAnalytics.remove(plugin) }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when reset is called, then it should call the reset method on Analytics`() {
+        javaAnalytics.reset()
+
+        verify(exactly = 1) { mockAnalytics.reset() }
+        confirmVerified(mockAnalytics)
+    }
+}

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelperTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelperTest.kt
@@ -1,5 +1,7 @@
 package com.rudderstack.sdk.kotlin.core.javacompat
 
+import com.rudderstack.sdk.kotlin.core.provideJsonObject
+import com.rudderstack.sdk.kotlin.core.provideMap
 import kotlinx.serialization.ExperimentalSerializationApi
 import org.junit.jupiter.api.Test
 
@@ -37,7 +39,7 @@ class JsonInteropHelperTest {
     }
 
     @Test
-    fun `given map with nested map, when converted, then returns correct nested JsonObject`() {
+    fun `given map, with nested map, when converted, then returns correct nested JsonObject`() {
         val originalMap: Map<String, Any?> = mapOf(
             "topLevel" to "value",
             "mapKey" to mapOf(
@@ -63,7 +65,7 @@ class JsonInteropHelperTest {
     }
 
     @Test
-    fun `given map with list when converted then returns correct JsonObject with JsonArray`() {
+    fun `given map with list, when converted, then returns correct JsonObject with JsonArray`() {
         val originalMap: Map<String, Any> = mapOf(
             "listKey" to listOf(1, "two", true, null),
             "emptyList" to emptyList<Any>()
@@ -84,30 +86,12 @@ class JsonInteropHelperTest {
     }
 
     @Test
-    fun `given map with complex nested structure when converted then returns correct JsonObject`() {
-        val deeplyNested: Map<String, Any?> =
-            mapOf(
-                "level1" to mapOf(
-                    "level2" to listOf(
-                        mapOf("name1" to "item1"),
-                        mapOf("name2" to "item2"),
-                        mapOf("name3" to null)
-                    )
-                )
-            )
+    fun `given map with complex nested structure, when converted, then returns correct JsonObject`() {
+        val deeplyNested: Map<String, Any?> = provideMap()
 
         val actualJsonObject = JsonInteropHelper.fromMap(deeplyNested)
 
-        val expectedJson =
-            buildJsonObject {
-                put("level1", buildJsonObject {
-                    put("level2", buildJsonArray {
-                        add(buildJsonObject { put("name1", "item1") })
-                        add(buildJsonObject { put("name2", "item2") })
-                        add(buildJsonObject { put("name3", null) })
-                    })
-                })
-            }
+        val expectedJson = provideJsonObject()
         verifyResult(expectedJson.toString(), actualJsonObject.toString())
     }
 
@@ -122,7 +106,7 @@ class JsonInteropHelperTest {
     }
 
     @Test
-    fun `given map with unsupported type when converted then throws IllegalArgumentException`() {
+    fun `given map with unsupported type, when converted, then throws IllegalArgumentException`() {
         val mapWithUnsupportedType = mapOf(
             "invalidType" to Exception("test")
         )

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelperTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelperTest.kt
@@ -1,5 +1,9 @@
 package com.rudderstack.sdk.kotlin.core.javacompat
 
+import com.rudderstack.sdk.kotlin.core.assertJsonContents
+import com.rudderstack.sdk.kotlin.core.assertMapContents
+import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.toJsonObject
+import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.toRawMap
 import com.rudderstack.sdk.kotlin.core.provideJsonObject
 import com.rudderstack.sdk.kotlin.core.provideMap
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -11,7 +15,6 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.assertThrows
-import org.skyscreamer.jsonassert.JSONAssert
 
 @OptIn(ExperimentalSerializationApi::class)
 class JsonInteropHelperTest {
@@ -26,7 +29,7 @@ class JsonInteropHelperTest {
             "nullKey" to null
         )
 
-        val actualJsonObject: JsonObject = JsonInteropHelper.fromMap(originalMap)
+        val actualJsonObject: JsonObject = originalMap.toJsonObject()
 
         val expectedJson = buildJsonObject {
             put("booleanKey", true)
@@ -35,7 +38,7 @@ class JsonInteropHelperTest {
             put("stringKey", "stringValue")
             put("nullKey", null)
         }
-        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+        assertJsonContents(expectedJson.toString(), actualJsonObject.toString())
     }
 
     @Test
@@ -50,7 +53,7 @@ class JsonInteropHelperTest {
             "emptyMap" to emptyMap<String, Any>()
         )
 
-        val actualJsonObject = JsonInteropHelper.fromMap(originalMap)
+        val actualJsonObject = originalMap.toJsonObject()
 
         val expectedJson = buildJsonObject {
             put("topLevel", "value")
@@ -61,7 +64,7 @@ class JsonInteropHelperTest {
             })
             put("emptyMap", buildJsonObject {})
         }
-        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+        assertJsonContents(expectedJson.toString(), actualJsonObject.toString())
     }
 
     @Test
@@ -71,7 +74,7 @@ class JsonInteropHelperTest {
             "emptyList" to emptyList<Any>()
         )
 
-        val actualJsonObject = JsonInteropHelper.fromMap(originalMap)
+        val actualJsonObject = originalMap.toJsonObject()
 
         val expectedJson = buildJsonObject {
             put("listKey", buildJsonArray {
@@ -82,27 +85,27 @@ class JsonInteropHelperTest {
             })
             put("emptyList", buildJsonArray {})
         }
-        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+        assertJsonContents(expectedJson.toString(), actualJsonObject.toString())
     }
 
     @Test
     fun `given map with complex nested structure, when converted, then returns correct JsonObject`() {
         val deeplyNested: Map<String, Any?> = provideMap()
 
-        val actualJsonObject = JsonInteropHelper.fromMap(deeplyNested)
+        val actualJsonObject = deeplyNested.toJsonObject()
 
         val expectedJson = provideJsonObject()
-        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+        assertJsonContents(expectedJson.toString(), actualJsonObject.toString())
     }
 
     @Test
     fun `given map with empty map, when converted, then returns correct JsonObject`() {
         val emptyMap: Map<String, Any> = emptyMap()
 
-        val actualJsonObject = JsonInteropHelper.fromMap(emptyMap)
+        val actualJsonObject = emptyMap.toJsonObject()
 
         val expectedJson = buildJsonObject {}
-        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+        assertJsonContents(expectedJson.toString(), actualJsonObject.toString())
     }
 
     @Test
@@ -112,11 +115,17 @@ class JsonInteropHelperTest {
         )
 
         assertThrows<IllegalArgumentException> {
-            JsonInteropHelper.fromMap(mapWithUnsupportedType)
+            mapWithUnsupportedType.toJsonObject()
         }
     }
 
-    private fun verifyResult(expected: String, actual: String) {
-        JSONAssert.assertEquals(expected, actual, true)
+    @Test
+    fun `given JsonObject, when converted to map, then returns correct map`() {
+        val jsonObject = provideJsonObject()
+
+        val actualMap = jsonObject.toRawMap()
+
+        val expectedMap = provideMap()
+        assertMapContents(expectedMap, actualMap)
     }
 }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelperTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JsonInteropHelperTest.kt
@@ -1,0 +1,138 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import org.junit.jupiter.api.Test
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.assertThrows
+import org.skyscreamer.jsonassert.JSONAssert
+
+@OptIn(ExperimentalSerializationApi::class)
+class JsonInteropHelperTest {
+
+    @Test
+    fun `given map with primitive values, when converted, then returns correct JsonObject`() {
+        val originalMap: Map<String, Any?> = mapOf(
+            "booleanKey" to true,
+            "doubleKey" to 3.14,
+            "intKey" to 42,
+            "stringKey" to "stringValue",
+            "nullKey" to null
+        )
+
+        val actualJsonObject: JsonObject = JsonInteropHelper.fromMap(originalMap)
+
+        val expectedJson = buildJsonObject {
+            put("booleanKey", true)
+            put("doubleKey", 3.14)
+            put("intKey", 42)
+            put("stringKey", "stringValue")
+            put("nullKey", null)
+        }
+        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+    }
+
+    @Test
+    fun `given map with nested map, when converted, then returns correct nested JsonObject`() {
+        val originalMap: Map<String, Any?> = mapOf(
+            "topLevel" to "value",
+            "mapKey" to mapOf(
+                "nestedKey1" to "nestedValue1",
+                "nestedKey2" to 123,
+                "nestedKey3" to null
+            ),
+            "emptyMap" to emptyMap<String, Any>()
+        )
+
+        val actualJsonObject = JsonInteropHelper.fromMap(originalMap)
+
+        val expectedJson = buildJsonObject {
+            put("topLevel", "value")
+            put("mapKey", buildJsonObject {
+                put("nestedKey1", "nestedValue1")
+                put("nestedKey2", 123)
+                put("nestedKey3", null)
+            })
+            put("emptyMap", buildJsonObject {})
+        }
+        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+    }
+
+    @Test
+    fun `given map with list when converted then returns correct JsonObject with JsonArray`() {
+        val originalMap: Map<String, Any> = mapOf(
+            "listKey" to listOf(1, "two", true, null),
+            "emptyList" to emptyList<Any>()
+        )
+
+        val actualJsonObject = JsonInteropHelper.fromMap(originalMap)
+
+        val expectedJson = buildJsonObject {
+            put("listKey", buildJsonArray {
+                add(1)
+                add("two")
+                add(true)
+                add(null)
+            })
+            put("emptyList", buildJsonArray {})
+        }
+        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+    }
+
+    @Test
+    fun `given map with complex nested structure when converted then returns correct JsonObject`() {
+        val deeplyNested: Map<String, Any?> =
+            mapOf(
+                "level1" to mapOf(
+                    "level2" to listOf(
+                        mapOf("name1" to "item1"),
+                        mapOf("name2" to "item2"),
+                        mapOf("name3" to null)
+                    )
+                )
+            )
+
+        val actualJsonObject = JsonInteropHelper.fromMap(deeplyNested)
+
+        val expectedJson =
+            buildJsonObject {
+                put("level1", buildJsonObject {
+                    put("level2", buildJsonArray {
+                        add(buildJsonObject { put("name1", "item1") })
+                        add(buildJsonObject { put("name2", "item2") })
+                        add(buildJsonObject { put("name3", null) })
+                    })
+                })
+            }
+        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+    }
+
+    @Test
+    fun `given map with empty map, when converted, then returns correct JsonObject`() {
+        val emptyMap: Map<String, Any> = emptyMap()
+
+        val actualJsonObject = JsonInteropHelper.fromMap(emptyMap)
+
+        val expectedJson = buildJsonObject {}
+        verifyResult(expectedJson.toString(), actualJsonObject.toString())
+    }
+
+    @Test
+    fun `given map with unsupported type when converted then throws IllegalArgumentException`() {
+        val mapWithUnsupportedType = mapOf(
+            "invalidType" to Exception("test")
+        )
+
+        assertThrows<IllegalArgumentException> {
+            JsonInteropHelper.fromMap(mapWithUnsupportedType)
+        }
+    }
+
+    private fun verifyResult(expected: String, actual: String) {
+        JSONAssert.assertEquals(expected, actual, true)
+    }
+}

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/RudderOptionBuilderTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/RudderOptionBuilderTest.kt
@@ -1,0 +1,85 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RudderOptionBuilderTest {
+
+    @Test
+    fun `given integrations map, when setIntegrations called, then integrations are set correctly in result`() {
+        val builder = RudderOptionBuilder()
+        val integrations: Map<String, Any> = getMap()
+
+        val result = builder.setIntegrations(integrations).build()
+
+        val expected = getJsonObject()
+        assertEquals(expected, result.integrations)
+    }
+
+    @Test
+    fun `given external ids list, when setExternalId called, then externalIds are set correctly in result`() {
+        val builder = RudderOptionBuilder()
+        val externalIds = getExternalIds()
+
+        val result = builder.setExternalId(externalIds).build()
+
+        assertEquals(externalIds, result.externalIds)
+    }
+
+    @Test
+    fun `given custom context map, when setCustomContext called, then customContext is set correctly in result`() {
+        val builder = RudderOptionBuilder()
+        val customContext = getMap()
+
+        val result = builder.setCustomContext(customContext).build()
+
+        val expected = getJsonObject()
+        assertEquals(expected, result.customContext)
+    }
+
+    @Test
+    fun `when all setters chained, then builds complete RudderOption with all values set`() {
+        val integrations = getMap()
+        val externalIds = getExternalIds()
+        val customContext = getMap()
+
+        val result = RudderOptionBuilder()
+            .setIntegrations(integrations)
+            .setExternalId(externalIds)
+            .setCustomContext(customContext)
+            .build()
+
+        val expectedIntegrations = getJsonObject()
+        val expectedExternalIds = getExternalIds()
+        val expectedCustomContext = getJsonObject()
+        assertEquals(expectedIntegrations, result.integrations)
+        assertEquals(expectedExternalIds, result.externalIds)
+        assertEquals(expectedCustomContext, result.customContext)
+    }
+}
+
+private fun getMap() = mapOf(
+    "All" to true,
+    "Google Analytics" to false,
+    "key-1" to mapOf(
+        "key-2" to "value-2",
+        "key-3" to 23,
+    )
+)
+
+private fun getExternalIds() = listOf(
+    ExternalId("id1", "value1"),
+    ExternalId("id2", "value2")
+)
+
+private fun getJsonObject() = buildJsonObject {
+    put("All", true)
+    put("Google Analytics", false)
+    put("key-1", buildJsonObject {
+        put("key-2", "value-2")
+        put("key-3", 23)
+    })
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ junit-bom = "5.11.4"
 kotlin = "1.9.0"
 kotlinx-coroutines-core = "1.8.0"
 kotlinx-serialization-json = "1.5.1"
-mockk = "1.13.7"
+mockk = "1.13.10"
 lifecycle-process = "2.8.7"
 navigation = "2.8.9"
 nexus = "2.0.0"
@@ -27,6 +27,7 @@ lifecycle-viewmodel-compose = "2.8.7"
 material3-android = "1.3.2"
 navigation-compose = "2.8.9"
 play-services-ads = "23.5.0"
+annotation-jvm = "1.9.1"
 
 ui = "1.7.8"
 
@@ -58,6 +59,7 @@ ui = { module = "androidx.compose.ui:ui", version.ref = "ui" }
 ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "ui" }
 ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
 androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3-android" }
+androidx-annotation-jvm = { group = "androidx.annotation", name = "annotation-jvm", version.ref = "annotation-jvm" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/kotlin-jvm-app/build.gradle.kts
+++ b/kotlin-jvm-app/build.gradle.kts
@@ -13,4 +13,6 @@ kotlin {
 
 dependencies {
     implementation(project(":core"))
+
+    implementation(libs.androidx.annotation.jvm)
 }

--- a/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
+++ b/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
@@ -180,6 +180,7 @@ public class JavaCompat {
         value.put("isActive", true);
         value.put("scores", Arrays.asList(10, 20, 30));
         value.put("details", Map.of("city", "Delhi", "zip", 12345));
+        value.put("isNull", null);
 
         return value;
     }

--- a/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
+++ b/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
@@ -1,0 +1,201 @@
+package com.rudderstack.android.kotlin_jvm_app.javacompat;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
+import com.rudderstack.sdk.kotlin.core.Configuration;
+import com.rudderstack.sdk.kotlin.core.javacompat.ConfigurationBuilder;
+import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId;
+import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
+import com.rudderstack.sdk.kotlin.core.javacompat.JavaAnalytics;
+import com.rudderstack.sdk.kotlin.core.javacompat.RudderOptionBuilder;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class provides a compatibility layer for Java analytics events.
+ * <p>
+ * The main method is at bottom. Use that to make events.
+ */
+public class JavaCompat {
+
+    private final JavaAnalytics analytics;
+
+    public JavaCompat(@NonNull String writeKey, @NonNull String dataPlaneUrl) {
+        analytics = analyticsFactory(writeKey, dataPlaneUrl);
+    }
+
+    @VisibleForTesting
+    public JavaCompat(JavaAnalytics analytics) {
+        this.analytics = analytics;
+    }
+
+    @NonNull
+    private static JavaAnalytics analyticsFactory(@NonNull String writeKey, @NonNull String dataPlaneUrl) {
+        Configuration configuration = new ConfigurationBuilder(writeKey, dataPlaneUrl)
+                .setGzipEnabled(true)
+                .build();
+
+        return new JavaAnalytics(configuration);
+    }
+
+    /**
+     * Make a track event.
+     * <p>
+     * Sample code:
+     *
+     * <pre>{@code
+     * JavaCompat.track();
+     * }</pre>
+     */
+    public void track() {
+        String name = "Sample track event";
+        Map<String, Object> properties = getMap();
+        RudderOption option = getRudderOption();
+
+        analytics.track(name);
+        analytics.track(name, properties);
+        analytics.track(name, option);
+        analytics.track(name, properties, option);
+    }
+
+    /**
+     * Make a screen event.
+     * <p>
+     * Sample code:
+     *
+     * <pre>{@code
+     * JavaCompat.screen();
+     * }</pre>
+     */
+    public void screen() {
+        String screenName = "Sample screen event";
+        String category = "Sample screen category";
+        Map<String, Object> properties = getMap();
+        RudderOption option = getRudderOption();
+
+        analytics.screen(screenName);
+        analytics.screen(screenName, category);
+        analytics.screen(screenName, properties);
+        analytics.screen(screenName, option);
+        analytics.screen(screenName, properties, option);
+        analytics.screen(screenName, category, properties);
+        analytics.screen(screenName, category, option);
+        analytics.screen(screenName, category, properties, option);
+    }
+
+    /**
+     * Make a group event.
+     * <p>
+     * Sample code:
+     *
+     * <pre>{@code
+     * JavaCompat.group();
+     * }</pre>
+     */
+    public void group() {
+        String groupId = "Sample group ID";
+        Map<String, Object> traits = getMap();
+        RudderOption option = getRudderOption();
+
+        analytics.group(groupId);
+        analytics.group(groupId, traits);
+        analytics.group(groupId, option);
+        analytics.group(groupId, traits, option);
+    }
+
+    /**
+     * Make an identify event.
+     * <p>
+     * Sample code:
+     *
+     * <pre>{@code
+     * JavaCompat.identify();
+     * }</pre>
+     */
+    public void identify() {
+        String userId = "Sample user ID";
+        Map<String, Object> traits = getMap();
+        RudderOption option = getRudderOption();
+
+        analytics.identify(userId);
+        analytics.identify(traits);
+        analytics.identify(userId, traits);
+        analytics.identify(userId, option);
+        analytics.identify(traits, option);
+        analytics.identify(userId, traits, option);
+    }
+
+    /**
+     * Make an alias event.
+     * <p>
+     * Sample code:
+     *
+     * <pre>{@code
+     * JavaCompat.alias();
+     * }</pre>
+     */
+    public void alias() {
+        String newId = "Sample alias";
+        String previousId = "Sample previous ID";
+        RudderOption option = getRudderOption();
+
+        analytics.alias(newId);
+        analytics.alias(newId, option);
+        analytics.alias(newId, previousId);
+        analytics.alias(newId, previousId, option);
+    }
+
+    public static void main(String[] args) {
+        // Example usage
+        JavaCompat javaCompat = new JavaCompat("your_write_key", "your_data_plane_url");
+        javaCompat.track();
+        javaCompat.screen();
+        javaCompat.group();
+        javaCompat.identify();
+        javaCompat.alias();
+    }
+
+    @NonNull
+    private static Map<String, Object> getMap() {
+        Map<String, Object> value = new HashMap<>();
+        value.put("key-1", "value-1");
+        value.put("age", 30);
+        value.put("isActive", true);
+        value.put("scores", Arrays.asList(10, 20, 30));
+        value.put("details", Map.of("city", "Delhi", "zip", 12345));
+
+        return value;
+    }
+
+    @NonNull
+    private static RudderOption getRudderOption() {
+        Map<String, Object> integrations = getIntegrations();
+        List<ExternalId> externalIds = getExternalIds();
+        Map<String, Object> customContext = getMap();
+        return new RudderOptionBuilder()
+                .setIntegrations(integrations)
+                .setExternalId(externalIds)
+                .setCustomContext(customContext)
+                .build();
+    }
+
+    @NonNull
+    private static Map<String, Object> getIntegrations() {
+        Map<String, Object> integrations = new LinkedHashMap<>();
+        integrations.put("All", true);
+        integrations.put("Google Analytics", false);
+        return integrations;
+    }
+
+    @NonNull
+    private static List<ExternalId> getExternalIds() {
+        ExternalId externalId1 = new ExternalId("externalId1", "value1");
+        ExternalId externalId2 = new ExternalId("externalId2", "value2");
+        return Arrays.asList(externalId1, externalId2);
+    }
+}

--- a/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
+++ b/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
@@ -1,9 +1,11 @@
 package com.rudderstack.android.kotlin_jvm_app.javacompat;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import com.rudderstack.sdk.kotlin.core.Configuration;
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics;
 import com.rudderstack.sdk.kotlin.core.javacompat.ConfigurationBuilder;
 import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId;
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
@@ -20,6 +22,12 @@ import java.util.Map;
  * This class provides a compatibility layer for Java analytics events.
  * <p>
  * The main method is at bottom. Use that to make events.
+ *
+ * <p>
+ * Sample code:
+ * <pre>{@code
+ * JavaCompat javaCompat = new JavaCompat(writeKey, dataPlaneUrl);
+ * }</pre>
  */
 public class JavaCompat {
 
@@ -45,12 +53,6 @@ public class JavaCompat {
 
     /**
      * Make a track event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * JavaCompat.track();
-     * }</pre>
      */
     public void track() {
         String name = "Sample track event";
@@ -65,12 +67,6 @@ public class JavaCompat {
 
     /**
      * Make a screen event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * JavaCompat.screen();
-     * }</pre>
      */
     public void screen() {
         String screenName = "Sample screen event";
@@ -90,12 +86,6 @@ public class JavaCompat {
 
     /**
      * Make a group event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * JavaCompat.group();
-     * }</pre>
      */
     public void group() {
         String groupId = "Sample group ID";
@@ -110,12 +100,6 @@ public class JavaCompat {
 
     /**
      * Make an identify event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * JavaCompat.identify();
-     * }</pre>
      */
     public void identify() {
         String userId = "Sample user ID";
@@ -132,12 +116,6 @@ public class JavaCompat {
 
     /**
      * Make an alias event.
-     * <p>
-     * Sample code:
-     *
-     * <pre>{@code
-     * JavaCompat.alias();
-     * }</pre>
      */
     public void alias() {
         String newId = "Sample alias";
@@ -150,6 +128,36 @@ public class JavaCompat {
         analytics.alias(newId, previousId, option);
     }
 
+    /**
+     * Get the anonymous ID.
+     *
+     * @return The anonymous ID.
+     */
+    @Nullable
+    public String getAnonymousId() {
+        return analytics.getAnonymousId();
+    }
+
+    /**
+     * Get the user ID.
+     *
+     * @return The user ID.
+     */
+    @Nullable
+    public String getUserId() {
+        return analytics.getUserId();
+    }
+
+    /**
+     * Get the user traits.
+     *
+     * @return The user traits.
+     */
+    @Nullable
+    public Map<String, Object> getTraits() {
+        return analytics.getTraits();
+    }
+
     public static void main(String[] args) {
         // Example usage
         JavaCompat javaCompat = new JavaCompat("your_write_key", "your_data_plane_url");
@@ -158,6 +166,10 @@ public class JavaCompat {
         javaCompat.group();
         javaCompat.identify();
         javaCompat.alias();
+
+        LoggerAnalytics.INSTANCE.verbose("JavaCompat: Anonymous ID: " + javaCompat.getAnonymousId());
+        LoggerAnalytics.INSTANCE.verbose("JavaCompat: User ID: " + javaCompat.getUserId());
+        LoggerAnalytics.INSTANCE.verbose("JavaCompat: User Traits: " + javaCompat.getTraits());
     }
 
     @NonNull


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- Added the Java compatibility support for `Analytics` and `Configuration` classes.
- Also, added sample Java classes to demonstrate how to use the API's and plugins in `Java`.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

### Refactor

- Fix the `android/build.gradle` file nested code.
- In Android
    - Configuration.kt and SessionConfiguration: Replaced hard coded booleans constants with proper defined constants. The reason for that is to promote re-usability in the Builder classes.
    - Test: Added a util method called `provideSessionConfiguration`.

### New feature

- Android:
    - Added `ConfigurationBuilder`: To build the Android `Configuration` object.
    - Added `JavaAnalytics` and `JavaAnalyticsTest`: To initialise the Analytics SDK and access all the public API's.
- Core:
    - Added `ConfigurationBuilder` and `ConfigurationBuilderTest`: To build the core `Configuration` object.
    - Added `JavaAnalytics` and `JavaAnalyticsTest`: To initialise the Analytics SDK and access all the public API's.
    - Added `JsonInteropHelper` and `JsonInteropHelperTest`: Added two `internal` methods 
        - `internal fun Map<String, Any?>.toJsonObject(): JsonObject`: To convert the `Map` type value to `JsonObject`. (This is currently utilised in the public event API to convert the `properties/traits`.)
        - `internal fun `JsonObject.toRawMap(): Map<String, Any?>`: To convert the `JsonObject` type value to `Map`. (This is needed to return the `traits` in `Map`.)
        - **NOTE: Java doesn't support `JsonObject` type. Therefore, we will support `Map` type, and these utility functions will help convert the values to the required types. For now, I've kept it `internal`, as I don't find any concrete use case to expose it to the user.** 
    - Added `RudderOptionBuilder`: To build the `RudderOption` object.
    - Tests: Added some util methods.

### Sample app

- Android:
    - Added a `CustomJavaPlugin` in Java: 
        - This class implements the Plugins interface. Our Plugin interface is fully supported in Java.
        - A compatibility class written in Java. This class can help us in testing the public API's.
    - Added `JavaCompat` and `JavaCompatTest`: This is a sample class to trigger events using Java-based wrapper API's.
- Core: 
    - Added `androidx.annotation:annotation-jvm` dependency for adding annotations.
    - Added `JavaCompat` class: This is a sample class to trigger events using Java-based wrapper API's.

### Chore

- Bumped the `mockk` version to the `1.13.10`. This is to address this issue, which occurs while running tests (in the sample app):
> java.lang.IllegalArgumentException: Java 21 (65) is not supported by the current version of Byte Buddy which officially supports Java 20 (64) - update Byte Buddy or set net.bytebuddy.experimental as a VM property

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

1. In `RudderAnalyticsUtils`: 
    a. Change from `lateinit var analytics: Analytics` to `lateinit var analytics: JavaCompat`.
    b. Comment out the existing `Analytics` initialisation code in the `initialize()`.
    c. (Optional) Comment our other codes in the same class, which might not be required. 
    d. Add this two lines: `analytics = JavaCompat(application, BuildConfig.WRITE_KEY, BuildConfig.DATA_PLANE_URL)` and `analytics.add(JavaEventFilteringPlugin())`.
2. In `MainViewModel`:
    a. Change this `is MainViewModelState.AnalyticsState.StartSessionWithCustomId -> analytics.startSession(sessionId = 1000000001)` to `is MainViewModelState.AnalyticsState.StartSessionWithCustomId -> analytics.startSession(1000000001)`.
    b. Comment out all the event-related code i.e., replace the named arguments approach with this `analytics.track()`. This will fire multiple track events.
3. In `JavaCompat`: Instruments the required events.
4. Run the app -> Fire events -> and Verify that events were reaching.
5. Also, verify that `JavaEventFilteringPlugin()` is filtering out the lifecycle events!

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->

Note:
- For now, I've skipped exposing the `analytics` instance in the `JavaAnalytics` class. As I believe it's not needed for now. If required, we can expose that in future, using some getter function.
- Going forward, whenever any new public Anlaytics API's are added, we need to ensure they are added at the following places:
    - Always add the public Analytics API's in the sample Android app module - `JavaCompat` and `JavaCompatTest` classes, as we only have the unit test over there. 
    - If the public API's is part of the `core`, then add them in the core `JavaCompat` class, as well.
- If there's any change in the `Configuration` class, then we just need to add the corresponding unit tests.