### PR TITLE
fix: logging error method by adding JvmOverloads and add examples

### DIFF
--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
@@ -117,6 +117,7 @@ object LoggerAnalytics {
      * @param log The message to log.
      * @param throwable An optional exception to log alongside the error message.
      */
+    @JvmOverloads
     fun error(log: String, throwable: Throwable? = null) {
         if (Logger.LogLevel.ERROR >= logLevel) {
             logger?.error(log, throwable)

--- a/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
+++ b/kotlin-jvm-app/src/main/java/com/rudderstack/android/kotlin_jvm_app/javacompat/JavaCompat.java
@@ -161,6 +161,18 @@ public class JavaCompat {
     }
 
     /**
+     * Log examples for different log levels.
+     */
+    public void logExamples() {
+        LoggerAnalytics.INSTANCE.verbose("JavaCompat: This is a verbose log");
+        LoggerAnalytics.INSTANCE.debug("JavaCompat: This is a debug log");
+        LoggerAnalytics.INSTANCE.info("JavaCompat: This is an info log");
+        LoggerAnalytics.INSTANCE.warn("JavaCompat: This is a warn log");
+        LoggerAnalytics.INSTANCE.error("JavaCompat: This is an error log");
+        LoggerAnalytics.INSTANCE.error("JavaCompat: This is an error log with exception", new Exception("Sample exception"));
+    }
+
+    /**
      * Get the anonymous ID.
      *
      * @return The anonymous ID.
@@ -200,6 +212,7 @@ public class JavaCompat {
         javaCompat.alias();
         javaCompat.reset();
         javaCompat.resetWithOptions(true, false, true);
+        javaCompat.logExamples();
 
         LoggerAnalytics.INSTANCE.verbose("JavaCompat: Anonymous ID: " + javaCompat.getAnonymousId());
         LoggerAnalytics.INSTANCE.verbose("JavaCompat: User ID: " + javaCompat.getUserId());


### PR DESCRIPTION
## Description
This PR fixes Java compatibility issues with the `LoggerAnalytics.error()` method by adding the `@JvmOverloads` annotation. The issue was that Java code couldn't properly call the Kotlin method with default parameters, specifically the optional `throwable` parameter. Additionally, this PR includes enhanced Java compatibility testing by adding comprehensive logging examples in the JavaCompat test class to demonstrate proper usage of all LoggerAnalytics methods from Java code.

**Issue Fixed:** SDK-3842 - LoggerAnalytics error method compatibility issue with Java

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Added `@JvmOverloads` annotation to the `LoggerAnalytics.error()` method in `LoggerAnalytics.kt` to enable proper Java interoperability with the optional `throwable` parameter
- Enhanced `JavaCompat.java` test class with a new `logExamples()` method that demonstrates usage of all LoggerAnalytics logging levels from Java code
- Added example calls for verbose, debug, info, warn, and error logging methods
- Included example of error logging both with and without exception parameter to verify the fix works correctly
- Updated the main method in JavaCompat to call the new `logExamples()` method for comprehensive testing

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. **Build the project**: Run `./gradlew build` to ensure the project compiles successfully
2. **Run Java compatibility test**: Execute the JavaCompat main method to verify all logging methods work from Java code
3. **Verify error method overloads**: Test both `LoggerAnalytics.error("message")` and `LoggerAnalytics.error("message", exception)` calls from Java
4. **Check compilation**: Ensure Java code can now successfully call the error method without compilation errors
5. **Manual testing**: Create a simple Java class that calls all LoggerAnalytics methods to verify full compatibility

## Breaking Changes
None. This change is fully backward compatible and only improves Java interoperability without affecting existing Kotlin or Java code.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A - This is a backend compatibility fix with no UI changes.

## Additional Context
- This fix addresses the common Kotlin-Java interoperability issue where Kotlin methods with default parameters are not easily callable from Java without the `@JvmOverloads` annotation
- The `@JvmOverloads` annotation generates multiple Java method overloads for different parameter combinations, making the API more Java-friendly
- The enhanced JavaCompat test class serves as both a fix verification and a reference implementation for Java developers using the SDK
- This change specifically resolves issues where Java developers were unable to call `LoggerAnalytics.error("message")` without explicitly passing `null` for the throwable parameter
- The fix maintains full backward compatibility while improving the developer experience for Java users of the SDK