### PR TITLE
fix(firebase): setting of traits and hyphen keys

### DIFF
--- a/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegration.kt
+++ b/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegration.kt
@@ -76,7 +76,7 @@ class FirebaseIntegration : StandardIntegration, IntegrationPlugin() {
                 .filterNot { it in IDENTIFY_RESERVED_KEYWORDS || it == USER_ID_KEY }
                 .forEach { key ->
                     val firebaseCompatibleKey = formatFirebaseKey(key)
-                    val value = getString(traits[key], maxLength = MAX_TRAITS_VALUE_LENGTH)
+                    val value = getString(value = traits[key], maxLength = MAX_TRAITS_VALUE_LENGTH)
                     firebaseAnalytics?.setUserProperty(firebaseCompatibleKey, value)
                 }
         }

--- a/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegration.kt
+++ b/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegration.kt
@@ -76,7 +76,7 @@ class FirebaseIntegration : StandardIntegration, IntegrationPlugin() {
                 .filterNot { it in IDENTIFY_RESERVED_KEYWORDS || it == USER_ID_KEY }
                 .forEach { key ->
                     val firebaseCompatibleKey = formatFirebaseKey(key)
-                    val value = getString(traits[key])
+                    val value = getString(traits[key], maxLength = MAX_TRAITS_VALUE_LENGTH)
                     firebaseAnalytics?.setUserProperty(firebaseCompatibleKey, value)
                 }
         }
@@ -234,7 +234,7 @@ class FirebaseIntegration : StandardIntegration, IntegrationPlugin() {
 
     private fun makeFirebaseEvent(firebaseEvent: String, params: Bundle, properties: JsonObject?) {
         attachAllCustomProperties(params, properties)
-        LoggerAnalytics.debug("FirebaseIntegration: Logged \"$firebaseEvent\" to Firebase and properties: $properties")
+        LoggerAnalytics.debug("FirebaseIntegration: Logged \"$firebaseEvent\" to Firebase")
         firebaseAnalytics?.logEvent(firebaseEvent, params)
     }
 }

--- a/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/Utils.kt
+++ b/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/Utils.kt
@@ -91,6 +91,7 @@ internal fun formatFirebaseKey(key: String): String {
     return key
         .trim()
         .replace(" ", "_")
+        .replace("-", "_")
         .take(MAX_KEY_LENGTH)
 }
 

