### PR TITLE
feat: add write key param in sourceConfig API

### DIFF
--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/SourceConfigManager.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/SourceConfigManager.kt
@@ -157,7 +157,8 @@ private fun Analytics.createGetHttpClientFactory(): HttpClient {
     )
 }
 
-private fun Analytics.getQuery() = when (getPlatformType()) {
+@VisibleForTesting
+internal fun Analytics.getQuery() = when (getPlatformType()) {
     PlatformType.Mobile -> {
         mapOf(
             PLATFORM to ANDROID,

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/SourceConfigManager.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/SourceConfigManager.kt
@@ -30,6 +30,7 @@ private const val VERSION = "v"
 private const val BUILD_VERSION = "bv"
 private const val ANDROID = "android"
 private const val KOTLIN = "kotlin"
+private const val WRITE_KEY = "writeKey"
 
 private const val SOURCE_CONFIG_RETRY_ATTEMPT = 5
 
@@ -161,6 +162,7 @@ private fun Analytics.getQuery() = when (getPlatformType()) {
         mapOf(
             PLATFORM to ANDROID,
             VERSION to this.storage.getLibraryVersion().getVersionName(),
+            WRITE_KEY to this.configuration.writeKey,
             BUILD_VERSION to this.storage.getLibraryVersion().getBuildVersion()
         )
     }
@@ -169,6 +171,7 @@ private fun Analytics.getQuery() = when (getPlatformType()) {
         mapOf(
             PLATFORM to KOTLIN,
             VERSION to this.storage.getLibraryVersion().getVersionName(),
+            WRITE_KEY to this.configuration.writeKey,
         )
     }
 }


### PR DESCRIPTION
## Description
This PR adds the `writeKey` parameter to the query parameters sent when fetching source configuration from the RudderStack Control Plane API. The `writeKey` is now included in the HTTP request query parameters for both mobile (Android) and server (Kotlin JVM) platforms.

The changes include making the `getQuery()` function internal and testable, and adding comprehensive unit tests to verify the correct inclusion of the write key in query parameters for both platform types.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Added `WRITE_KEY` constant to define the query parameter key
- Modified `getQuery()` function to include `writeKey` parameter from `analytics.configuration.writeKey`
- Changed `getQuery()` function visibility from private to internal with `@VisibleForTesting` annotation for testability
- Enhanced query parameter map for both `PlatformType.Mobile` and `PlatformType.Server` to include the write key
- Added comprehensive unit tests covering both mobile and server platform scenarios
- Imported necessary testing utilities including `PlatformType` and `Assertions.assertEquals`

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. **Unit Tests**: Run the new test cases `SourceConfigManagerTest`:
   - `given mobile platform, when getQuery is called, then it should contain correct query params`
   - `given server platform, when getQuery is called, then it should contain correct query params`
   
2. **Integration Testing**: 
   - Initialize the RudderStack SDK with a valid write key
   - Monitor network requests to verify that the `writeKey` parameter is included in source config API calls
   - Test both Android (mobile) and Kotlin JVM (server) platforms
   
3. **Manual Verification**:
   - Check that source configuration requests include the write key in query parameters
   - Verify that the correct platform type (`android` or `kotlin`) is still included
   - Ensure version and build version parameters remain intact

## Breaking Changes
None - This is a non-breaking change that only adds an additional query parameter to existing API calls.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This change involves backend API query parameters and does not affect the UI.

## Additional Context
This feature is part of ticket SDK-2888 which aims to improve source configuration handling by providing the write key as a query parameter. This allows the backend service to:

- Better identify the source making the configuration request
- Improve logging and monitoring capabilities for configuration requests
- Enable more granular access control and rate limiting if needed

The implementation maintains backward compatibility and follows existing patterns in the codebase for query parameter handling across different platform types.