### PR TITLE
refactor: android deeplink plugin uses deprecated api

### DIFF
--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPlugin.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPlugin.kt
@@ -6,6 +6,7 @@ import android.net.ParseException
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import androidx.core.net.toUri
 import com.rudderstack.sdk.kotlin.android.plugins.lifecyclemanagment.ActivityLifecycleObserver
 import com.rudderstack.sdk.kotlin.android.storage.CheckBuildVersionUseCase
 import com.rudderstack.sdk.kotlin.android.utils.addLifecycleObserver
@@ -17,7 +18,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import com.rudderstack.sdk.kotlin.android.Analytics as AndroidAnalytics
 import com.rudderstack.sdk.kotlin.android.Configuration as AndroidConfiguration
-import androidx.core.net.toUri
 
 internal const val REFERRING_APPLICATION_KEY = "referring_application"
 internal const val URL_KEY = "url"
@@ -76,7 +76,13 @@ internal class DeeplinkPlugin : Plugin, ActivityLifecycleObserver {
     private fun getReferrerCompatible(activity: Activity): Uri? {
         var referrerUri: Uri?
         val intent = activity.intent
-        referrerUri = intent.getParcelableExtra(Intent.EXTRA_REFERRER)
+
+        referrerUri = if (CheckBuildVersionUseCase.isAndroidVersionAtLeast(Build.VERSION_CODES.TIRAMISU)) {
+            intent.getParcelableExtra(Intent.EXTRA_REFERRER, Uri::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            intent.getParcelableExtra(Intent.EXTRA_REFERRER)
+        }
 
         if (referrerUri == null) {
             // Intent.EXTRA_REFERRER_NAME

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPlugin.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPlugin.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.net.ParseException
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import com.rudderstack.sdk.kotlin.android.plugins.lifecyclemanagment.ActivityLifecycleObserver
 import com.rudderstack.sdk.kotlin.android.storage.CheckBuildVersionUseCase
@@ -16,6 +17,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import com.rudderstack.sdk.kotlin.android.Analytics as AndroidAnalytics
 import com.rudderstack.sdk.kotlin.android.Configuration as AndroidConfiguration
+import androidx.core.net.toUri
 
 internal const val REFERRING_APPLICATION_KEY = "referring_application"
 internal const val URL_KEY = "url"
@@ -64,7 +66,7 @@ internal class DeeplinkPlugin : Plugin, ActivityLifecycleObserver {
     }
 
     private fun Activity.getReferrerString(): String? {
-        return if (CheckBuildVersionUseCase.isAndroidVersionLollipopAndAbove()) {
+        return if (CheckBuildVersionUseCase.isAndroidVersionAtLeast(Build.VERSION_CODES.LOLLIPOP_MR1)) {
             this.referrer?.toString()
         } else {
             getReferrerCompatible(this)?.toString()
@@ -81,7 +83,7 @@ internal class DeeplinkPlugin : Plugin, ActivityLifecycleObserver {
             referrerUri = intent.getStringExtra("android.intent.extra.REFERRER_NAME")?.let {
                 // Try parsing the referrer URL; if it's invalid, return null
                 try {
-                    Uri.parse(it)
+                    it.toUri()
                 } catch (ignored: ParseException) {
                     null
                 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/CheckBuildVersionUseCase.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/CheckBuildVersionUseCase.kt
@@ -1,8 +1,6 @@
 package com.rudderstack.sdk.kotlin.android.storage
 
-import android.annotation.SuppressLint
 import android.os.Build
-import androidx.annotation.ChecksSdkIntAtLeast
 
 internal object CheckBuildVersionUseCase {
 
@@ -12,8 +10,6 @@ internal object CheckBuildVersionUseCase {
      * @param sdkLevel The minimum SDK level to check against
      * @return true if the device is running on at least the specified SDK level
      */
-    @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.LOLLIPOP_MR1)
-    @SuppressLint("ObsoleteSdkInt")
     internal fun isAndroidVersionAtLeast(sdkLevel: Int): Boolean {
         return Build.VERSION.SDK_INT >= sdkLevel
     }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/CheckBuildVersionUseCase.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/CheckBuildVersionUseCase.kt
@@ -6,13 +6,15 @@ import androidx.annotation.ChecksSdkIntAtLeast
 
 internal object CheckBuildVersionUseCase {
 
+    /**
+     * Checks if the current Android version is at least the specified SDK level.
+     *
+     * @param sdkLevel The minimum SDK level to check against
+     * @return true if the device is running on at least the specified SDK level
+     */
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.LOLLIPOP_MR1)
     @SuppressLint("ObsoleteSdkInt")
-    internal fun isAndroidVersionLollipopAndAbove(): Boolean {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
-    }
-
-    internal fun isAndroidVersionNAndAbove(): Boolean {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+    internal fun isAndroidVersionAtLeast(sdkLevel: Int): Boolean {
+        return Build.VERSION.SDK_INT >= sdkLevel
     }
 }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -1,7 +1,9 @@
 package com.rudderstack.sdk.kotlin.android.storage
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import androidx.core.content.edit
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.storage.KeyValueStorage
@@ -47,14 +49,13 @@ internal class SharedPrefsStore(
         put(key, value)
     }
 
+    @SuppressLint("NewApi")
     @UseWithCaution
     override fun delete() {
-        val isDeleted = if (CheckBuildVersionUseCase.isAndroidVersionNAndAbove()) {
+        val isDeleted = if (CheckBuildVersionUseCase.isAndroidVersionAtLeast(Build.VERSION_CODES.N)) {
             context.deleteSharedPreferences(prefsName)
         } else {
-            File(context.getSharedPreferencesFilePath(prefsName))
-                .takeIf { file -> file.exists() }
-                ?.delete() ?: false
+            File(context.getSharedPreferencesFilePath(prefsName)).takeIf { file -> file.exists() }?.delete() ?: false
         }
         LoggerAnalytics.debug("Attempt to delete shared preferences successful: $isDeleted")
     }

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStore.kt
@@ -1,6 +1,5 @@
 package com.rudderstack.sdk.kotlin.android.storage
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
@@ -49,7 +48,6 @@ internal class SharedPrefsStore(
         put(key, value)
     }
 
-    @SuppressLint("NewApi")
     @UseWithCaution
     override fun delete() {
         val isDeleted = if (CheckBuildVersionUseCase.isAndroidVersionAtLeast(Build.VERSION_CODES.N)) {

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPluginTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/plugins/DeeplinkPluginTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Application
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import com.rudderstack.sdk.kotlin.android.Configuration
 import com.rudderstack.sdk.kotlin.android.storage.CheckBuildVersionUseCase
 import com.rudderstack.sdk.kotlin.android.utils.addLifecycleObserver
@@ -67,7 +68,7 @@ class DeeplinkPluginTest {
         )
         every { (mockAnalytics as AndroidAnalytics).addLifecycleObserver(plugin) } just Runs
         mockkObject(CheckBuildVersionUseCase)
-        every { CheckBuildVersionUseCase.isAndroidVersionLollipopAndAbove() } returns true
+        every { CheckBuildVersionUseCase.isAndroidVersionAtLeast(Build.VERSION_CODES.LOLLIPOP_MR1) } returns true
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -137,7 +138,7 @@ class DeeplinkPluginTest {
     fun `given trackDeepLinks is enabled and api level is 21, when onActivityCreated is called, then Deeplink opened event called with correct properties`() =
         runTest {
             val trackingEnabled = true
-            every { CheckBuildVersionUseCase.isAndroidVersionLollipopAndAbove() } returns false
+            every { CheckBuildVersionUseCase.isAndroidVersionAtLeast(Build.VERSION_CODES.LOLLIPOP_MR1) } returns false
             val mockConfiguration = mockk<Configuration> {
                 every { application } returns mockApplication
                 every { trackDeepLinks } returns trackingEnabled

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/storage/SharedPrefsStoreTest.kt
@@ -2,6 +2,7 @@ package com.rudderstack.sdk.kotlin.android.storage
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import com.rudderstack.sdk.kotlin.core.internals.utils.UseWithCaution
 import io.mockk.every
 import io.mockk.mockk
@@ -132,7 +133,7 @@ class SharedPrefsStoreTest {
     @OptIn(UseWithCaution::class)
     @Test
     fun `given android version is N and above, when deletePrefs is called, then verify that shared preference is deleted`() {
-        every { CheckBuildVersionUseCase.isAndroidVersionNAndAbove() } returns true
+        every { CheckBuildVersionUseCase.isAndroidVersionAtLeast(Build.VERSION_CODES.N) } returns true
 
         sharedPrefsStore.delete()
 


### PR DESCRIPTION
## Description of the change

>  Updated the DeeplinkPlugin to handle the deprecated `getParcelableExtra` method by using the new type-safe version for Android 13 (Tiramisu, API 33) and above. This change ensures compatibility with newer Android versions while maintaining support for older versions.

Specifically:
- Modified `getReferrerCompatible()` method in `DeeplinkPlugin.kt` to use the new `getParcelableExtra(String, Class)` method for Android 13+
- Refactored the existing `CheckBuildVersionUseCase.isAndroidVersionAtLeast()` method to determine which API to use based on the device's Android version.
- Added proper `@Suppress("DEPRECATION")` annotation for the older method to avoid lint warnings
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