--- a/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/Utils.kt
+++ b/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/Utils.kt
@@ -110,7 +110,7 @@ private fun isValidProperty(key: String, firebaseKey: String, properties: JsonOb
 private fun addPropertyToBundle(params: Bundle, firebaseKey: String, key: String, properties: JsonObject) {
     when {
         properties.isString(key) -> {
-            val value = getString(properties[key], maxLength = MAX_PROPERTY_VALUE_LENGTH)
+            val value = getString(value = properties[key], maxLength = MAX_PROPERTY_VALUE_LENGTH)
             params.putString(firebaseKey, value)
         }
 

--- a/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/Utils.kt
+++ b/integrations/firebase/src/main/kotlin/com/rudderstack/integration/kotlin/firebase/Utils.kt
@@ -104,7 +104,7 @@ internal fun attachAllCustomProperties(params: Bundle, properties: JsonObject?) 
 }
 
 private fun isValidProperty(key: String, firebaseKey: String, properties: JsonObject): Boolean {
-    return !(firebaseKey in RESERVED_EVENTS_KEYWORDS || properties.isKeyEmpty(key))
+    return !(firebaseKey.lowercase() in RESERVED_EVENTS_KEYWORDS || properties.isKeyEmpty(key))
 }
 
 private fun addPropertyToBundle(params: Bundle, firebaseKey: String, key: String, properties: JsonObject) {
@@ -118,7 +118,7 @@ private fun addPropertyToBundle(params: Bundle, firebaseKey: String, key: String
         properties.isLong(key) -> params.putLong(firebaseKey, properties.getLong(key) ?: 0)
         properties.isDouble(key) -> params.putDouble(firebaseKey, properties.getDouble(key) ?: 0.0)
         properties.isBoolean(key) -> params.putBoolean(firebaseKey, properties.getBoolean(key) ?: false)
-        else -> properties[key]?.toString()?.takeIf { it.length <= MAX_PROPERTY_VALUE_LENGTH }?.let {
+        else -> properties[key]?.toString()?.take(MAX_PROPERTY_VALUE_LENGTH)?.let {
             params.putString(
                 firebaseKey,
                 it

--- a/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegrationTest.kt
+++ b/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegrationTest.kt
@@ -136,7 +136,7 @@ class FirebaseIntegrationTest {
                 setUserProperty("justArr", "[1,2,3,4]")
                 setUserProperty("key_with_hyphen", "value with hyphen")
                 val expectedAddress = "[{\"city\":\"Hyderabad\",\"state\":\"Telangana\",\"country\":\"India\",\"street\":\"Mig\"},{\"city\":\"Hyderabad\",\"state\":\"Telangana\",\"country\":\"India\",\"street\":\"Mig\"}]"
-                setUserProperty("address", expectedAddress.take(100))
+                setUserProperty("address", expectedAddress.take(36))
             }
         }
     }

--- a/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegrationTest.kt
+++ b/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegrationTest.kt
@@ -633,13 +633,6 @@ private fun provideTraits(): JsonObject {
     val isJavaFun = true
     val greeting = "Hello World"
 
-    // Creating Different Object types
-    val map2 = HashMap<String, String>()
-    map2["key2"] = "value2"
-    val mutableMap2: MutableMap<String, String> = mutableMapOf()
-    mutableMap2["name"] = "Java World"
-    mutableMap2["city"] = "Delhi"
-
     // Creating Different Array types in Kotlin
     val address1 = buildJsonObject {
         put("city", "Hyderabad")

--- a/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegrationTest.kt
+++ b/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegrationTest.kt
@@ -9,11 +9,6 @@ import com.rudderstack.sdk.kotlin.core.internals.models.ScreenEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.TrackEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
 import com.rudderstack.sdk.kotlin.android.Analytics
-import com.rudderstack.sdk.kotlin.core.internals.models.Event
-import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
-import com.rudderstack.sdk.kotlin.core.internals.models.Traits
-import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.UserIdentity
-import com.rudderstack.sdk.kotlin.core.internals.platform.PlatformType
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -141,7 +136,6 @@ class FirebaseIntegrationTest {
         }
     }
 
-
     @Test
     fun `when reset is called, then setUserId is called with null`() {
         firebaseIntegration.reset()
@@ -191,6 +185,28 @@ class FirebaseIntegrationTest {
         firebaseIntegration.track(TrackEvent(event, properties))
 
         verify(exactly = 1) { mockFirebaseAnalytics.logEvent(FirebaseAnalytics.Event.APP_OPEN, mockBundle) }
+        verifyBundleIsEmpty()
+    }
+
+    @Test
+    fun `given event name contains hyphen, when track is called, then logEvent is called with proper event name`() {
+        val event = "Event-Name-With-Hyphen"
+        val properties = emptyJsonObject
+
+        firebaseIntegration.track(TrackEvent(event, properties))
+
+        verify(exactly = 1) { mockFirebaseAnalytics.logEvent("Event_Name_With_Hyphen", mockBundle) }
+        verifyBundleIsEmpty()
+    }
+
+    @Test
+    fun `given event name contains spaces, when track is called, then logEvent is called with proper event name`() {
+        val event = "Event Name With Spaces"
+        val properties = emptyJsonObject
+
+        firebaseIntegration.track(TrackEvent(event, properties))
+
+        verify(exactly = 1) { mockFirebaseAnalytics.logEvent("Event_Name_With_Spaces", mockBundle) }
         verifyBundleIsEmpty()
     }
 

--- a/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegrationTest.kt
+++ b/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/FirebaseIntegrationTest.kt
@@ -111,7 +111,7 @@ class FirebaseIntegrationTest {
     fun `given identify event with different traits, when identify is called, then setUserProperty is called with stringify values`() {
         val traits = provideTraits()
         every { mockAnalytics.traits } returns traits
-        val identifyEvent = provideIdentifyEvent()
+        val identifyEvent = IdentifyEvent()
 
         firebaseIntegration.identify(identifyEvent)
 
@@ -602,33 +602,6 @@ class FirebaseIntegrationTest {
             )
         )
     }
-}
-
-private fun provideUserIdentity(
-    anonymousId: String = "<anonymousId>",
-    userId: String = "user_id_4",
-    traits: Traits = provideTraits(),
-) = UserIdentity(
-    anonymousId = anonymousId,
-    userId = userId,
-    traits = traits,
-)
-
-internal fun provideIdentifyEvent(
-    options: RudderOption = RudderOption(),
-    userIdentityState: UserIdentity = provideUserIdentity(),
-) = IdentifyEvent(
-    options = options,
-    userIdentityState = userIdentityState,
-).also {
-    it.applyMockedValues()
-    it.updateData(PlatformType.Mobile)
-}
-
-private fun Event.applyMockedValues() {
-    this.originalTimestamp = "<original-timestamp>"
-    this.context = emptyJsonObject
-    this.messageId = "<message-id>"
 }
 
 private fun provideTraits(): JsonObject {

--- a/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/UtilsTest.kt
+++ b/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/UtilsTest.kt
@@ -1,0 +1,80 @@
+import com.rudderstack.integration.kotlin.firebase.getString
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class UtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("provideJsonElementsForGetString")
+    fun `when getString is called with different JsonElement types, it should return the expected string`(
+        jsonElement: Any?,
+        expected: String,
+    ) {
+        val result = getString(jsonElement as? JsonElement)
+
+        assertEquals(expected, result)
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun provideJsonElementsForGetString(): Stream<Arguments> {
+            return Stream.of(
+                // JsonPrimitive cases
+                Arguments.of(JsonPrimitive("string value"), "string value"),
+                Arguments.of(JsonPrimitive(123), "123"),
+                Arguments.of(JsonPrimitive(3.14), "3.14"),
+                Arguments.of(JsonPrimitive(true), "true"),
+
+                // JsonArray cases
+                Arguments.of(
+                    buildJsonArray {
+                        add("item1")
+                        add(2)
+                    },
+                    "[\"item1\",2]"
+                ),
+                Arguments.of(
+                    buildJsonArray { },
+                    "[]"
+                ),
+
+                // JsonObject cases
+                Arguments.of(
+                    buildJsonObject { put("key", "value") },
+                    "{\"key\":\"value\"}"
+                ),
+
+                // Null case
+                Arguments.of(null, "null"),
+
+                // JsonNull case
+                Arguments.of(JsonNull, "null"),
+
+                // Nested JsonObject case
+                Arguments.of(
+                    buildJsonObject {
+                        put("outer", buildJsonObject {
+                            put("inner", "value")
+                        })
+                        put("outer2", buildJsonArray {
+                            add("item1")
+                            add(2)
+                        })
+                    },
+                    "{\"outer\":{\"inner\":\"value\"},\"outer2\":[\"item1\",2]}"
+                )
+            )
+        }
+    }
+}

--- a/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/UtilsTest.kt
+++ b/integrations/firebase/src/test/kotlin/com/rudderstack/integration/kotlin/firebase/UtilsTest.kt
@@ -20,7 +20,7 @@ class UtilsTest {
         jsonElement: Any?,
         expected: String,
     ) {
-        val result = getString(jsonElement as? JsonElement)
+        val result = getString(jsonElement as? JsonElement, maxLength = 100)
 
         assertEquals(expected, result)
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed or features are added. Also, provide relevant motivation and context. If this is a breaking change, explain why and what to expect. -->

- Fixed the issue where a few traits were not set.
- Fixed the issue where if the traits value is of length > 36 then it's not set.
- Fixed the issue where if the event name or property keys contain `-`, then they result in errors.
- Now, we no longer convert the event name / event properties or traits into lowercase. I didn't find any documentation for this. Therefore, I've removed that support.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
<!-- Please include a summary of the technical changes and which issue is fixed or features are added. -->

### FirebaseIntegration.kt

- Refactored the setting of userId code to make it more readable.
- Fixed: Firebase allows traits value up to a maximum length of 36 characters. I’ve applied this limit—previously, the Firebase SDK logged an error when this was exceeded. Now, we trim the value to prevent that.
- Fixed: Premature processing of traits key: Previously, we were prematurely processing the `traits key` by converting it to `lowercase`, which caused issues when fetching the corresponding traits value. This has been fixed by deferring the key processing to the appropriate stage.
- Fixed: Setting of a few traits values. Previously, setting these values caused issues because the Firebase identify API only accepts string values. Previously, we attempted to convert values using `analytics.traits?.getString(key)`, but this did not handle complex types like `JsonArray or JsonObject`. I resolved this by introducing a `getString` method that reliably converts any `JsonElement` type into a `string`.
- Chore: Previously, we were logging `properties` for the track & screen event types. This seems incorrect to me, as we are actually passing `params: Bundle` to the Firebase API, and not the properties. Therefore, I've removed that.

### Utils.kt

- Changed the variable name from `TRACK_RESERVED_KEYWORDS` to `RESERVED_EVENTS_KEYWORDS`: Because we were filtering properties for both track and screen events. The previous name falsely implies that the variable will only be used for the Track events type.
- getTrimmedKey: 
    - Renamed the method to `formatFirebaseKey`, as it was doing more than trimming operation.
    - Added a step to replace `-` with `_`. (This is needed to bring it in parity with v1 integration.)
- Introduced a `getString` method to convert the value into String.
- In `addPropertyToBundle` method - `else` block: Now, value will not be silently dropped, instead a trimmed value will be used. 

### Unit tests

- Added test cases for traits fix and getString method.

## Checklist
<!-- Please ensure that your pull request meets the following requirements by checking the boxes. If something is not applicable, leave it unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [ ] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [ ] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
<!-- Please describe the tests that you ran to verify your changes. Include details about the test environment, test cases, and results. Attach test logs if possible. -->

## Breaking Changes
<!-- If this PR introduces breaking changes, list them here, explaining what is broken and how users can migrate their existing code. -->

- Now, we no longer convert the event name / event properties or traits into lowercase. I didn't find any documentation for this. Therefore, I've removed that support.
- Also, Firebase accepts value with uppercase characters, refer screenshot:

<img width="631" alt="image" src="https://github.com/user-attachments/assets/47d1de28-949e-4c1e-8a8f-014bc7086f2b" />

## Maintainers Checklist
<!-- This section is for project maintainers to use before merging the PR. -->
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
<!-- If your changes involve a UI update, provide before and after screenshots to illustrate your changes. -->

## Additional Context
<!-- Add any other context or information about the pull request that might be helpful, such as related PRs, references, discussions, etc. -->
