### PR TITLE
fix: integrations management plugin crash issue

### DIFF
--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/policies/FrequencyFlushPolicy.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/policies/FrequencyFlushPolicy.kt
@@ -7,14 +7,14 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 internal const val DEFAULT_FLUSH_INTERVAL_IN_MILLIS = 10_000L
-internal const val DEFAULT_MIN_SLEEP_TIMEOUT = 1L
+internal const val DEFAULT_MIN_SLEEP_TIMEOUT_IN_MILLIS = 1000L
 
 /**
  * FrequencyFlushPolicy is a concrete implementation of the FlushPolicy interface
  * that automatically triggers a flush action at a specified interval, once scheduled.
  *
  * @property flushIntervalInMillis The interval in milliseconds between each flush.
- *                                 If set below [DEFAULT_MIN_SLEEP_TIMEOUT], it defaults
+ *                                 If set below [DEFAULT_MIN_SLEEP_TIMEOUT_IN_MILLIS], it defaults
  *                                 to [DEFAULT_FLUSH_INTERVAL_IN_MILLIS].
  */
 class FrequencyFlushPolicy(private var flushIntervalInMillis: Long = DEFAULT_FLUSH_INTERVAL_IN_MILLIS) : FlushPolicy {
@@ -24,7 +24,7 @@ class FrequencyFlushPolicy(private var flushIntervalInMillis: Long = DEFAULT_FLU
 
     init {
         flushIntervalInMillis = when {
-            flushIntervalInMillis >= DEFAULT_MIN_SLEEP_TIMEOUT -> flushIntervalInMillis
+            flushIntervalInMillis >= DEFAULT_MIN_SLEEP_TIMEOUT_IN_MILLIS -> flushIntervalInMillis
             else -> DEFAULT_FLUSH_INTERVAL_IN_MILLIS
         }
     }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/policies/FrequencyFlushPolicyTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/policies/FrequencyFlushPolicyTest.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import com.rudderstack.sdk.kotlin.core.mockAnalytics
 import kotlinx.coroutines.test.TestScope
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class FrequencyFlushPolicyTest {
 
@@ -72,8 +74,8 @@ class FrequencyFlushPolicyTest {
     }
 
     @Test
-    fun `given flush interval is set to 1, when the policy is scheduled, then it should flush after the scheduled interval`() {
-        val flushInterval = 1L
+    fun `given flush interval is set to min value, when the policy is scheduled, then it should flush after the scheduled interval`() {
+        val flushInterval = DEFAULT_MIN_SLEEP_TIMEOUT_IN_MILLIS
         val frequencyFlushPolicy = FrequencyFlushPolicy(flushInterval)
 
         frequencyFlushPolicy.schedule(mockAnalytics)
@@ -97,9 +99,11 @@ class FrequencyFlushPolicyTest {
         }
     }
 
-    @Test
-    fun `given flush interval is set to 0, when the policy is scheduled, then it should flush after the default interval`() {
-        val flushInterval = 0L
+    @ParameterizedTest
+    @ValueSource(longs = [0L, -1L, 1L, 900L, 999L])
+    fun `given flush interval is set to value less than min value, when the policy is scheduled, then it should flush after the default interval`(
+        flushInterval: Long,
+    ) {
         val frequencyFlushPolicy = FrequencyFlushPolicy(flushInterval)
 
         frequencyFlushPolicy.schedule(mockAnalytics)


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->
This PR fixes the `IntegrationsManagementPlugin` crash when the `FrequencyFlushPolicy` interval was set to 1ms.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->
The PR does the following changes:
1. It increases the min interval possible for the `FrequencyFlushPolicy` to 1 second.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->
- Set the interval of `FrequencyFlushPolicy` to 1 ms, pass it in the config of SDK and then run the sample app.
- Check the flushing behaviour. Check for any error logs in the logcat.

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->
The issue was happening because of following reason:
![image](https://github.com/user-attachments/assets/9ad01f04-7c38-4200-bf64-a377ee7b7c5a)

Although, we are starting the fetching of sourceConfig after the plugins are added [here](https://github.com/rudderlabs/rudder-sdk-kotlin/blob/8c3891d471869c612475400275e6241ee2e68069/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt#L260) (note: adding of plugins initialises their analytics lateinit property), [this](https://github.com/rudderlabs/rudder-sdk-kotlin/blob/8c3891d471869c612475400275e6241ee2e68069/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/queue/EventQueue.kt#L63-L68) coroutine still gets executed and flushPoliciesFacade.schedule(analytics) is getting called since the default value of isSourceEnabled is true. The schedule here internally calls the FrequencyFlushPolicy 's schedule [here](https://github.com/rudderlabs/rudder-sdk-kotlin/blob/8c3891d471869c612475400275e6241ee2e68069/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/policies/FrequencyFlushPolicy.kt#L33-L40). This calls the flush method of IntegrationsManagementPlugin [here](https://github.com/rudderlabs/rudder-sdk-kotlin/blob/8c3891d471869c612475400275e6241ee2e68069/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt#L132). Since, its flush call uses the analytics latent property (which is yet to be initialised [here](https://github.com/rudderlabs/rudder-sdk-kotlin/blob/8c3891d471869c612475400275e6241ee2e68069/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt#L248)), it causes the exception.

