### PR TITLE
fix: change logging APIs to support multiple SDK instance

### DIFF
--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -231,7 +231,7 @@ class Analytics(
     }
 
     private fun setup() {
-        setLogger(logger = AndroidLogger())
+        LoggerAnalytics.setLoggerIfNull(logger = AndroidLogger())
         add(AndroidConnectivityObserverPlugin(connectivityState))
         add(DeviceInfoPlugin())
         add(AppInfoPlugin())

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -231,7 +231,7 @@ class Analytics(
     }
 
     private fun setup() {
-        LoggerAnalytics.setLoggerIfNull(logger = AndroidLogger())
+        LoggerAnalytics.setPlatformLogger(logger = AndroidLogger())
         add(AndroidConnectivityObserverPlugin(connectivityState))
         add(DeviceInfoPlugin())
         add(AppInfoPlugin())

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Configuration.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Configuration.kt
@@ -2,7 +2,6 @@ package com.rudderstack.sdk.kotlin.android
 
 import android.app.Application
 import com.rudderstack.sdk.kotlin.core.Configuration
-import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
 
 internal const val DEFAULT_SESSION_TIMEOUT_IN_MILLIS = 300_000L
@@ -36,7 +35,6 @@ internal const val DEFAULT_SESSION_TIMEOUT_IN_MILLIS = 300_000L
  * @param writeKey The write key used to authenticate and send data to the backend. This field is required.
  * @param dataPlaneUrl The URL of the data plane to which events are sent. This field is required.
  * @param controlPlaneUrl The URL of the control plane, used for remote configuration management. Defaults to `DEFAULT_CONTROL_PLANE_URL`.
- * @param logLevel The log level used for SDK logging. By default, it uses the `DEBUG` log level.
  * @param flushPolicies A list of flush policies defining when and how events should be sent to the backend. Defaults to `DEFAULT_FLUSH_POLICIES`.
  * @param gzipEnabled Flag to enable or disable GZIP compression for network requests. Defaults to `DEFAULT_GZIP_STATUS`.
  *
@@ -64,13 +62,11 @@ data class Configuration @JvmOverloads constructor(
     override val writeKey: String,
     override val dataPlaneUrl: String,
     override val controlPlaneUrl: String = DEFAULT_CONTROL_PLANE_URL,
-    override val logLevel: Logger.LogLevel = Logger.DEFAULT_LOG_LEVEL,
     override val flushPolicies: List<FlushPolicy> = DEFAULT_FLUSH_POLICIES,
     override val gzipEnabled: Boolean = DEFAULT_GZIP_STATUS
 ) : Configuration(
     writeKey = writeKey,
     dataPlaneUrl = dataPlaneUrl,
-    logLevel = logLevel,
     flushPolicies = flushPolicies,
 )
 

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/AnalyticsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/AnalyticsTest.kt
@@ -199,9 +199,9 @@ class AnalyticsTest {
         }
 
     @Test
-    fun `when SDK is initialised, then AndroidLogger with default log level should be set`() {
+    fun `when SDK is initialised, then AndroidLogger should be set`() {
         verify(exactly = 1) {
-            LoggerAnalytics.setup(any<AndroidLogger>(), LogLevel.NONE)
+            LoggerAnalytics.setPlatformLogger(any<AndroidLogger>())
         }
     }
 

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/logger/LoggerAnalyticsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/logger/LoggerAnalyticsTest.kt
@@ -27,7 +27,8 @@ class LoggerAnalyticsTest {
     @Test
     fun `given android logger is provided and log level is VERBOSE, when all types of logs are called, then it should log all types of logs`() {
         val logger = spyk(AndroidLogger())
-        LoggerAnalytics.setup(logger = logger, logLevel = Logger.LogLevel.VERBOSE)
+        LoggerAnalytics.setLogger(logger = logger)
+        LoggerAnalytics.logLevel = Logger.LogLevel.VERBOSE
 
         LoggerAnalytics.verbose("Verbose log")
         LoggerAnalytics.debug("Debug log")
@@ -47,7 +48,8 @@ class LoggerAnalyticsTest {
     @Test
     fun `given android logger is provided and log level is INFO, when all types of logs are called, then it should log only INFO, WARN and ERROR logs`() {
         val logger = spyk(AndroidLogger())
-        LoggerAnalytics.setup(logger = logger, logLevel = Logger.LogLevel.INFO)
+        LoggerAnalytics.setLogger(logger = logger)
+        LoggerAnalytics.logLevel = Logger.LogLevel.INFO
 
         LoggerAnalytics.verbose("Verbose log")
         LoggerAnalytics.debug("Debug log")
@@ -70,7 +72,8 @@ class LoggerAnalyticsTest {
     @Test
     fun `given android logger is provided and log level is NONE, when all types of logs are called, then it should not log any logs`() {
         val logger = spyk(AndroidLogger())
-        LoggerAnalytics.setup(logger = logger, logLevel = Logger.LogLevel.NONE)
+        LoggerAnalytics.setLogger(logger = logger)
+        LoggerAnalytics.logLevel = Logger.LogLevel.NONE
 
         LoggerAnalytics.verbose("Verbose log")
         LoggerAnalytics.debug("Debug log")

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/Utils.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/utils/Utils.kt
@@ -68,7 +68,8 @@ fun mockUri(
 }
 
 fun setupLogger(logger: Logger, level: Logger.LogLevel = Logger.LogLevel.VERBOSE) {
-    LoggerAnalytics.setup(logger = logger, logLevel = level)
+    LoggerAnalytics.setLogger(logger = logger)
+    LoggerAnalytics.logLevel = level
 }
 
 // As Mockk doesn't seems to support spying on lambda function, we need to create a class for the same.

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/RudderAnalyticsUtils.kt
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/RudderAnalyticsUtils.kt
@@ -29,6 +29,11 @@ object RudderAnalyticsUtils {
      * @param application The Android Application instance
      */
     fun initialize(application: Application) {
+        // setting the LogLevel
+        LoggerAnalytics.logLevel = Logger.LogLevel.VERBOSE
+        // setting the logger if needed
+        // LoggerAnalytics.setLogger(MyCustomLogger())
+
         analytics = Analytics(
             configuration = Configuration(
                 trackApplicationLifecycleEvents = true,
@@ -40,7 +45,6 @@ object RudderAnalyticsUtils {
                     sessionTimeoutInMillis = 3000,
                 ),
                 gzipEnabled = true,
-                logLevel = Logger.LogLevel.VERBOSE,
             )
         )
         analytics.add(sampleIntegrationPlugin())

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -92,7 +92,7 @@ open class Analytics protected constructor(
 
     private fun runForBaseTypeOnly() {
         if (this::class == Analytics::class) {
-            LoggerAnalytics.setLoggerIfNull(logger = KotlinLogger())
+            LoggerAnalytics.setPlatformLogger(logger = KotlinLogger())
             connectivityState.dispatch(ConnectivityState.SetDefaultStateAction())
             setupSourceConfig()
         }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -1,7 +1,6 @@
 package com.rudderstack.sdk.kotlin.core
 
 import com.rudderstack.sdk.kotlin.core.internals.logger.KotlinLogger
-import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.models.AliasEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.Event
@@ -93,7 +92,7 @@ open class Analytics protected constructor(
 
     private fun runForBaseTypeOnly() {
         if (this::class == Analytics::class) {
-            setLogger(logger = KotlinLogger())
+            LoggerAnalytics.setLoggerIfNull(logger = KotlinLogger())
             connectivityState.dispatch(ConnectivityState.SetDefaultStateAction())
             setupSourceConfig()
         }
@@ -107,19 +106,6 @@ open class Analytics protected constructor(
             fetchCachedSourceConfigAndNotifyObservers()
             refreshSourceConfigAndNotifyObservers()
         }
-    }
-
-    /**
-     * Configures the logger for analytics with a specified `Logger` instance.
-     *
-     * This function sets up the `LoggerAnalytics` with the provided `logger` instance,
-     * applying the log level specified in the configuration.
-     *
-     * @param logger The `Logger` instance to use for logging. Defaults to an instance of `KotlinLogger`.
-     */
-    fun setLogger(logger: Logger) {
-        if (!isAnalyticsActive()) return
-        LoggerAnalytics.setup(logger = logger, logLevel = configuration.logLevel)
     }
 
     /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Configuration.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Configuration.kt
@@ -27,6 +27,7 @@ open class Configuration @JvmOverloads constructor(
 ) {
 
     companion object {
+
         /**
          * The default status of GZIP compression for network requests.
          * If true, GZIP is enabled; if false, it is disabled.
@@ -42,10 +43,11 @@ open class Configuration @JvmOverloads constructor(
          * The default flush policies for `CountFlushPolicy` and `FrequencyFlushPolicy`,
          * which define the conditions under which events are flushed to the server.
          */
-        val DEFAULT_FLUSH_POLICIES: List<FlushPolicy> = listOf(
-            CountFlushPolicy(),
-            FrequencyFlushPolicy(),
-            StartupFlushPolicy(),
-        )
+        val DEFAULT_FLUSH_POLICIES: List<FlushPolicy>
+            get() = listOf(
+                CountFlushPolicy(),
+                FrequencyFlushPolicy(),
+                StartupFlushPolicy(),
+            )
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Configuration.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Configuration.kt
@@ -3,7 +3,6 @@ package com.rudderstack.sdk.kotlin.core
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_CONTROL_PLANE_URL
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_FLUSH_POLICIES
 import com.rudderstack.sdk.kotlin.core.Configuration.Companion.DEFAULT_GZIP_STATUS
-import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import com.rudderstack.sdk.kotlin.core.internals.policies.CountFlushPolicy
 import com.rudderstack.sdk.kotlin.core.internals.policies.FlushPolicy
 import com.rudderstack.sdk.kotlin.core.internals.policies.FrequencyFlushPolicy
@@ -16,7 +15,6 @@ import com.rudderstack.sdk.kotlin.core.internals.policies.StartupFlushPolicy
  * @property writeKey The write key provided by RudderStack to authenticate API requests.
  * @property dataPlaneUrl The URL of the data plane where all event data will be sent.
  * @property controlPlaneUrl The URL of the control plane for fetching configuration settings. Defaults to [DEFAULT_CONTROL_PLANE_URL].
- * @property logLevel The log level used for logging events, errors, and debug information. Defaults to [Logger.DEFAULT_LOG_LEVEL].
  * @property gzipEnabled A flag indicating whether GZIP compression is enabled for network requests. Defaults to [DEFAULT_GZIP_STATUS].
  * @property flushPolicies A list of flush policies that determine when to flush events to the data plane. Defaults to [DEFAULT_FLUSH_POLICIES].
  */
@@ -24,7 +22,6 @@ open class Configuration @JvmOverloads constructor(
     open val writeKey: String,
     open val dataPlaneUrl: String,
     open val controlPlaneUrl: String = DEFAULT_CONTROL_PLANE_URL,
-    open val logLevel: Logger.LogLevel = Logger.DEFAULT_LOG_LEVEL,
     open val gzipEnabled: Boolean = DEFAULT_GZIP_STATUS,
     open val flushPolicies: List<FlushPolicy> = DEFAULT_FLUSH_POLICIES,
 ) {

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
@@ -1,5 +1,6 @@
 package com.rudderstack.sdk.kotlin.core.internals.logger
 
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger.Companion.DEFAULT_LOG_LEVEL
 import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
 
 /**
@@ -8,12 +9,17 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
  * logging across different environments.
  *
  * ### Setup
- * Use the `setLogger` method to configure the logger instance, specify a log level and optionally set a tag.:
+ * Use the `setLogger` method to configure the logger instance:
  *
  * ```kotlin
- * LoggerAnalytics.setup(logger = AndroidLogger(), level = configuration.logLevel, tag = "MyTag")
+ * LoggerAnalytics.setup(logger = AndroidLogger())
  * // Or for Kotlin environments
- * LoggerAnalytics.setup(logger = KotlinLogger(), level = configuration.logLevel, tag = "MyTag")
+ * LoggerAnalytics.setup(logger = KotlinLogger())
+ * ```
+ * Use `logLevel` to set the desired log level:
+ *
+ * ```kotlin
+ * LoggerAnalytics.logLevel = Logger.LogLevel.VERBOSE
  * ```
  *
  * ### Usage
@@ -31,22 +37,34 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
  * and clarity for debugging and tracking events across SDK modules.
  */
 object LoggerAnalytics {
+
     private var logger: Logger? = null
-    private var logLevel: Logger.LogLevel = Logger.DEFAULT_LOG_LEVEL
-        @Synchronized private set
+
+    /**
+     * The log level for the logger. This determines the minimum severity of messages that will be logged.
+     */
+    var logLevel: Logger.LogLevel = DEFAULT_LOG_LEVEL
+        @Synchronized set
 
         @Synchronized get
 
     /**
-     * Sets the logger instance and log level for the SDK.
-     *
-     * @param logger The logger instance to use (e.g., `AndroidLogger` or `KotlinLogger`).
-     * @param logLevel The log level to activate for the logger, defining the minimum severity of logs to display.
+     * Sets the logger instance if null.
      */
     @InternalRudderApi
-    fun setup(logger: Logger, logLevel: Logger.LogLevel) {
+    fun setLoggerIfNull(logger: Logger) {
+        if (this.logger == null) {
+            this.logger = logger
+        }
+    }
+
+    /**
+     * Sets the logger instance. This method allows you to set a custom logger for the SDK.
+     *
+     * @param logger The logger instance to set.
+     */
+    fun setLogger(logger: Logger) {
         this.logger = logger
-        this.logLevel = logLevel
     }
 
     /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
@@ -52,7 +52,7 @@ object LoggerAnalytics {
      * Sets the logger instance if null.
      */
     @InternalRudderApi
-    fun setLoggerIfNull(logger: Logger) {
+    fun setPlatformLogger(logger: Logger) {
         if (this.logger == null) {
             this.logger = logger
         }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -211,9 +211,9 @@ class AnalyticsTest {
     }
 
     @Test
-    fun `when SDK is initialised, then KotlinLogger and default log level should be set`() {
+    fun `when SDK is initialised, then KotlinLogger should be set`() {
         verify(exactly = 1) {
-            LoggerAnalytics.setup(any<KotlinLogger>(), LogLevel.NONE)
+            LoggerAnalytics.setPlatformLogger(any<KotlinLogger>())
         }
     }
 

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/Utils.kt
@@ -75,7 +75,8 @@ private fun String.cleanJsonString(): String {
 }
 
 fun setupLogger(logger: Logger, level: Logger.LogLevel = Logger.LogLevel.VERBOSE) {
-    LoggerAnalytics.setup(logger = logger, logLevel = level)
+    LoggerAnalytics.setPlatformLogger(logger = logger)
+    LoggerAnalytics.logLevel = level
 }
 
 // As Mockk doesn't seems to support spying on lambda function, we need to create a class for the same.

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalyticsTest.kt
@@ -10,7 +10,8 @@ class LoggerAnalyticsTest {
     @Test
     fun `given kotlin logger is provided and log level is VERBOSE, when all types of logs are called, then it should log all types of logs`() {
         val logger = spyk(KotlinLogger())
-        LoggerAnalytics.setup(logger = logger, logLevel = Logger.LogLevel.VERBOSE)
+        LoggerAnalytics.setLogger(logger)
+        LoggerAnalytics.logLevel = Logger.LogLevel.VERBOSE
 
         LoggerAnalytics.verbose("Verbose log")
         LoggerAnalytics.debug("Debug log")
@@ -30,7 +31,8 @@ class LoggerAnalyticsTest {
     @Test
     fun `given kotlin logger is provided and log level is INFO, when all types of logs are called, then it should log only INFO, WARN and ERROR logs`() {
         val logger = spyk(KotlinLogger())
-        LoggerAnalytics.setup(logger = logger, logLevel = Logger.LogLevel.INFO)
+        LoggerAnalytics.setLogger(logger)
+        LoggerAnalytics.logLevel = Logger.LogLevel.INFO
 
         LoggerAnalytics.verbose("Verbose log")
         LoggerAnalytics.debug("Debug log")
@@ -53,7 +55,8 @@ class LoggerAnalyticsTest {
     @Test
     fun `given kotlin logger is provided and log level is NONE, when all types of logs are called, then it should not log any logs`() {
         val logger = spyk(KotlinLogger())
-        LoggerAnalytics.setup(logger = logger, logLevel = Logger.LogLevel.NONE)
+        LoggerAnalytics.setLogger(logger)
+        LoggerAnalytics.logLevel = Logger.LogLevel.NONE
 
         LoggerAnalytics.verbose("Verbose log")
         LoggerAnalytics.debug("Debug log")

--- a/integrations/adjust/src/main/java/com/rudderstack/integration/kotlin/adjust/AdjustIntegration.kt
+++ b/integrations/adjust/src/main/java/com/rudderstack/integration/kotlin/adjust/AdjustIntegration.kt
@@ -48,7 +48,7 @@ class AdjustIntegration : StandardIntegration, IntegrationPlugin(), ActivityLife
                 adjustInstance = initAdjust(
                     application = analytics.application,
                     appToken = config.appToken,
-                    logLevel = analytics.configuration.logLevel,
+                    logLevel = LoggerAnalytics.logLevel,
                 )
                 (analytics as? Analytics)?.addLifecycleObserver(this)
                 LoggerAnalytics.verbose("AdjustIntegration: Adjust SDK initialized.")

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
@@ -56,7 +56,7 @@ class BrazeIntegration : StandardIntegration, IntegrationPlugin(), ActivityLifec
         braze ?: run {
             destinationConfig.parse<RudderBrazeConfig>()?.let { config ->
                 this.brazeConfig = config
-                initBraze(analytics.application, config, analytics.configuration.logLevel).also {
+                initBraze(analytics.application, config, LoggerAnalytics.logLevel).also {
                     braze = it
                     setUserAlias()
                 }

--- a/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/BrazeIntegrationTest.kt
+++ b/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/BrazeIntegrationTest.kt
@@ -16,6 +16,7 @@ import com.rudderstack.integration.kotlin.braze.Utility.readFileAsJsonObject
 import com.rudderstack.sdk.kotlin.android.utils.application
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import io.mockk.MockKAnnotations
 import io.mockk.clearMocks
@@ -75,7 +76,8 @@ class BrazeIntegrationTest {
         every { initBrazeConfig() } returns mockBrazeConfigBuilder
 
         // LogLevel
-        every { mockAnalytics.configuration.logLevel } returns Logger.LogLevel.VERBOSE
+        mockkObject(LoggerAnalytics)
+        every { LoggerAnalytics.logLevel } returns Logger.LogLevel.VERBOSE
 
         // Braze
         mockkObject(Braze)

--- a/integrations/facebook/src/main/kotlin/com/rudderstack/integration/kotlin/facebook/FacebookIntegration.kt
+++ b/integrations/facebook/src/main/kotlin/com/rudderstack/integration/kotlin/facebook/FacebookIntegration.kt
@@ -48,7 +48,7 @@ class FacebookIntegration : StandardIntegration, IntegrationPlugin() {
         facebookAppEventsLogger ?: run {
             destinationConfig.parseConfig<FacebookDestinationConfig>()
                 .let { config ->
-                    if (analytics.configuration.logLevel <= Logger.LogLevel.DEBUG) {
+                    if (LoggerAnalytics.logLevel <= Logger.LogLevel.DEBUG) {
                         FacebookSdk.setIsDebugEnabled(true)
                         FacebookSdk.addLoggingBehavior(LoggingBehavior.APP_EVENTS)
                     }

--- a/integrations/facebook/src/test/kotlin/com/rudderstack/integration/kotlin/facebook/FacebookIntegrationTest.kt
+++ b/integrations/facebook/src/test/kotlin/com/rudderstack/integration/kotlin/facebook/FacebookIntegrationTest.kt
@@ -10,6 +10,7 @@ import com.rudderstack.sdk.kotlin.android.Analytics
 import com.rudderstack.sdk.kotlin.android.Configuration
 import com.rudderstack.sdk.kotlin.core.ecommerce.ECommerceEvents
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.models.IdentifyEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.ScreenEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.TrackEvent
@@ -268,9 +269,9 @@ class FacebookIntegrationTest {
 
     @Test
     fun `when logLevel in configuration is debug, then logging is enabled for facebook sdk`() {
-        every { mockAnalytics.configuration } returns mockk<Configuration>(relaxed = true) {
-            every { logLevel } returns Logger.LogLevel.DEBUG
-        }
+        mockkObject(LoggerAnalytics)
+        every { LoggerAnalytics.logLevel } returns Logger.LogLevel.DEBUG
+        every { mockAnalytics.configuration } returns mockk<Configuration>(relaxed = true)
 
         createFacebookIntegration()
 
@@ -282,9 +283,9 @@ class FacebookIntegrationTest {
 
     @Test
     fun `when logLevel in configuration is verbose, then logging is enabled for facebook sdk`() {
-        every { mockAnalytics.configuration } returns mockk<Configuration>(relaxed = true) {
-            every { logLevel } returns Logger.LogLevel.VERBOSE
-        }
+        mockkObject(LoggerAnalytics)
+        every { LoggerAnalytics.logLevel } returns Logger.LogLevel.VERBOSE
+        every { mockAnalytics.configuration } returns mockk<Configuration>(relaxed = true)
 
         createFacebookIntegration()
 
@@ -296,9 +297,9 @@ class FacebookIntegrationTest {
 
     @Test
     fun `when logLevel in configuration is info, then logging is not enabled for facebook sdk`() {
-        every { mockAnalytics.configuration } returns mockk<Configuration>(relaxed = true) {
-            every { logLevel } returns Logger.LogLevel.INFO
-        }
+        mockkObject(LoggerAnalytics)
+        every { LoggerAnalytics.logLevel } returns Logger.LogLevel.INFO
+        every { mockAnalytics.configuration } returns mockk<Configuration>(relaxed = true)
 
         createFacebookIntegration()
 

--- a/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/main.kt
+++ b/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/main.kt
@@ -13,11 +13,11 @@ import java.util.Date
 private lateinit var analytics: Analytics
 
 fun main() {
+    LoggerAnalytics.logLevel = Logger.LogLevel.VERBOSE
     analytics = Analytics(
         configuration = Configuration(
             writeKey = "<WRITE KEY>",
             dataPlaneUrl = "<DATA PLANE URL>",
-            logLevel = Logger.LogLevel.VERBOSE,
             gzipEnabled = DEFAULT_GZIP_STATUS,
         )
     )


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->
This PR refactors the logging APIs to make them independent of a particular SDK instance to provide support for multiple SDK instance.
It also changes the `DEFAULT_FLUSH_POLICIES` used in `Configuration` to use the getter so that it re-instantiated every time it is accessed.

## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->
The following changes are done:
1. The `logLevel` was earlier present in the SDK `Configuration` but used to set the log level for all the SDK instances. It is moved to the `LoggerAnalytics` singleton object which now controls the logging behaviour for all the instances of the SDK in a given process.
2. The `setLogger` API was present inside the `Analytics` class which is now moved to the `LoggerAnalytics` as it will set a custom `Logger` for all the instances of the SDK present in a given process.
3. `setPlatformLogger` method is introduced for setting of the `Logger` within the SDK. This method relies on null check in the `LoggerAnalytics` object before setting the logger, which helps us prevent overriding the logger which is set by the client.
4. Relevant test cases are updated.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->
Run the sample app and check for the logs. They should be same as before. Try setting a custom `Logger` using `setLogger` API and check if it works correctly.

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->
**Note**: Since, the logging APIs are independent of a particular instance of the SDK, distinguishing between the logs of different instances of SDK in a same process is impossible.
