### PR TITLE
feat: add overload for reset method with options

### DIFF
--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -26,12 +26,15 @@ import com.rudderstack.sdk.kotlin.android.plugins.sessiontracking.SessionTrackin
 import com.rudderstack.sdk.kotlin.android.storage.provideAndroidStorage
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.platform.Platform
 import com.rudderstack.sdk.kotlin.core.internals.platform.PlatformType
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.internals.utils.isAnalyticsActive
 import com.rudderstack.sdk.kotlin.core.internals.utils.isSourceEnabled
 import com.rudderstack.sdk.kotlin.core.provideAnalyticsConfiguration
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries as AndroidResetEntry
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetOptions as AndroidResetOption
 
 private const val MIN_SESSION_ID_LENGTH = 10
 
@@ -108,12 +111,24 @@ class Analytics(
     /**
      * Resets the user identity, clears the existing anonymous ID and
      * generate a new one, also clears the user ID and traits.
+     *
+     * @param options Android-specific reset options to control which data to reset
      */
-    override fun reset() {
+    override fun reset(options: ResetOptions) {
         if (!isAnalyticsActive()) return
-        super.reset()
 
-        sessionTrackingPlugin.sessionManager.refreshSession()
+        if (options !is AndroidResetOption) {
+            LoggerAnalytics.debug("The options should be of type Android ResetOption.")
+        }
+        if (options.entries !is AndroidResetEntry) {
+            LoggerAnalytics.debug("The entries in ResetOption should be of type Android ResetEntry.")
+        }
+
+        super.reset(options)
+
+        if ((options.entries as? AndroidResetEntry)?.session != false) {
+            sessionTrackingPlugin.sessionManager.refreshSession()
+        }
 
         if (!isSourceEnabled()) return
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -118,7 +118,7 @@ class Analytics(
         if (!isAnalyticsActive()) return
 
         if (options !is AndroidResetOption) {
-            LoggerAnalytics.debug("The options should be of type Android ResetOption.")
+            LoggerAnalytics.debug("The options should be of type Android ResetOptions.")
         }
 
         super.reset(options)

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -109,10 +109,22 @@ class Analytics(
     }
 
     /**
-     * Resets the user identity, clears the existing anonymous ID and
-     * generate a new one, also clears the user ID and traits.
+     * Resets the user identity to its initial state with Android-specific functionality.
      *
-     * @param options Android-specific reset options to control which data to reset
+     * By default, this method:
+     * - Generates a new anonymous ID (clears the existing one)
+     * - Clears the user ID (sets it to empty string)
+     * - Clears user traits (resets to empty JSON object)
+     * - Refreshes the user session (Android-specific behavior)
+     *
+     * @param options Android-specific [ResetOptions] to override the default reset behavior.
+     *                When provided, the `ResetEntries` configuration within these options
+     *                allows selective control over which data entries are reset:
+     *                - `anonymousId`: Controls whether to generate a new anonymous ID
+     *                - `userId`: Controls whether to clear the user ID
+     *                - `traits`: Controls whether to clear user traits
+     *                - `session`: Controls whether to refresh the session (Android-specific)
+     *                These options override the default behavior of resetting all user data.
      */
     override fun reset(options: ResetOptions) {
         if (!isAnalyticsActive()) return

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/Analytics.kt
@@ -120,9 +120,6 @@ class Analytics(
         if (options !is AndroidResetOption) {
             LoggerAnalytics.debug("The options should be of type Android ResetOption.")
         }
-        if (options.entries !is AndroidResetEntry) {
-            LoggerAnalytics.debug("The entries in ResetOption should be of type Android ResetEntry.")
-        }
 
         super.reset(options)
 

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.navigation.NavController
 import com.rudderstack.sdk.kotlin.android.Analytics
 import com.rudderstack.sdk.kotlin.android.Configuration
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.javacompat.JavaAnalytics
 import org.jetbrains.annotations.VisibleForTesting
@@ -48,12 +49,16 @@ class JavaAnalytics private constructor(
         analytics.endSession()
     }
 
+    override fun reset() {
+        analytics.reset()
+    }
+
     /**
      * Resets the user identity, clears the existing anonymous ID and
      * generate a new one, also clears the user ID and traits.
      */
-    override fun reset() {
-        analytics.reset()
+    override fun reset(options: ResetOptions) {
+        analytics.reset(options)
     }
 
     /**

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalytics.kt
@@ -49,13 +49,33 @@ class JavaAnalytics private constructor(
         analytics.endSession()
     }
 
+    /**
+     * Resets the user identity to its initial state.
+     *
+     * This method performs a complete reset by default:
+     * - Generates a new anonymous ID
+     * - Clears the user ID
+     * - Clears user traits
+     * - Refreshes the session (Android-specific)
+     */
     override fun reset() {
         analytics.reset()
     }
 
     /**
-     * Resets the user identity, clears the existing anonymous ID and
-     * generate a new one, also clears the user ID and traits.
+     * Resets the user identity with selective control over which data to reset.
+     *
+     * By default, [reset] clears all user data, but this method overload allows you to override
+     * that behavior using the provided options.
+     *
+     * @param options [ResetOptions] that override the default reset behavior.
+     *                The `ResetEntries` configuration within these options allows
+     *                selective control over which data entries are reset:
+     *                - `anonymousId`: When true, generates a new anonymous ID
+     *                - `userId`: When true, clears the user ID
+     *                - `traits`: When true, clears user traits
+     *                - `session`: When true, refreshes the user session (Android-specific).
+     *                Each flag overrides the default behavior of resetting all data.
      */
     override fun reset(options: ResetOptions) {
         analytics.reset(options)

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetEntriesBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetEntriesBuilder.kt
@@ -1,0 +1,56 @@
+package com.rudderstack.sdk.kotlin.android.javacompat
+
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries
+import com.rudderstack.sdk.kotlin.core.javacompat.ResetEntriesBuilder
+
+/**
+ * Builder class for creating ResetEntries instances.
+ *
+ * This builder class provides Java interop support for configuring reset entries.
+ */
+class ResetEntriesBuilder : ResetEntriesBuilder() {
+
+    private var session: Boolean = true
+
+    /**
+     * Sets whether to reset the session data.
+     */
+    fun setSession(reset: Boolean) = apply {
+        session = reset
+    }
+
+    /**
+     * Sets whether to reset the anonymous ID.
+     */
+    override fun setAnonymousId(reset: Boolean) = apply {
+        super.setAnonymousId(reset)
+    }
+
+    /**
+     * Sets whether to reset the user ID.
+     */
+    override fun setUserId(reset: Boolean) = apply {
+        super.setUserId(reset)
+    }
+
+    /**
+     * Sets whether to reset user traits.
+     */
+    override fun setTraits(reset: Boolean) = apply {
+        super.setTraits(reset)
+    }
+
+    /**
+     * Builds the ResetEntries instance with the configured properties.
+     */
+    override fun build(): ResetEntries {
+        val coreEntries = super.build()
+
+        return ResetEntries(
+            anonymousId = coreEntries.anonymousId,
+            userId = coreEntries.userId,
+            traits = coreEntries.traits,
+            session = session
+        )
+    }
+}

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetEntriesBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetEntriesBuilder.kt
@@ -4,44 +4,68 @@ import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries
 import com.rudderstack.sdk.kotlin.core.javacompat.ResetEntriesBuilder
 
 /**
- * Builder class for creating ResetEntries instances.
+ * Android-specific builder class for creating [ResetEntries] instances with Java interoperability.
  *
- * This builder class provides Java interop support for configuring reset entries.
+ * This builder extends the core [ResetEntriesBuilder] to provide Android-specific functionality
+ * such as control over refreshing the user session. It provides a fluent API for Java clients to configure reset
+ * entry options that override the default reset behavior.
+ *
+ * Example usage:
+ * ```java
+ * ResetEntries entries = new ResetEntriesBuilder()
+ *     .setAnonymousId(true)   // Generate new anonymous ID
+ *     .setUserId(false)       // Keep current user ID (override default)
+ *     .setTraits(true)        // Clear user traits
+ *     .setSession(false)      // Keep current session (override default)
+ *     .build();
+ * ```
  */
 class ResetEntriesBuilder : ResetEntriesBuilder() {
 
     private var session: Boolean = true
 
     /**
-     * Sets whether to reset the session data.
+     * Sets whether to reset the session data, overriding the default behavior (Android-specific).
+     *
+     * @param reset When true, refreshes the current session (default behavior).
+     *              When false, keeps the current session (overrides default).
      */
     fun setSession(reset: Boolean) = apply {
         session = reset
     }
 
     /**
-     * Sets whether to reset the anonymous ID.
+     * Sets whether to reset the anonymous ID, overriding the default behavior.
+     *
+     * @param reset When true, generates a new anonymous ID (default behavior).
+     *              When false, keeps the current anonymous ID (overrides default).
      */
     override fun setAnonymousId(reset: Boolean) = apply {
         super.setAnonymousId(reset)
     }
 
     /**
-     * Sets whether to reset the user ID.
+     * Sets whether to reset the user ID, overriding the default behavior.
+     *
+     * @param reset When true, clears the user ID to empty string (default behavior).
+     *              When false, keeps the current user ID (overrides default).
      */
     override fun setUserId(reset: Boolean) = apply {
         super.setUserId(reset)
     }
 
     /**
-     * Sets whether to reset user traits.
+     * Sets whether to reset user traits, overriding the default behavior.
+     *
+     * @param reset When true, clears user traits to empty JSON object (default behavior).
+     *              When false, keeps the current user traits (overrides default).
      */
     override fun setTraits(reset: Boolean) = apply {
         super.setTraits(reset)
     }
 
     /**
-     * Builds the ResetEntries instance with the configured properties.
+     * Builds the [ResetEntries] instance with the configured properties.
      */
     override fun build(): ResetEntries {
         val coreEntries = super.build()

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetOptionsBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetOptionsBuilder.kt
@@ -7,16 +7,38 @@ import com.rudderstack.sdk.kotlin.core.javacompat.ResetOptionsBuilder
 import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries as AndroidResetEntries
 
 /**
- * Builder class for creating ResetOptions instances.
+ * Android-specific builder class for creating [ResetOptions] instances with Java interoperability.
  *
- * This builder class provides Java interop support for configuring reset options.
+ * This builder extends the core [ResetOptionsBuilder] to provide Android-specific functionality
+ * such as control over refreshing the user session. It provides a fluent API for Java clients to configure reset
+ * options that override the default reset behavior.
+ *
+ * Example usage:
+ * ```java
+ * ResetEntries customEntries = new ResetEntriesBuilder()
+ *     .setUserId(true)
+ *     .setAnonymousId(false)  // Override default - keep anonymous ID
+ *     .setTraits(true)
+ *     .setSession(false)      // Override default - keep session
+ *     .build();
+ *
+ * ResetOptions options = new ResetOptionsBuilder()
+ *     .setEntries(customEntries)
+ *     .build();
+ *
+ * analytics.reset(options);
+ * ```
  */
 class ResetOptionsBuilder : ResetOptionsBuilder() {
 
     private var entries: AndroidResetEntries = AndroidResetEntries()
 
     /**
-     * Sets the reset entries configuration.
+     * Sets the ResetEntries configuration that overrides the default reset behavior.
+     *
+     * @param entries [ResetEntries] configuration that specifies which data types
+     *                should be reset, allowing selective override of the default
+     *                behavior (which resets all data including session).
      */
     override fun setEntries(entries: ResetEntries) = apply {
         this.entries = AndroidResetEntries(

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetOptionsBuilder.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetOptionsBuilder.kt
@@ -1,0 +1,38 @@
+package com.rudderstack.sdk.kotlin.android.javacompat
+
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries.Companion.DEFAULT_SESSION
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetOptions
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
+import com.rudderstack.sdk.kotlin.core.javacompat.ResetOptionsBuilder
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries as AndroidResetEntries
+
+/**
+ * Builder class for creating ResetOptions instances.
+ *
+ * This builder class provides Java interop support for configuring reset options.
+ */
+class ResetOptionsBuilder : ResetOptionsBuilder() {
+
+    private var entries: AndroidResetEntries = AndroidResetEntries()
+
+    /**
+     * Sets the reset entries configuration.
+     */
+    override fun setEntries(entries: ResetEntries) = apply {
+        this.entries = AndroidResetEntries(
+            anonymousId = entries.anonymousId,
+            userId = entries.userId,
+            traits = entries.traits,
+            session = (entries as? AndroidResetEntries)?.session ?: DEFAULT_SESSION
+        )
+    }
+
+    /**
+     * Builds the ResetOptions instance with the configured properties.
+     */
+    override fun build(): ResetOptions {
+        return ResetOptions(
+            entries = entries
+        )
+    }
+}

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetEntries.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetEntries.kt
@@ -1,0 +1,20 @@
+package com.rudderstack.sdk.kotlin.android.models.reset
+
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
+
+/**
+ * `ResetEntries` is an Android-specific data class that extends the core ResetEntries model
+ * to define which user-related data entries should be reset when performing a reset operation.
+ * This class includes Android-specific functionality such as session management.
+ *
+ * @property anonymousId Flag indicating whether to reset the anonymous ID. Defaults to true.
+ * @property userId Flag indicating whether to reset the user ID. Defaults to true.
+ * @property traits Flag indicating whether to reset user traits. Defaults to true.
+ * @property session Flag indicating whether to reset the session data. Defaults to true.
+ */
+data class ResetEntries @JvmOverloads constructor(
+    override val anonymousId: Boolean = true,
+    override val userId: Boolean = true,
+    override val traits: Boolean = true,
+    val session: Boolean = true,
+) : ResetEntries()

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetEntries.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetEntries.kt
@@ -13,8 +13,17 @@ import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
  * @property session Flag indicating whether to reset the session data. Defaults to true.
  */
 data class ResetEntries @JvmOverloads constructor(
-    override val anonymousId: Boolean = true,
-    override val userId: Boolean = true,
-    override val traits: Boolean = true,
-    val session: Boolean = true,
-) : ResetEntries()
+    override val anonymousId: Boolean = DEFAULT_ANONYMOUS_ID,
+    override val userId: Boolean = DEFAULT_USER_ID,
+    override val traits: Boolean = DEFAULT_TRAITS,
+    val session: Boolean = DEFAULT_SESSION,
+) : ResetEntries() {
+
+    companion object {
+
+        /**
+         * Default status of resetting the user session.
+         */
+        internal const val DEFAULT_SESSION = true
+    }
+}

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetEntries.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetEntries.kt
@@ -3,14 +3,23 @@ package com.rudderstack.sdk.kotlin.android.models.reset
 import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
 
 /**
- * `ResetEntries` is an Android-specific data class that extends the core ResetEntries model
+ * Android-specific configuration class that extends the [ResetEntries] model
  * to define which user-related data entries should be reset when performing a reset operation.
- * This class includes Android-specific functionality such as session management.
  *
- * @property anonymousId Flag indicating whether to reset the anonymous ID. Defaults to true.
- * @property userId Flag indicating whether to reset the user ID. Defaults to true.
- * @property traits Flag indicating whether to reset user traits. Defaults to true.
- * @property session Flag indicating whether to reset the session data. Defaults to true.
+ * This class allows you to override the default reset behavior (which resets all data)
+ * by selectively controlling which specific data entries are reset. Each boolean flag
+ * overrides the default behavior for that specific data type.
+ *
+ * This class includes Android-specific functionality such as user session.
+ *
+ * @property anonymousId Flag that overrides the default behavior for anonymous ID reset.
+ *                       When true, generates a new anonymous ID (default: true).
+ * @property userId Flag that overrides the default behavior for user ID reset.
+ *                  When true, clears the user ID to empty string (default: true).
+ * @property traits Flag that overrides the default behavior for user traits reset.
+ *                  When true, clears user traits to empty JSON object (default: true).
+ * @property session Flag that overrides the default behavior for session reset (Android-specific).
+ *                   When true, refreshes the current session (default: true).
  */
 data class ResetEntries @JvmOverloads constructor(
     override val anonymousId: Boolean = DEFAULT_ANONYMOUS_ID,

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetOptions.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetOptions.kt
@@ -7,8 +7,8 @@ import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
  * to configure the reset operation for user data. This class provides Android-specific
  * reset functionality and options.
  *
- * @property entries The specific entries to reset, using the Android-specific ResetEntries configuration.
- *                   Defaults to a new ResetEntries instance with all flags set to true.
+ * @property entries The specific entries to reset, using the Android-specific `ResetEntries` configuration.
+ *                   Defaults to a new `ResetEntries` instance with all flags set to true.
  */
 data class ResetOptions @JvmOverloads constructor(
     override val entries: ResetEntries = ResetEntries(),

--- a/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetOptions.kt
+++ b/android/src/main/kotlin/com/rudderstack/sdk/kotlin/android/models/reset/ResetOptions.kt
@@ -1,0 +1,15 @@
+package com.rudderstack.sdk.kotlin.android.models.reset
+
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
+
+/**
+ * `ResetOptions` is an Android-specific data class that extends the core ResetOptions model
+ * to configure the reset operation for user data. This class provides Android-specific
+ * reset functionality and options.
+ *
+ * @property entries The specific entries to reset, using the Android-specific ResetEntries configuration.
+ *                   Defaults to a new ResetEntries instance with all flags set to true.
+ */
+data class ResetOptions @JvmOverloads constructor(
+    override val entries: ResetEntries = ResetEntries(),
+) : ResetOptions()

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/AnalyticsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/AnalyticsTest.kt
@@ -42,6 +42,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -275,16 +276,16 @@ class AnalyticsTest {
         // Setup initial state with user data
         analytics.identify(userId = USER_ID, traits = TRAITS)
         val originalAnonymousId = analytics.anonymousId
-        val originalUserId = analytics.userId
         val originalTraits = analytics.traits
         val originalSessionId = analytics.sessionId
-        
+
+        every { DateTimeUtils.getSystemCurrentTime() } returns NEW_SESSION_ID.toMilliSeconds()
         val resetOptions = AndroidResetOptions(
             entries = AndroidResetEntries(
                 anonymousId = false,
-                userId = false,
+                userId = true,
                 traits = false,
-                session = false
+                session = true
             )
         )
 
@@ -297,9 +298,9 @@ class AnalyticsTest {
         val newSessionId = analytics.sessionId
         
         assertEquals(originalAnonymousId, newAnonymousId) // AnonymousId should remain unchanged
-        assertEquals(originalUserId, newUserId) // UserId should remain unchanged
+        assertEquals("", newUserId) // UserId should be cleared
         assertEquals(originalTraits, newTraits) // Traits should remain unchanged
-        assertEquals(originalSessionId, newSessionId) // Session should remain unchanged
+        assertTrue(newSessionId != originalSessionId) // Session should change
     }
 
     @Test

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/AnalyticsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/AnalyticsTest.kt
@@ -249,7 +249,7 @@ class AnalyticsTest {
         analytics.reset(coreResetOptions)
 
         verify(exactly = 1) {
-            LoggerAnalytics.debug("The options should be of type Android ResetOption.")
+            LoggerAnalytics.debug("The options should be of type Android ResetOptions.")
         }
     }
 
@@ -267,7 +267,7 @@ class AnalyticsTest {
         analytics.reset(androidResetOptions)
 
         verify(exactly = 0) {
-            LoggerAnalytics.debug("The options should be of type Android ResetOption.")
+            LoggerAnalytics.debug("The options should be of type Android ResetOptions.")
         }
     }
     

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.navigation.NavController
 import com.rudderstack.sdk.kotlin.android.Configuration
 import com.rudderstack.sdk.kotlin.android.Analytics
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import io.mockk.MockKAnnotations
 import io.mockk.confirmVerified
@@ -79,6 +80,16 @@ class JavaAnalyticsTest {
         javaAnalytics.reset()
 
         verify { mockAnalytics.reset(any()) }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when reset is called with options, then it should call the corresponding method on Analytics`() {
+        val options = ResetOptions()
+
+        javaAnalytics.reset(options)
+
+        verify { mockAnalytics.reset(options) }
         confirmVerified(mockAnalytics)
     }
 

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/JavaAnalyticsTest.kt
@@ -78,7 +78,7 @@ class JavaAnalyticsTest {
     fun `when reset is called, then it should call the corresponding method on Analytics`() {
         javaAnalytics.reset()
 
-        verify { mockAnalytics.reset() }
+        verify { mockAnalytics.reset(any()) }
         confirmVerified(mockAnalytics)
     }
 

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetEntriesBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetEntriesBuilderTest.kt
@@ -1,0 +1,72 @@
+package com.rudderstack.sdk.kotlin.android.javacompat
+
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ResetEntriesBuilderTest {
+
+    private lateinit var resetEntriesBuilder: ResetEntriesBuilder
+
+    @BeforeEach
+    fun setUp() {
+        resetEntriesBuilder = ResetEntriesBuilder()
+    }
+
+    @Test
+    fun `when ResetEntries object is created with only default values, then it should have default values`() {
+        val resetEntries = resetEntriesBuilder.build()
+
+        val expectedResetEntries = ResetEntries()
+        assertEquals(expectedResetEntries, resetEntries)
+    }
+
+    @Test
+    fun `when setAnonymousId is set to false, then anonymousId should be false`() {
+        val resetEntries = resetEntriesBuilder.setAnonymousId(false).build()
+
+        assertFalse(resetEntries.anonymousId)
+    }
+
+    @Test
+    fun `when setUserId is set to false, then userId should be false`() {
+        val resetEntries = resetEntriesBuilder.setUserId(false).build()
+
+        assertFalse(resetEntries.userId)
+    }
+
+    @Test
+    fun `when setTraits is set to false, then traits should be false`() {
+        val resetEntries = resetEntriesBuilder.setTraits(false).build()
+
+        assertFalse(resetEntries.traits)
+    }
+
+    @Test
+    fun `when setSession is set to false, then session should be false`() {
+        val resetEntries = resetEntriesBuilder.setSession(false).build()
+
+        assertFalse(resetEntries.session)
+    }
+
+    @Test
+    fun `when all custom configurations are set, then the ResetEntries object should reflect those values`() {
+        val actualResetEntries = resetEntriesBuilder
+            .setAnonymousId(false)
+            .setUserId(false)
+            .setTraits(false)
+            .setSession(false)
+            .build()
+
+        val expectedResetEntries = ResetEntries(
+            anonymousId = false,
+            userId = false,
+            traits = false,
+            session = false
+        )
+
+        assertEquals(expectedResetEntries, actualResetEntries)
+    }
+}

--- a/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetOptionsBuilderTest.kt
+++ b/android/src/test/kotlin/com/rudderstack/sdk/kotlin/android/javacompat/ResetOptionsBuilderTest.kt
@@ -1,0 +1,67 @@
+package com.rudderstack.sdk.kotlin.android.javacompat
+
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetOptions
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries as CoreResetEntries
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ResetOptionsBuilderTest {
+
+    private lateinit var resetOptionsBuilder: ResetOptionsBuilder
+
+    @BeforeEach
+    fun setUp() {
+        resetOptionsBuilder = ResetOptionsBuilder()
+    }
+
+    @Test
+    fun `when ResetOptions object is created with only default values, then it should have default values`() {
+        val resetOptions = resetOptionsBuilder.build()
+
+        val expectedResetOptions = ResetOptions()
+        assertEquals(expectedResetOptions, resetOptions)
+    }
+
+    @Test
+    fun `when setEntries is set with core ResetEntries, then entries should be converted to Android ResetEntries`() {
+        val coreEntries = CoreResetEntries(
+            anonymousId = false,
+            userId = false,
+            traits = false
+        )
+
+        val resetOptions = resetOptionsBuilder.setEntries(coreEntries).build()
+
+        val expectedEntries = ResetEntries(
+            anonymousId = false,
+            userId = false,
+            traits = false,
+            session = true // Should use default session value
+        )
+
+        assertEquals(expectedEntries, resetOptions.entries)
+    }
+
+    @Test
+    fun `when setEntries is set with Android ResetEntries, then entries should be updated`() {
+        val androidEntries = ResetEntries(
+            anonymousId = false,
+            userId = true,
+            traits = false,
+            session = false
+        )
+
+        val resetOptions = resetOptionsBuilder.setEntries(androidEntries).build()
+
+        val expectedEntries = ResetEntries(
+            anonymousId = false,
+            userId = true,
+            traits = false,
+            session = false
+        )
+
+        assertEquals(expectedEntries, resetOptions.entries)
+    }
+}

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -11,7 +11,11 @@ import androidx.navigation.NavController;
 import com.rudderstack.sdk.kotlin.android.Configuration;
 import com.rudderstack.sdk.kotlin.android.SessionConfiguration;
 import com.rudderstack.sdk.kotlin.android.javacompat.ConfigurationBuilder;
+import com.rudderstack.sdk.kotlin.android.javacompat.ResetEntriesBuilder;
+import com.rudderstack.sdk.kotlin.android.javacompat.ResetOptionsBuilder;
 import com.rudderstack.sdk.kotlin.android.javacompat.SessionConfigurationBuilder;
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries;
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetOptions;
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger;
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics;
 import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId;
@@ -19,10 +23,6 @@ import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
 import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics;
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin;
 import com.rudderstack.sdk.kotlin.core.javacompat.RudderOptionBuilder;
-import com.rudderstack.sdk.kotlin.core.javacompat.ResetEntriesBuilder;
-import com.rudderstack.sdk.kotlin.core.javacompat.ResetOptionsBuilder;
-import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries;
-import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -118,12 +118,14 @@ public class JavaCompat {
      * @param resetUserId Whether to reset the user ID
      * @param resetAnonymousId Whether to reset the anonymous ID
      * @param resetTraits Whether to reset user traits
+     * @param resetSession Whether to reset user session
      */
-    public void resetWithOptions(boolean resetUserId, boolean resetAnonymousId, boolean resetTraits) {
+    public void resetWithOptions(boolean resetUserId, boolean resetAnonymousId, boolean resetTraits, boolean resetSession) {
         ResetEntries resetEntries = new ResetEntriesBuilder()
                 .setUserId(resetUserId)
                 .setAnonymousId(resetAnonymousId)
                 .setTraits(resetTraits)
+                .setSession(resetSession)
                 .build();
         
         ResetOptions resetOptions = new ResetOptionsBuilder()

--- a/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
+++ b/app/src/main/java/com/rudderstack/sampleapp/analytics/javacompat/JavaCompat.java
@@ -19,6 +19,10 @@ import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
 import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics;
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin;
 import com.rudderstack.sdk.kotlin.core.javacompat.RudderOptionBuilder;
+import com.rudderstack.sdk.kotlin.core.javacompat.ResetEntriesBuilder;
+import com.rudderstack.sdk.kotlin.core.javacompat.ResetOptionsBuilder;
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries;
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -106,6 +110,27 @@ public class JavaCompat {
      */
     public void reset() {
         analytics.reset();
+    }
+
+    /**
+     * Partial reset with custom configuration.
+     *
+     * @param resetUserId Whether to reset the user ID
+     * @param resetAnonymousId Whether to reset the anonymous ID
+     * @param resetTraits Whether to reset user traits
+     */
+    public void resetWithOptions(boolean resetUserId, boolean resetAnonymousId, boolean resetTraits) {
+        ResetEntries resetEntries = new ResetEntriesBuilder()
+                .setUserId(resetUserId)
+                .setAnonymousId(resetAnonymousId)
+                .setTraits(resetTraits)
+                .build();
+        
+        ResetOptions resetOptions = new ResetOptionsBuilder()
+                .setEntries(resetEntries)
+                .build();
+                
+        analytics.reset(resetOptions);
     }
 
     /**

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavController
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import io.mockk.MockKAnnotations
@@ -12,6 +13,7 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -63,6 +65,60 @@ class JavaCompatTest {
         verify(exactly = 1) {
             mockJavaAnalytics.reset()
         }
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when resetWithOptions is called with all true, then it should call reset with correct options`() {
+        val resetOptionsSlot = slot<ResetOptions>()
+        
+        javaCompat.resetWithOptions(true, true, true)
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.reset(capture(resetOptionsSlot))
+        }
+        
+        val capturedOptions = resetOptionsSlot.captured
+        assertEquals(true, capturedOptions.entries.userId)
+        assertEquals(true, capturedOptions.entries.anonymousId)
+        assertEquals(true, capturedOptions.entries.traits)
+        
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when resetWithOptions is called with all false, then it should call reset with correct options`() {
+        val resetOptionsSlot = slot<ResetOptions>()
+        
+        javaCompat.resetWithOptions(false, false, false)
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.reset(capture(resetOptionsSlot))
+        }
+        
+        val capturedOptions = resetOptionsSlot.captured
+        assertEquals(false, capturedOptions.entries.userId)
+        assertEquals(false, capturedOptions.entries.anonymousId)
+        assertEquals(false, capturedOptions.entries.traits)
+        
+        confirmVerified(mockJavaAnalytics)
+    }
+
+    @Test
+    fun `when resetWithOptions is called with mixed values, then it should call reset with correct options`() {
+        val resetOptionsSlot = slot<ResetOptions>()
+        
+        javaCompat.resetWithOptions(true, false, true)
+
+        verify(exactly = 1) {
+            mockJavaAnalytics.reset(capture(resetOptionsSlot))
+        }
+        
+        val capturedOptions = resetOptionsSlot.captured
+        assertEquals(true, capturedOptions.entries.userId)
+        assertEquals(false, capturedOptions.entries.anonymousId)
+        assertEquals(true, capturedOptions.entries.traits)
+        
         confirmVerified(mockJavaAnalytics)
     }
 

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavController
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sdk.kotlin.android.javacompat.JavaAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
-import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
+import com.rudderstack.sdk.kotlin.android.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import io.mockk.MockKAnnotations
@@ -72,7 +72,7 @@ class JavaCompatTest {
     fun `when resetWithOptions is called with all true, then it should call reset with correct options`() {
         val resetOptionsSlot = slot<ResetOptions>()
         
-        javaCompat.resetWithOptions(true, true, true)
+        javaCompat.resetWithOptions(true, true, true, true)
 
         verify(exactly = 1) {
             mockJavaAnalytics.reset(capture(resetOptionsSlot))
@@ -82,6 +82,7 @@ class JavaCompatTest {
         assertEquals(true, capturedOptions.entries.userId)
         assertEquals(true, capturedOptions.entries.anonymousId)
         assertEquals(true, capturedOptions.entries.traits)
+        assertEquals(true, capturedOptions.entries.session)
         
         confirmVerified(mockJavaAnalytics)
     }
@@ -90,7 +91,7 @@ class JavaCompatTest {
     fun `when resetWithOptions is called with all false, then it should call reset with correct options`() {
         val resetOptionsSlot = slot<ResetOptions>()
         
-        javaCompat.resetWithOptions(false, false, false)
+        javaCompat.resetWithOptions(false, false, false, false)
 
         verify(exactly = 1) {
             mockJavaAnalytics.reset(capture(resetOptionsSlot))
@@ -100,6 +101,7 @@ class JavaCompatTest {
         assertEquals(false, capturedOptions.entries.userId)
         assertEquals(false, capturedOptions.entries.anonymousId)
         assertEquals(false, capturedOptions.entries.traits)
+        assertEquals(false, capturedOptions.entries.session)
         
         confirmVerified(mockJavaAnalytics)
     }
@@ -108,7 +110,7 @@ class JavaCompatTest {
     fun `when resetWithOptions is called with mixed values, then it should call reset with correct options`() {
         val resetOptionsSlot = slot<ResetOptions>()
         
-        javaCompat.resetWithOptions(true, false, true)
+        javaCompat.resetWithOptions(true, false, true, false)
 
         verify(exactly = 1) {
             mockJavaAnalytics.reset(capture(resetOptionsSlot))
@@ -118,6 +120,7 @@ class JavaCompatTest {
         assertEquals(true, capturedOptions.entries.userId)
         assertEquals(false, capturedOptions.entries.anonymousId)
         assertEquals(true, capturedOptions.entries.traits)
+        assertEquals(false, capturedOptions.entries.session)
         
         confirmVerified(mockJavaAnalytics)
     }
@@ -282,7 +285,7 @@ class JavaCompatTest {
         val anonymousId = "anonymousId"
         every { mockJavaAnalytics.anonymousId } returns anonymousId
 
-        val actualAnonymousId = javaCompat.anonymousId
+        val actualAnonymousId = javaCompat.getAnonymousId()
 
         assertEquals(anonymousId, actualAnonymousId)
     }
@@ -292,7 +295,7 @@ class JavaCompatTest {
         val userId = "userId"
         every { mockJavaAnalytics.userId } returns userId
 
-        val actualUserId = javaCompat.userId
+        val actualUserId = javaCompat.getUserId()
 
         assertEquals(userId, actualUserId)
     }
@@ -302,7 +305,7 @@ class JavaCompatTest {
         val traits: Map<String, Any> = mapOf("key-1" to "value-1")
         every { mockJavaAnalytics.traits } returns traits
 
-        val actualTraits = javaCompat.traits
+        val actualTraits = javaCompat.getTraits()
 
         assertEquals(traits, actualTraits)
     }

--- a/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
+++ b/app/src/test/kotlin/com/rudderstack/sampleapp/analytics/javacompat/JavaCompatTest.kt
@@ -285,7 +285,7 @@ class JavaCompatTest {
         val anonymousId = "anonymousId"
         every { mockJavaAnalytics.anonymousId } returns anonymousId
 
-        val actualAnonymousId = javaCompat.getAnonymousId()
+        val actualAnonymousId = javaCompat.anonymousId
 
         assertEquals(anonymousId, actualAnonymousId)
     }
@@ -295,7 +295,7 @@ class JavaCompatTest {
         val userId = "userId"
         every { mockJavaAnalytics.userId } returns userId
 
-        val actualUserId = javaCompat.getUserId()
+        val actualUserId = javaCompat.userId
 
         assertEquals(userId, actualUserId)
     }
@@ -305,7 +305,7 @@ class JavaCompatTest {
         val traits: Map<String, Any> = mapOf("key-1" to "value-1")
         every { mockJavaAnalytics.traits } returns traits
 
-        val actualTraits = javaCompat.getTraits()
+        val actualTraits = javaCompat.traits
 
         assertEquals(traits, actualTraits)
     }

--- a/buildSrc/src/main/kotlin/RudderStackBuildConfig.kt
+++ b/buildSrc/src/main/kotlin/RudderStackBuildConfig.kt
@@ -18,8 +18,8 @@ object RudderStackBuildConfig {
     object AndroidAndCoreSDKs {
 
         const val PACKAGE_NAME = "com.rudderstack.sdk.kotlin"
-        const val VERSION_NAME = "1.0.0"
-        const val VERSION_CODE = "2"
+        const val VERSION_NAME = "1.1.0-beta.1"
+        const val VERSION_CODE = "3"
 
         object AndroidPublishConfig : MavenPublishConfig {
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -372,11 +372,11 @@ open class Analytics protected constructor(
     open fun reset(options: ResetOptions = ResetOptions()) {
         if (!isAnalyticsActive()) return
 
-        userIdentityState.dispatch(ResetUserIdentityAction(options))
+        userIdentityState.dispatch(ResetUserIdentityAction(options.entries))
         analyticsScope.launch(keyValueStorageDispatcher) {
             userIdentityState.value.resetUserIdentity(
                 storage = storage,
-                options = options
+                entries = options.entries
             )
         }
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -14,6 +14,7 @@ import com.rudderstack.sdk.kotlin.core.internals.models.TrackEvent
 import com.rudderstack.sdk.kotlin.core.internals.models.Traits
 import com.rudderstack.sdk.kotlin.core.internals.models.connectivity.ConnectivityState
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.ResetUserIdentityAction
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.SetUserIdAndTraitsAction
 import com.rudderstack.sdk.kotlin.core.internals.models.useridentity.SetUserIdForAliasEvent
@@ -355,14 +356,17 @@ open class Analytics protected constructor(
     /**
      * Resets the user identity, clears the existing anonymous ID and
      * generate a new one, also clears the user ID and traits.
+     *
+     * @param options Reset options to control which data to reset
      */
-    open fun reset() {
+    open fun reset(options: ResetOptions = ResetOptions()) {
         if (!isAnalyticsActive()) return
 
-        userIdentityState.dispatch(ResetUserIdentityAction)
+        userIdentityState.dispatch(ResetUserIdentityAction(options))
         analyticsScope.launch(keyValueStorageDispatcher) {
             userIdentityState.value.resetUserIdentity(
                 storage = storage,
+                options = options
             )
         }
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/Analytics.kt
@@ -354,10 +354,20 @@ open class Analytics protected constructor(
     }
 
     /**
-     * Resets the user identity, clears the existing anonymous ID and
-     * generate a new one, also clears the user ID and traits.
+     * Resets the user identity to its initial state.
      *
-     * @param options Reset options to control which data to reset
+     * By default, this method:
+     * - Generates a new anonymous ID (clears the existing one)
+     * - Clears the user ID (sets it to empty string)
+     * - Clears user traits (resets to empty JSON object)
+     *
+     * @param options Optional [ResetOptions] to override the default reset behavior.
+     *                When provided, the `ResetEntries` configuration within these options
+     *                allows selective control over which data entries are reset:
+     *                - `anonymousId`: Controls whether to generate a new anonymous ID
+     *                - `userId`: Controls whether to clear the user ID
+     *                - `traits`: Controls whether to clear user traits
+     *                If not provided, defaults to resetting all user data.
      */
     open fun reset(options: ResetOptions = ResetOptions()) {
         if (!isAnalyticsActive()) return

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetEntries.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetEntries.kt
@@ -1,13 +1,21 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.reset
 
 /**
- * `ResetEntries` is a configuration class that defines which user-related data entries
- * should be reset when performing a reset operation. This class serves as the base
- * configuration for reset operations across different platforms.
+ * Configuration class that defines which user-related data entries should be reset
+ * when performing a reset operation.
  *
- * @property anonymousId Flag indicating whether to reset the anonymous ID. Defaults to true.
- * @property userId Flag indicating whether to reset the user ID. Defaults to true.
- * @property traits Flag indicating whether to reset user traits. Defaults to true.
+ * This class allows you to override the default reset behavior (which resets all data)
+ * by selectively controlling which specific data entries are reset. Each boolean flag
+ * overrides the default behavior for that specific data type.
+ *
+ * This class serves as the base configuration for reset operations across different platforms.
+ *
+ * @property anonymousId Flag that overrides the default behavior for anonymous ID reset.
+ *                       When true, generates a new anonymous ID (default: true).
+ * @property userId Flag that overrides the default behavior for user ID reset.
+ *                  When true, clears the user ID to empty string (default: true).
+ * @property traits Flag that overrides the default behavior for user traits reset.
+ *                  When true, clears user traits to empty JSON object (default: true).
  */
 open class ResetEntries @JvmOverloads constructor(
     open val anonymousId: Boolean = DEFAULT_ANONYMOUS_ID,

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetEntries.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetEntries.kt
@@ -10,7 +10,25 @@ package com.rudderstack.sdk.kotlin.core.internals.models.reset
  * @property traits Flag indicating whether to reset user traits. Defaults to true.
  */
 open class ResetEntries @JvmOverloads constructor(
-    open val anonymousId: Boolean = true,
-    open val userId: Boolean = true,
-    open val traits: Boolean = true,
-)
+    open val anonymousId: Boolean = DEFAULT_ANONYMOUS_ID,
+    open val userId: Boolean = DEFAULT_USER_ID,
+    open val traits: Boolean = DEFAULT_TRAITS,
+) {
+
+    companion object {
+        /**
+         * Default status of resetting the anonymousId value.
+         */
+        const val DEFAULT_ANONYMOUS_ID = true
+
+        /**
+         * Default status of resetting the userId value.
+         */
+        const val DEFAULT_USER_ID = true
+
+        /**
+         * Default status of resetting the traits.
+         */
+        const val DEFAULT_TRAITS = true
+    }
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetEntries.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetEntries.kt
@@ -1,0 +1,16 @@
+package com.rudderstack.sdk.kotlin.core.internals.models.reset
+
+/**
+ * `ResetEntries` is a configuration class that defines which user-related data entries
+ * should be reset when performing a reset operation. This class serves as the base
+ * configuration for reset operations across different platforms.
+ *
+ * @property anonymousId Flag indicating whether to reset the anonymous ID. Defaults to true.
+ * @property userId Flag indicating whether to reset the user ID. Defaults to true.
+ * @property traits Flag indicating whether to reset user traits. Defaults to true.
+ */
+open class ResetEntries @JvmOverloads constructor(
+    open val anonymousId: Boolean = true,
+    open val userId: Boolean = true,
+    open val traits: Boolean = true,
+)

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetOptions.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetOptions.kt
@@ -1,0 +1,12 @@
+package com.rudderstack.sdk.kotlin.core.internals.models.reset
+
+/**
+ * `ResetOptions` is a configuration class that provides options for reset operations.
+ * This class serves as the base configuration for reset operations across different platforms.
+ *
+ * @property entries The specific entries to reset, using the ResetEntries configuration.
+ *                   Defaults to a new ResetEntries instance with all flags set to true.
+ */
+open class ResetOptions @JvmOverloads constructor(
+    open val entries: ResetEntries = ResetEntries(),
+)

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetOptions.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/ResetOptions.kt
@@ -1,11 +1,17 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.reset
 
 /**
- * `ResetOptions` is a configuration class that provides options for reset operations.
+ * Configuration class that provides options for reset operations.
+ *
+ * This class allows you to override the default reset behavior, which normally
+ * resets all user data (anonymous ID, user ID, and traits). By providing custom
+ * [ResetEntries], you can selectively control which data entries are reset.
+ *
  * This class serves as the base configuration for reset operations across different platforms.
  *
- * @property entries The specific entries to reset, using the ResetEntries configuration.
- *                   Defaults to a new ResetEntries instance with all flags set to true.
+ * @property entries The specific entries configuration that overrides the default reset behavior.
+ *                   Uses `ResetEntries` to selectively control which data is reset.
+ *                   Defaults to a new ResetEntries instance with all flags set to true (full reset).
  */
 open class ResetOptions @JvmOverloads constructor(
     open val entries: ResetEntries = ResetEntries(),

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityAction.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityAction.kt
@@ -1,16 +1,16 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.useridentity
 
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
-import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
 
-internal class ResetUserIdentityAction(val options: ResetOptions) : UserIdentity.UserIdentityAction {
+internal class ResetUserIdentityAction(private val entries: ResetEntries) : UserIdentity.UserIdentityAction {
 
     override fun reduce(currentState: UserIdentity): UserIdentity {
-        return with(options.entries) {
+        return with(entries) {
             currentState.copy(
                 anonymousId = when {
                     anonymousId -> generateUUID()
@@ -29,15 +29,15 @@ internal class ResetUserIdentityAction(val options: ResetOptions) : UserIdentity
     }
 }
 
-internal suspend fun UserIdentity.resetUserIdentity(storage: Storage, options: ResetOptions) {
+internal suspend fun UserIdentity.resetUserIdentity(storage: Storage, entries: ResetEntries) {
     storage.apply {
-        if (options.entries.anonymousId) {
+        if (entries.anonymousId) {
             write(StorageKeys.ANONYMOUS_ID, this@resetUserIdentity.anonymousId)
         }
-        if (options.entries.userId) {
+        if (entries.userId) {
             remove(StorageKeys.USER_ID)
         }
-        if (options.entries.traits) {
+        if (entries.traits) {
             remove(StorageKeys.TRAITS)
         }
     }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityAction.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityAction.kt
@@ -1,26 +1,45 @@
 package com.rudderstack.sdk.kotlin.core.internals.models.useridentity
 
 import com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.storage.Storage
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.empty
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
 
-internal data object ResetUserIdentityAction : UserIdentity.UserIdentityAction {
+internal class ResetUserIdentityAction(val options: ResetOptions) : UserIdentity.UserIdentityAction {
 
     override fun reduce(currentState: UserIdentity): UserIdentity {
         return currentState.copy(
-            anonymousId = generateUUID(),
-            userId = String.empty(),
-            traits = emptyJsonObject,
+            anonymousId = if (options.entries.anonymousId) {
+                generateUUID()
+            } else {
+                currentState.anonymousId
+            },
+            userId = if (options.entries.userId) {
+                String.empty()
+            } else {
+                currentState.userId
+            },
+            traits = if (options.entries.traits) {
+                emptyJsonObject
+            } else {
+                currentState.traits
+            }
         )
     }
 }
 
-internal suspend fun UserIdentity.resetUserIdentity(storage: Storage) {
-    storage.write(StorageKeys.ANONYMOUS_ID, this.anonymousId)
+internal suspend fun UserIdentity.resetUserIdentity(storage: Storage, options: ResetOptions) {
+    if (options.entries.anonymousId) {
+        storage.write(StorageKeys.ANONYMOUS_ID, this.anonymousId)
+    }
     storage.apply {
-        remove(StorageKeys.USER_ID)
-        remove(StorageKeys.TRAITS)
+        if (options.entries.userId) {
+            remove(StorageKeys.USER_ID)
+        }
+        if (options.entries.traits) {
+            remove(StorageKeys.TRAITS)
+        }
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityAction.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityAction.kt
@@ -34,12 +34,10 @@ internal suspend fun UserIdentity.resetUserIdentity(storage: Storage, options: R
     if (options.entries.anonymousId) {
         storage.write(StorageKeys.ANONYMOUS_ID, this.anonymousId)
     }
-    storage.apply {
-        if (options.entries.userId) {
-            remove(StorageKeys.USER_ID)
-        }
-        if (options.entries.traits) {
-            remove(StorageKeys.TRAITS)
-        }
+    if (options.entries.userId) {
+        storage.remove(StorageKeys.USER_ID)
+    }
+    if (options.entries.traits) {
+        storage.remove(StorageKeys.TRAITS)
     }
 }

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -3,6 +3,7 @@ package com.rudderstack.sdk.kotlin.core.javacompat
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.Configuration
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.toJsonObject
 import com.rudderstack.sdk.kotlin.core.javacompat.JsonInteropHelper.toRawMap
@@ -349,6 +350,15 @@ open class JavaAnalytics protected constructor(
      */
     open fun reset() {
         analytics.reset()
+    }
+
+    /**
+     * Clears user data and identifiers from the analytics instance with specific options
+     *
+     * @param options The reset options that specify which data entries should be reset
+     */
+    open fun reset(options: ResetOptions) {
+        analytics.reset(options = options)
     }
 }
 

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalytics.kt
@@ -346,16 +346,30 @@ open class JavaAnalytics protected constructor(
     }
 
     /**
-     * Clears all user data and identifiers from the analytics instance
+     * Resets the user identity to its initial state.
+     *
+     * This method performs a complete reset by default:
+     * - Generates a new anonymous ID
+     * - Clears the user ID
+     * - Clears user traits
      */
     open fun reset() {
         analytics.reset()
     }
 
     /**
-     * Clears user data and identifiers from the analytics instance with specific options
+     * Resets the user identity with selective control over which data to reset.
      *
-     * @param options The reset options that specify which data entries should be reset
+     * By default, [reset] clears all user data, but this method overload allows you to override
+     * that behavior using the provided options.
+     *
+     * @param options [ResetOptions] that override the default reset behavior.
+     *                The `ResetEntries` configuration within these options allows
+     *                selective control over which data entries are reset:
+     *                - `anonymousId`: When true, generates a new anonymous ID
+     *                - `userId`: When true, clears the user ID
+     *                - `traits`: When true, clears user traits
+     *                Each flag overrides the default behavior of resetting all data.
      */
     open fun reset(options: ResetOptions) {
         analytics.reset(options = options)

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetEntriesBuilder.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetEntriesBuilder.kt
@@ -3,9 +3,21 @@ package com.rudderstack.sdk.kotlin.core.javacompat
 import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
 
 /**
- * Builder class for creating ResetEntries instances.
+ * Builder class for creating ResetEntries instances with Java interoperability.
  *
- * This builder class provides Java interop support for configuring reset entries.
+ * This builder provides a fluent API for Java clients to configure reset entry options
+ * that override the default reset behavior. Each setter method allows you to specify
+ * whether a particular data type should be reset, overriding the default behavior
+ * of resetting all data.
+ *
+ * Example usage:
+ * ```java
+ * ResetEntries entries = new ResetEntriesBuilder()
+ *     .setAnonymousId(true)   // Generate new anonymous ID
+ *     .setUserId(false)       // Keep current user ID (override default)
+ *     .setTraits(true)        // Clear user traits
+ *     .build();
+ * ```
  */
 open class ResetEntriesBuilder {
 
@@ -14,21 +26,30 @@ open class ResetEntriesBuilder {
     private var traits: Boolean = true
 
     /**
-     * Sets whether to reset the anonymous ID.
+     * Sets whether to reset the anonymous ID, overriding the default behavior.
+     *
+     * @param reset When true, generates a new anonymous ID (default behavior).
+     *              When false, keeps the current anonymous ID (overrides default).
      */
     open fun setAnonymousId(reset: Boolean) = apply {
         anonymousId = reset
     }
 
     /**
-     * Sets whether to reset the user ID.
+     * Sets whether to reset the user ID, overriding the default behavior.
+     *
+     * @param reset When true, clears the user ID to empty string (default behavior).
+     *              When false, keeps the current user ID (overrides default).
      */
     open fun setUserId(reset: Boolean) = apply {
         userId = reset
     }
 
     /**
-     * Sets whether to reset user traits.
+     * Sets whether to reset user traits, overriding the default behavior.
+     *
+     * @param reset When true, clears user traits to empty JSON object (default behavior).
+     *              When false, keeps the current user traits (overrides default).
      */
     open fun setTraits(reset: Boolean) = apply {
         traits = reset

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetEntriesBuilder.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetEntriesBuilder.kt
@@ -1,0 +1,47 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
+
+/**
+ * Builder class for creating ResetEntries instances.
+ *
+ * This builder class provides Java interop support for configuring reset entries.
+ */
+open class ResetEntriesBuilder {
+
+    private var anonymousId: Boolean = true
+    private var userId: Boolean = true
+    private var traits: Boolean = true
+
+    /**
+     * Sets whether to reset the anonymous ID.
+     */
+    open fun setAnonymousId(reset: Boolean) = apply {
+        anonymousId = reset
+    }
+
+    /**
+     * Sets whether to reset the user ID.
+     */
+    open fun setUserId(reset: Boolean) = apply {
+        userId = reset
+    }
+
+    /**
+     * Sets whether to reset user traits.
+     */
+    open fun setTraits(reset: Boolean) = apply {
+        traits = reset
+    }
+
+    /**
+     * Builds the ResetEntries instance with the configured properties.
+     */
+    open fun build(): ResetEntries {
+        return ResetEntries(
+            anonymousId = anonymousId,
+            userId = userId,
+            traits = traits
+        )
+    }
+}

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetOptionsBuilder.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetOptionsBuilder.kt
@@ -4,16 +4,37 @@ import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
 import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 
 /**
- * Builder class for creating ResetOptions instances.
+ * Builder class for creating ResetOptions instances with Java interoperability.
  *
- * This builder class provides Java interop support for configuring reset options.
+ * This builder provides a fluent API for Java clients to configure reset options
+ * that override the default reset behavior. Use this builder to specify custom
+ * [ResetEntries] that selectively control which data entries are reset.
+ *
+ * Example usage:
+ * ```java
+ * ResetEntries customEntries = new ResetEntriesBuilder()
+ *     .setUserId(true)
+ *     .setAnonymousId(false)  // Override default - keep anonymous ID
+ *     .setTraits(true)
+ *     .build();
+ *
+ * ResetOptions options = new ResetOptionsBuilder()
+ *     .setEntries(customEntries)
+ *     .build();
+ *
+ * analytics.reset(options);
+ * ```
  */
 open class ResetOptionsBuilder {
 
     private var entries: ResetEntries = ResetEntries()
 
     /**
-     * Sets the reset entries configuration.
+     * Sets the reset entries configuration that overrides the default reset behavior.
+     *
+     * @param entries [ResetEntries] configuration that specifies which data types
+     *                should be reset, allowing selective override of the default
+     *                behavior (which resets all data).
      */
     open fun setEntries(entries: ResetEntries) = apply {
         this.entries = entries

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetOptionsBuilder.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetOptionsBuilder.kt
@@ -1,0 +1,30 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
+
+/**
+ * Builder class for creating ResetOptions instances.
+ *
+ * This builder class provides Java interop support for configuring reset options.
+ */
+open class ResetOptionsBuilder {
+
+    private var entries: ResetEntries = ResetEntries()
+
+    /**
+     * Sets the reset entries configuration.
+     */
+    open fun setEntries(entries: ResetEntries) = apply {
+        this.entries = entries
+    }
+
+    /**
+     * Builds the ResetOptions instance with the configured properties.
+     */
+    open fun build(): ResetOptions {
+        return ResetOptions(
+            entries = entries
+        )
+    }
+}

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsTest.kt
@@ -187,7 +187,7 @@ class AnalyticsTest {
         analytics.identify(userId = USER_ID, traits = TRAITS)
         analytics.identify(userId = "new-user-id", traits = TRAITS)
 
-        verify(exactly = 1) { analytics.reset() }
+        verify(exactly = 1) { analytics.reset(any()) }
     }
 
     @Test

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityActionTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityActionTest.kt
@@ -3,6 +3,8 @@ package com.rudderstack.sdk.kotlin.core.internals.models.useridentity
 import com.rudderstack.sdk.kotlin.core.ANONYMOUS_ID
 import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.internals.models.provider.provideUserIdentityState
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.storage.StorageKeys
 import com.rudderstack.sdk.kotlin.core.internals.utils.generateUUID
 import com.rudderstack.sdk.kotlin.core.mockAnalytics
@@ -34,10 +36,10 @@ class ResetUserIdentityActionTest {
     }
 
     @Test
-    fun `given some value is present in the user identity, when reset user identity action is performed, then it should reset all values`() {
+    fun `given some value is present in the user identity, when reset user identity action is performed with default options, then it should reset all values`() {
         val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
-        val result = ResetUserIdentityAction
+        val result = ResetUserIdentityAction(ResetOptions())
             .reduce(userIdentityState)
 
         val expected = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
@@ -45,10 +47,10 @@ class ResetUserIdentityActionTest {
     }
 
     @Test
-    fun `given empty user identity and clearAnonymousId is true, when reset user identity action is performed, then it should reset only anonymous ID`() {
+    fun `given empty user identity, when reset user identity action is performed with default options, then it should reset only anonymous ID`() {
         val userIdentityState = provideUserIdentityState()
 
-        val result = ResetUserIdentityAction
+        val result = ResetUserIdentityAction(ResetOptions())
             .reduce(userIdentityState)
 
         val expected = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
@@ -56,21 +58,122 @@ class ResetUserIdentityActionTest {
     }
 
     @Test
-    fun `when reset user identity action is performed, then it should reset all values`() =
+    fun `given user identity with values, when reset user identity action is performed with only anonymousId enabled, then it should reset only anonymous ID`() {
+        val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
+        val resetOptions = ResetOptions(ResetEntries(anonymousId = true, userId = false, traits = false))
+
+        val result = ResetUserIdentityAction(resetOptions)
+            .reduce(userIdentityState)
+
+        val expected = UserIdentity(
+            anonymousId = NEW_ANONYMOUS_ID,
+            userId = USER_ID,
+            traits = TRAITS
+        )
+        assert(expected == result)
+    }
+
+    @Test
+    fun `given user identity with values, when reset user identity action is performed with only userId enabled, then it should reset only user ID`() {
+        val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
+        val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = true, traits = false))
+
+        val result = ResetUserIdentityAction(resetOptions)
+            .reduce(userIdentityState)
+
+        val expected = UserIdentity(
+            anonymousId = ANONYMOUS_ID,
+            userId = "",
+            traits = TRAITS
+        )
+        assert(expected == result)
+    }
+
+    @Test
+    fun `given user identity with values, when reset user identity action is performed with only traits enabled, then it should reset only traits`() {
+        val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
+        val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = false, traits = true))
+
+        val result = ResetUserIdentityAction(resetOptions)
+            .reduce(userIdentityState)
+
+        val expected = UserIdentity(
+            anonymousId = ANONYMOUS_ID,
+            userId = USER_ID,
+            traits = com.rudderstack.sdk.kotlin.core.internals.models.emptyJsonObject
+        )
+        assert(expected == result)
+    }
+
+    @Test
+    fun `given user identity with values, when reset user identity action is performed with all flags disabled, then nothing should be reset`() {
+        val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
+        val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = false, traits = false))
+
+        val result = ResetUserIdentityAction(resetOptions)
+            .reduce(userIdentityState)
+
+        val expected = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
+        assert(expected == result)
+    }
+
+    @Test
+    fun `when reset user identity action is performed with default options, then it should reset all values in storage`() =
         runTest {
             val userIdentityState = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
 
-            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage)
+            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, options = ResetOptions())
             testDispatcher.scheduler.advanceUntilIdle()
 
-            coVerify(exactly = 1) {
-                mockAnalytics.storage.apply {
-                    write(StorageKeys.ANONYMOUS_ID, NEW_ANONYMOUS_ID)
-                    remove(StorageKeys.USER_ID)
-                    remove(StorageKeys.TRAITS)
-                }
+            coVerify {
+                mockAnalytics.storage.write(StorageKeys.ANONYMOUS_ID, NEW_ANONYMOUS_ID)
+                mockAnalytics.storage.remove(StorageKeys.USER_ID)
+                mockAnalytics.storage.remove(StorageKeys.TRAITS)
             }
         }
+
+    @Test
+    fun `when reset user identity action is performed with only anonymousId enabled, then it should only update anonymous ID in storage`() =
+        runTest {
+            val userIdentityState = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
+            val resetOptions = ResetOptions(ResetEntries(anonymousId = true, userId = false, traits = false))
+
+            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, options = resetOptions)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify {
+                mockAnalytics.storage.write(StorageKeys.ANONYMOUS_ID, NEW_ANONYMOUS_ID)
+            }
+        }
+
+    @Test
+    fun `when reset user identity action is performed with only userId enabled, then it should only remove user ID from storage`() =
+        runTest {
+            val userIdentityState = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
+            val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = true, traits = false))
+
+            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, options = resetOptions)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify {
+                mockAnalytics.storage.remove(StorageKeys.USER_ID)
+            }
+        }
+
+    @Test
+    fun `when reset user identity action is performed with only traits enabled, then it should only remove traits from storage`() =
+        runTest {
+            val userIdentityState = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
+            val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = false, traits = true))
+
+            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, options = resetOptions)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify {
+                mockAnalytics.storage.remove(StorageKeys.TRAITS)
+            }
+        }
+
 }
 
 private fun provideUserIdentityStateAfterFirstIdentifyEventIsMade(): UserIdentity =

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityActionTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/useridentity/ResetUserIdentityActionTest.kt
@@ -36,10 +36,10 @@ class ResetUserIdentityActionTest {
     }
 
     @Test
-    fun `given some value is present in the user identity, when reset user identity action is performed with default options, then it should reset all values`() {
+    fun `given some value is present in the user identity, when reset user identity action is performed with default entries, then it should reset all values`() {
         val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
 
-        val result = ResetUserIdentityAction(ResetOptions())
+        val result = ResetUserIdentityAction(ResetOptions().entries)
             .reduce(userIdentityState)
 
         val expected = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
@@ -47,10 +47,10 @@ class ResetUserIdentityActionTest {
     }
 
     @Test
-    fun `given empty user identity, when reset user identity action is performed with default options, then it should reset only anonymous ID`() {
+    fun `given empty user identity, when reset user identity action is performed with default entries, then it should reset only anonymous ID`() {
         val userIdentityState = provideUserIdentityState()
 
-        val result = ResetUserIdentityAction(ResetOptions())
+        val result = ResetUserIdentityAction(ResetOptions().entries)
             .reduce(userIdentityState)
 
         val expected = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
@@ -62,7 +62,7 @@ class ResetUserIdentityActionTest {
         val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
         val resetOptions = ResetOptions(ResetEntries(anonymousId = true, userId = false, traits = false))
 
-        val result = ResetUserIdentityAction(resetOptions)
+        val result = ResetUserIdentityAction(resetOptions.entries)
             .reduce(userIdentityState)
 
         val expected = UserIdentity(
@@ -78,7 +78,7 @@ class ResetUserIdentityActionTest {
         val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
         val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = true, traits = false))
 
-        val result = ResetUserIdentityAction(resetOptions)
+        val result = ResetUserIdentityAction(resetOptions.entries)
             .reduce(userIdentityState)
 
         val expected = UserIdentity(
@@ -94,7 +94,7 @@ class ResetUserIdentityActionTest {
         val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
         val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = false, traits = true))
 
-        val result = ResetUserIdentityAction(resetOptions)
+        val result = ResetUserIdentityAction(resetOptions.entries)
             .reduce(userIdentityState)
 
         val expected = UserIdentity(
@@ -106,11 +106,11 @@ class ResetUserIdentityActionTest {
     }
 
     @Test
-    fun `given user identity with values, when reset user identity action is performed with all flags disabled, then nothing should be reset`() {
+    fun `given user identity with values, when reset user identity action is performed with all entries disabled, then nothing should be reset`() {
         val userIdentityState = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
         val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = false, traits = false))
 
-        val result = ResetUserIdentityAction(resetOptions)
+        val result = ResetUserIdentityAction(resetOptions.entries)
             .reduce(userIdentityState)
 
         val expected = provideUserIdentityStateAfterFirstIdentifyEventIsMade()
@@ -118,11 +118,11 @@ class ResetUserIdentityActionTest {
     }
 
     @Test
-    fun `when reset user identity action is performed with default options, then it should reset all values in storage`() =
+    fun `when reset user identity action is performed with default entries, then it should reset all values in storage`() =
         runTest {
             val userIdentityState = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
 
-            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, options = ResetOptions())
+            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, entries = ResetOptions().entries)
             testDispatcher.scheduler.advanceUntilIdle()
 
             coVerify {
@@ -138,7 +138,7 @@ class ResetUserIdentityActionTest {
             val userIdentityState = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
             val resetOptions = ResetOptions(ResetEntries(anonymousId = true, userId = false, traits = false))
 
-            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, options = resetOptions)
+            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, entries = resetOptions.entries)
             testDispatcher.scheduler.advanceUntilIdle()
 
             coVerify {
@@ -152,7 +152,7 @@ class ResetUserIdentityActionTest {
             val userIdentityState = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
             val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = true, traits = false))
 
-            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, options = resetOptions)
+            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, entries = resetOptions.entries)
             testDispatcher.scheduler.advanceUntilIdle()
 
             coVerify {
@@ -166,7 +166,7 @@ class ResetUserIdentityActionTest {
             val userIdentityState = provideUserIdentityState(anonymousId = NEW_ANONYMOUS_ID)
             val resetOptions = ResetOptions(ResetEntries(anonymousId = false, userId = false, traits = true))
 
-            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, options = resetOptions)
+            userIdentityState.resetUserIdentity(storage = mockAnalytics.storage, entries = resetOptions.entries)
             testDispatcher.scheduler.advanceUntilIdle()
 
             coVerify {

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
@@ -4,6 +4,7 @@ import com.rudderstack.sdk.kotlin.core.Analytics
 import com.rudderstack.sdk.kotlin.core.Configuration
 import com.rudderstack.sdk.kotlin.core.assertMapContents
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 import com.rudderstack.sdk.kotlin.core.internals.plugins.Plugin
 import com.rudderstack.sdk.kotlin.core.provideJsonObject
 import com.rudderstack.sdk.kotlin.core.provideMap
@@ -268,6 +269,16 @@ class JavaAnalyticsTest {
         javaAnalytics.reset()
 
         verify(exactly = 1) { mockAnalytics.reset(any()) }
+        confirmVerified(mockAnalytics)
+    }
+
+    @Test
+    fun `when reset is called with options, then it should call the reset method with options on Analytics`() {
+        val options = ResetOptions()
+
+        javaAnalytics.reset(options)
+
+        verify(exactly = 1) { mockAnalytics.reset(options = options) }
         confirmVerified(mockAnalytics)
     }
 }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/JavaAnalyticsTest.kt
@@ -267,7 +267,7 @@ class JavaAnalyticsTest {
     fun `when reset is called, then it should call the reset method on Analytics`() {
         javaAnalytics.reset()
 
-        verify(exactly = 1) { mockAnalytics.reset() }
+        verify(exactly = 1) { mockAnalytics.reset(any()) }
         confirmVerified(mockAnalytics)
     }
 }

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetEntriesBuilderTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetEntriesBuilderTest.kt
@@ -1,0 +1,71 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ResetEntriesBuilderTest {
+
+    private lateinit var resetEntriesBuilder: ResetEntriesBuilder
+
+    @BeforeEach
+    fun setUp() {
+        resetEntriesBuilder = ResetEntriesBuilder()
+    }
+
+    @Test
+    fun `when ResetEntries object is created with only default values, then it should have default values`() {
+        val resetEntries = resetEntriesBuilder.build()
+
+        resetEntries.also {
+            assertTrue(it.anonymousId)
+            assertTrue(it.userId)
+            assertTrue(it.traits)
+        }
+    }
+
+    @Test
+    fun `when setAnonymousId is set to false, then anonymousId should be false`() {
+        val resetEntries = resetEntriesBuilder.setAnonymousId(false).build()
+
+        assertFalse(resetEntries.anonymousId)
+    }
+
+    @Test
+    fun `when setUserId is set to false, then userId should be false`() {
+        val resetEntries = resetEntriesBuilder.setUserId(false).build()
+
+        assertFalse(resetEntries.userId)
+    }
+
+    @Test
+    fun `when setTraits is set to false, then traits should be false`() {
+        val resetEntries = resetEntriesBuilder.setTraits(false).build()
+
+        assertFalse(resetEntries.traits)
+    }
+
+    @Test
+    fun `when all custom configurations are set, then the ResetEntries object should reflect those values`() {
+        val actualResetEntries = resetEntriesBuilder
+            .setAnonymousId(false)
+            .setUserId(false)
+            .setTraits(false)
+            .build()
+
+        val expectedResetEntries = ResetEntries(
+            anonymousId = false,
+            userId = false,
+            traits = false
+        )
+
+        with(actualResetEntries) {
+            assertEquals(expectedResetEntries.anonymousId, anonymousId)
+            assertEquals(expectedResetEntries.userId, userId)
+            assertEquals(expectedResetEntries.traits, traits)
+        }
+    }
+}

--- a/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetOptionsBuilderTest.kt
+++ b/core/src/test/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/ResetOptionsBuilderTest.kt
@@ -1,0 +1,46 @@
+package com.rudderstack.sdk.kotlin.core.javacompat
+
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ResetOptionsBuilderTest {
+
+    private lateinit var resetOptionsBuilder: ResetOptionsBuilder
+
+    @BeforeEach
+    fun setUp() {
+        resetOptionsBuilder = ResetOptionsBuilder()
+    }
+
+    @Test
+    fun `when ResetOptions object is created with only default values, then it should have default values`() {
+        val defaultEntries = ResetEntries()
+
+        val resetOptions = resetOptionsBuilder.build()
+
+        with(resetOptions.entries) {
+            assertEquals(defaultEntries.anonymousId, anonymousId)
+            assertEquals(defaultEntries.userId, userId)
+            assertEquals(defaultEntries.traits, traits)
+        }
+    }
+
+    @Test
+    fun `when setEntries is set with custom ResetEntries, then entries should be updated`() {
+        val customEntries = ResetEntries(
+            anonymousId = false,
+            userId = false,
+            traits = false
+        )
+
+        val resetOptions = resetOptionsBuilder.setEntries(customEntries).build()
+
+        with(resetOptions.entries) {
+            assertEquals(customEntries.anonymousId, anonymousId)
+            assertEquals(customEntries.userId, userId)
+            assertEquals(customEntries.traits, traits)
+        }
+    }
+}

--- a/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
+++ b/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
@@ -11,6 +11,10 @@ import com.rudderstack.sdk.kotlin.core.internals.models.ExternalId;
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption;
 import com.rudderstack.sdk.kotlin.core.javacompat.JavaAnalytics;
 import com.rudderstack.sdk.kotlin.core.javacompat.RudderOptionBuilder;
+import com.rudderstack.sdk.kotlin.core.javacompat.ResetEntriesBuilder;
+import com.rudderstack.sdk.kotlin.core.javacompat.ResetOptionsBuilder;
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries;
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -129,6 +133,34 @@ public class JavaCompat {
     }
 
     /**
+     * Make a RESET call.
+     */
+    public void reset() {
+        analytics.reset();
+    }
+
+    /**
+     * Partial reset with custom configuration.
+     *
+     * @param resetUserId Whether to reset the user ID
+     * @param resetAnonymousId Whether to reset the anonymous ID
+     * @param resetTraits Whether to reset user traits
+     */
+    public void resetWithOptions(boolean resetUserId, boolean resetAnonymousId, boolean resetTraits) {
+        ResetEntries resetEntries = new ResetEntriesBuilder()
+                .setUserId(resetUserId)
+                .setAnonymousId(resetAnonymousId)
+                .setTraits(resetTraits)
+                .build();
+        
+        ResetOptions resetOptions = new ResetOptionsBuilder()
+                .setEntries(resetEntries)
+                .build();
+                
+        analytics.reset(resetOptions);
+    }
+
+    /**
      * Get the anonymous ID.
      *
      * @return The anonymous ID.
@@ -166,6 +198,8 @@ public class JavaCompat {
         javaCompat.group();
         javaCompat.identify();
         javaCompat.alias();
+        javaCompat.reset();
+        javaCompat.resetWithOptions(true, false, true);
 
         LoggerAnalytics.INSTANCE.verbose("JavaCompat: Anonymous ID: " + javaCompat.getAnonymousId());
         LoggerAnalytics.INSTANCE.verbose("JavaCompat: User ID: " + javaCompat.getUserId());

--- a/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/main.kt
+++ b/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/main.kt
@@ -8,6 +8,8 @@ import com.rudderstack.sdk.kotlin.core.internals.logger.LoggerAnalytics
 import com.rudderstack.sdk.kotlin.core.internals.models.Properties
 import com.rudderstack.sdk.kotlin.core.internals.models.RudderOption
 import com.rudderstack.sdk.kotlin.core.internals.models.Traits
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetEntries
+import com.rudderstack.sdk.kotlin.core.internals.models.reset.ResetOptions
 import java.util.Date
 
 private lateinit var analytics: Analytics
@@ -56,5 +58,12 @@ fun trackMessageKotlinAPI(analytics: Analytics) {
         traits = Traits(emptyMap()),
         options = RudderOption()
     )
+
+    analytics.reset()
+
+    analytics.reset(options = ResetOptions(
+        entries = ResetEntries(anonymousId = false, userId = true)
+    ))
+
     LoggerAnalytics.debug("Message sent")
 }


### PR DESCRIPTION
## Description
This PR introduces a new overloaded `reset()` method that accepts a `ResetOptions` parameter, enabling granular control over which user data components should be reset. Instead of always resetting all user data (anonymous ID, user ID, traits and user session), developers can now selectively reset specific components based on their requirements.

The implementation includes new data classes `ResetOptions` and `ResetEntries` that provide a configurable approach to the reset functionality, along with Java-compatible builder classes for seamless integration across both Kotlin and Java codebases.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
### Core Module Changes
- **New Data Classes**: Added `ResetOptions` and `ResetEntries` classes in `core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/models/reset/` package
  - `ResetEntries`: Configures which specific data components to reset (anonymousId, userId, traits) with default values of `true`
  - `ResetOptions`: Wrapper class containing ResetEntries configuration with JVM overloads support for Java compatibility
- **Enhanced Reset Logic**: Modified `ResetUserIdentityAction` class from data object to regular class accepting `ResetOptions`
  - Conditional reset logic based on option flags in the `reduce()` method
  - Updated `resetUserIdentity()` extension function to accept `ResetOptions` parameter
  - Storage operations now respect individual flags (anonymousId write, userId/traits removal)
- **Analytics API Extension**: Added overloaded `reset(options: ResetOptions)` method to main Analytics class
- **Java Compatibility**: Created builder classes for Java interoperability in `core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/javacompat/`
  - `ResetEntriesBuilder`: Fluent API for constructing ResetEntries instances with chainable setters
  - `ResetOptionsBuilder`: Fluent API for constructing ResetOptions instances
- **Updated Java Analytics**: Added `reset(options: ResetOptions)` method to `JavaAnalytics` class for Java API consistency

### Android Module Changes
- **Android-Specific Data Classes**: Added `ResetEntries` and `ResetOptions` in `android/models/reset/` extending the core models
  - `ResetEntries`: Adds a new `session` flag to control whether session data is reset (in addition to anonymousId, userId, traits)
  - `ResetOptions`: Accepts the Android-specific `ResetEntries` for granular reset control
- **Analytics API Extension**: Overridden `reset(options: ResetOptions)` in `android/Analytics.kt` to support Android-specific options and session reset. Added a debug log for nudging users to use the android's `ResetOptions` instead of core's. 
- **Java Compatibility**: Android-specific builder classes in `android/javacompat/`
  - `ResetEntriesBuilder`: Adds `setSession()` for session reset flag
  - `ResetOptionsBuilder`: Accepts Android-specific entries and builds Android `ResetOptions`
- **Java Analytics**: Overridden `reset(options: ResetOptions)` in `android/javacompat/JavaAnalytics.kt` for Android API

### Test Coverage (Core Module)
- **Analytics Tests**: Added 15+ new test cases in `AnalyticsTest.kt` covering all reset option combinations
  - Tests for selective reset functionality (individual flags: anonymousId, userId, traits)
  - Tests for storage operation verification with different flag combinations
  - Tests for edge cases (all flags disabled, SDK shutdown scenarios)
- **ResetUserIdentityAction Tests**: Updated `ResetUserIdentityActionTest.kt` with comprehensive test coverage
  - Tests for conditional reset behavior based on options
  - Storage operation verification tests for each flag combination
- **Java Builder Tests**: Added complete test suites for builder classes
  - `ResetEntriesBuilderTest.kt`: Tests for fluent API and default values
  - `ResetOptionsBuilderTest.kt`: Tests for configuration and builder pattern
- **Java Analytics Tests**: Updated `JavaAnalyticsTest.kt` to verify new reset method integration

### Sample Applications
- **Kotlin JVM App**: Updated `main.kt` with usage examples of the new reset functionality
  - Demonstrates both default and selective reset patterns
- **Java Compatibility Demo**: Updated `JavaCompat.java` with comprehensive examples
  - Shows usage of builder pattern for Java developers
  - Includes `resetWithOptions()` method demonstrating selective reset configuration

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
### Core Module Testing
#### Kotlin API Testing:
```kotlin
// Test default behavior (resets everything)
analytics.reset()

// Test selective reset (only reset user ID and traits, keep anonymous ID)
analytics.reset(options = ResetOptions(
    entries = ResetEntries(
        anonymousId = false,
        userId = true,
        traits = true
    )
))

// Test preserving all data except anonymous ID
analytics.reset(options = ResetOptions(
    entries = ResetEntries(
        anonymousId = true,
        userId = false,
        traits = false
    )
))
```

### Android Module Testing
#### Kotlin API (Android):
```kotlin
import com.rudderstack.sdk.kotlin.android.models.reset.ResetEntries
import com.rudderstack.sdk.kotlin.android.models.reset.ResetOptions

// Reset everything (default)
analytics.reset()

// Selective reset including session
analytics.reset(
    ResetOptions(
        entries = ResetEntries(
            anonymousId = true,
            userId = false,
            traits = false,
            session = true // Android-specific
        )
    )
)
```

#### Java API (Android):
```java
import com.rudderstack.sdk.kotlin.android.javacompat.ResetEntriesBuilder;
import com.rudderstack.sdk.kotlin.android.javacompat.ResetOptionsBuilder;

ResetEntries entries = new ResetEntriesBuilder()
    .setAnonymousId(true)
    .setUserId(false)
    .setTraits(false)
    .setSession(true) // Android-specific
    .build();

ResetOptions options = new ResetOptionsBuilder()
    .setEntries(entries)
    .build();

analytics.reset(options);
```

#### Java API Testing:
```java
// Test default reset
analytics.reset();

// Test selective reset using builders
ResetEntries entries = new ResetEntriesBuilder()
    .setAnonymousId(false)
    .setUserId(true)
    .setTraits(true)
    .build();

ResetOptions options = new ResetOptionsBuilder()
    .setEntries(entries)
    .build();

analytics.reset(options);

// Test using the convenience method in JavaCompat
javaCompat.resetWithOptions(true, false, true); // reset userId and traits, keep anonymousId
```

### Sample Application Testing
#### Kotlin JVM App (`kotlin-jvm-app` module):
- Run the updated `main.kt` to see usage examples
- Verify both default and selective reset functionality
- Check console output for proper reset behavior

#### Java Compatibility Demo:
- Run `JavaCompat.java` to test Java interoperability
- Verify builder pattern works correctly
- Confirm all reset combinations function as expected

### Verification Steps:
1. **Setup**: Identify a user and verify all user data is present (anonymousId, userId, traits, session)
2. **Default Reset**: Call `reset()` without parameters and verify all data is reset
3. **Selective Reset**: Call `reset()` with various option combinations:
   - Core: Reset only anonymousId: `ResetEntries(anonymousId = true, userId = false, traits = false)`
   - Core: Reset only userId: `ResetEntries(anonymousId = false, userId = true, traits = false)`
   - Core: Reset only traits: `ResetEntries(anonymousId = false, userId = false, traits = true)`
   - Android: Reset only session: `ResetEntries(anonymousId = false, userId = false, traits = false, session = true)`
   - Mixed combinations: Various true/false combinations
4. **Storage Verification**: Confirm storage operations align with the specified flags
5. **Session Verification (Android)**: Test session reset functionality when session flag is enabled
6. **Java Interoperability**: Test builder classes work correctly from Java code for both core and Android modules
7. **Edge Cases**: Test with all flags disabled (should preserve all data)

### Unit Test Verification:
- Run `AnalyticsTest.kt` to verify core functionality (15+ new test cases)
- Run `ResetUserIdentityActionTest.kt` to verify action behavior
- Run `ResetEntriesBuilderTest.kt` and `ResetOptionsBuilderTest.kt` for Java builder testing
- Run `JavaAnalyticsTest.kt` to verify Java API integration

## Breaking Changes
None. This is a backward-compatible addition. The existing `reset()` method without parameters continues to work exactly as before, resetting all user data components.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This change involves API functionality without UI components.

## Additional Context
This feature addresses the need for more granular control over reset operations, allowing developers to:
- Preserve anonymous IDs while clearing user identification data for privacy compliance
- Reset only user traits while maintaining identity information
- Implement custom reset strategies based on specific business requirements

### Modules Affected:
- **Core Module**: Primary implementation with new classes, enhanced reset logic, and comprehensive test coverage
- **Android Module**: Android-specific extensions for reset, including session reset, Android-specific data classes, and builder APIs
- **Sample Applications**: Updated kotlin-jvm-app and Java compatibility demos to showcase the new functionality

### Technical Implementation Highlights:
- **Backward Compatibility**: Existing `reset()` method unchanged - internally calls new method with default options
- **Memory Efficiency**: ResetOptions uses default parameters to minimize object creation
- **Thread Safety**: All reset operations maintain existing thread safety guarantees
- **Storage Optimization**: Only necessary storage operations are performed based on reset flags

### Design Decisions:
- **Builder Pattern for Java**: Ensures fluent, readable API for Java developers
- **Immutable Data Classes**: ResetOptions and ResetEntries are immutable for thread safety
- **Default-All-True**: Default behavior resets everything to maintain existing semantics
- **Granular Control**: Each identity component (anonymousId, userId, traits) can be controlled independently

The implementation maintains full backward compatibility and provides comprehensive test coverage for all reset option combinations. The Java builder pattern ensures seamless integration for Java developers while maintaining the idiomatic Kotlin API design.
