### PR TITLE
ci: refactor publishing and add release scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 import java.io.ByteArrayOutputStream
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.artifacts.ProjectDependency
 
 @Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
@@ -89,6 +92,33 @@ tasks.register("listModules") {
         }
         println("ANDROID_MODULES=${androidModules.joinToString(",")}")
         println("JVM_MODULES=${jvmModules.joinToString(",")}")
+    }
+}
+
+tasks.register("printDependencyChain") {
+    description = "Prints the dependency chain of all publishable modules"
+    group = "help"
+    doLast {
+        println("name|groupId|artifactId|version|packaging|deps")
+        subprojects.forEach { sub ->
+            if (!sub.plugins.hasPlugin("maven-publish")) return@forEach
+
+            val pub = sub.extensions.getByType<PublishingExtension>()
+                .publications.findByName("release") as? MavenPublication
+                ?: return@forEach
+
+            val packaging = if (sub.plugins.hasPlugin("com.android.library")) "aar" else "jar"
+
+            val deps = mutableListOf<String>()
+            sub.configurations.findByName("api")?.dependencies?.forEach { dep ->
+                if (dep is ProjectDependency) deps.add("${dep.dependencyProject.name}:api")
+            }
+            sub.configurations.findByName("implementation")?.dependencies?.forEach { dep ->
+                if (dep is ProjectDependency) deps.add("${dep.dependencyProject.name}:implementation")
+            }
+
+            println("${sub.name}|${pub.groupId}|${pub.artifactId}|${pub.version}|${packaging}|${deps.joinToString(",")}")
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,8 @@ plugins {
 }
 
 tasks.register<Delete>("clean") {
+    group = "build"
+    description = "Deletes the root project build directory"
     delete(rootProject.layout.buildDirectory)
 }
 

--- a/gradle/publishing/publishing.gradle.kts
+++ b/gradle/publishing/publishing.gradle.kts
@@ -1,11 +1,16 @@
 // Unified publishing script for all modules (core, android, and integrations).
 // Each module applies this script via: apply(from = rootProject.file("gradle/publishing/publishing.gradle.kts"))
-// Module type is detected via project.name to resolve the correct groupId, artifactId, and version.
+//
+// Examples:
+//   core    -> groupId: com.rudderstack.sdk.kotlin,         artifactId: core,    version: 6.0.0, packaging: jar
+//   android -> groupId: com.rudderstack.sdk.kotlin,         artifactId: android, version: 6.0.0, packaging: aar
+//   adjust  -> groupId: com.rudderstack.integration.kotlin, artifactId: adjust,  version: 6.0.0, packaging: aar
 
 apply(plugin = "maven-publish")
 apply(plugin = "signing")
 
-// e.g., for android module: ModuleConfig("com.rudderstack.sdk.kotlin", "android", "1.3.0", "aar")
+// ── Data Model ──────────────────────────────────────────────────────────────────
+
 data class ModuleConfig(
     val groupId: String,
     val artifactId: String,
@@ -13,99 +18,93 @@ data class ModuleConfig(
     val pomPackaging: String,
 )
 
-// Computes the next major version for semver range constraints in POM dependencies.
-// e.g., "1.3.0" -> "2.0.0", used to produce ranges like [1.3.0, 2.0.0)
+// ── Module Config Resolution ────────────────────────────────────────────────────
+
+// Returns the base (release) config for any module by name.
+// e.g., "core"    -> ModuleConfig("com.rudderstack.sdk.kotlin", "core", "6.0.0", "jar")
+// e.g., "android" -> ModuleConfig("com.rudderstack.sdk.kotlin", "android", "6.0.0", "aar")
+// e.g., "adjust"  -> ModuleConfig("com.rudderstack.integration.kotlin", "adjust", "6.0.0", "aar")
+fun getModuleConfig(moduleName: String): ModuleConfig = when (moduleName) {
+    "core" -> ModuleConfig(
+        groupId = RudderStackBuildConfig.SDK.PACKAGE_NAME,
+        artifactId = RudderStackBuildConfig.SDK.Core.PublishConfig.artifactId,
+        version = RudderStackBuildConfig.SDK.Core.VERSION_NAME,
+        pomPackaging = RudderStackBuildConfig.SDK.Core.PublishConfig.pomPackaging,
+    )
+    "android" -> ModuleConfig(
+        groupId = RudderStackBuildConfig.SDK.PACKAGE_NAME,
+        artifactId = RudderStackBuildConfig.SDK.Android.PublishConfig.artifactId,
+        version = RudderStackBuildConfig.SDK.Android.VERSION_NAME,
+        pomPackaging = RudderStackBuildConfig.SDK.Android.PublishConfig.pomPackaging,
+    )
+    else -> {
+        val info = RudderStackBuildConfig.Integrations.getModuleInfo(moduleName)
+        ModuleConfig(
+            groupId = RudderStackBuildConfig.Integrations.PACKAGE_NAME,
+            artifactId = info.artifactId,
+            version = info.versionName,
+            pomPackaging = info.pomPackaging,
+        )
+    }
+}
+
+val isRelease = hasProperty("release")
+
+// ── Snapshot Module Tracking ────────────────────────────────────────────────────
+
+// Modules being snapshot-released together. When a dependency is in this set,
+// its POM version is pinned to the exact snapshot instead of a release range.
+//
+// e.g., -PsnapshotModules=core,android,adjust -> setOf("core", "android", "adjust")
+// e.g., (not set)                             -> emptySet()
+val snapshotModules: Set<String> = findProperty("snapshotModules")
+    ?.toString()
+    ?.split(",")
+    ?.map { it.trim() }
+    ?.toSet()
+    ?: emptySet()
+
+// ── Dependency Version Resolution ───────────────────────────────────────────────
+
+// Computes the next major version for semver range constraints.
+// e.g., "6.0.0" -> "7.0.0", used to produce ranges like [6.0.0, 7.0.0)
 fun computeNextMajor(version: String): String {
     val major = version.split(".").first().toInt() + 1
     return "$major.0.0"
 }
 
-// Resolves publishing metadata (groupId, artifactId, version, packaging) based on the module applying this script.
-// Appends "-SNAPSHOT" suffix for non-release builds.
-// e.g., core module    -> ModuleConfig("com.rudderstack.sdk.kotlin", "core", "1.3.0-SNAPSHOT", "jar")
-// e.g., android module -> ModuleConfig("com.rudderstack.sdk.kotlin", "android", "1.3.0-SNAPSHOT", "aar")
-// e.g., adjust module  -> ModuleConfig("com.rudderstack.integration.kotlin", "adjust", "1.2.0-SNAPSHOT", "aar")
-fun getModuleConfig(): ModuleConfig {
-    val isRelease = hasProperty("release")
-    return when (project.name) {
-        "core" -> {
-            val version = RudderStackBuildConfig.SDK.Core.VERSION_NAME
-            ModuleConfig(
-                groupId = RudderStackBuildConfig.SDK.PACKAGE_NAME,
-                artifactId = RudderStackBuildConfig.SDK.Core.PublishConfig.artifactId,
-                version = if (isRelease) version else "$version-SNAPSHOT",
-                pomPackaging = RudderStackBuildConfig.SDK.Core.PublishConfig.pomPackaging,
-            )
-        }
-        "android" -> {
-            val version = RudderStackBuildConfig.SDK.Android.VERSION_NAME
-            ModuleConfig(
-                groupId = RudderStackBuildConfig.SDK.PACKAGE_NAME,
-                artifactId = RudderStackBuildConfig.SDK.Android.PublishConfig.artifactId,
-                version = if (isRelease) version else "$version-SNAPSHOT",
-                pomPackaging = RudderStackBuildConfig.SDK.Android.PublishConfig.pomPackaging,
-            )
-        }
-        else -> {
-
-            // integrations
-            val info = RudderStackBuildConfig.Integrations.getModuleInfo(project.name)
-            ModuleConfig(
-                groupId = RudderStackBuildConfig.Integrations.PACKAGE_NAME,
-                artifactId = info.artifactId,
-                version = if (isRelease) info.versionName else "${info.versionName}-SNAPSHOT",
-                pomPackaging = info.pomPackaging,
-            )
-        }
+// Resolves the POM version for a project dependency based on scope and snapshot state.
+//
+// e.g., core (api dep from android):               "6.0.0"           (exact, tight coupling)
+// e.g., android (implementation dep from adjust):   "[6.0.0, 7.0.0)" (range, loose coupling)
+// e.g., android (snapshot, -PsnapshotModules=...):  "6.0.0-SNAPSHOT" (pinned)
+fun resolveDepVersion(depName: String, isApiDep: Boolean): String {
+    val version = getModuleConfig(depName).version
+    return when {
+        depName in snapshotModules -> "${version}-SNAPSHOT"
+        isApiDep -> version
+        else -> "[${version}, ${computeNextMajor(version)})"
     }
 }
 
-// Maps project dependencies (e.g., project(":core"), project(":android")) to Maven coordinates for the POM.
-// Release builds:
-// - Core dependency: pinned to exact version (android module tightly couples with core)
-// - Android dependency: semver range [current, nextMajor) so integrations stay compatible across minor bumps
-// Snapshot builds:
-// - Both core and android dependencies: pinned to exact snapshot version
-// e.g., release: android's project(":core") -> ("com.rudderstack.sdk.kotlin", "core", "1.3.0")
-// e.g., release: adjust's project(":android") -> ("com.rudderstack.sdk.kotlin", "android", "[1.3.0, 2.0.0)")
-// e.g., snapshot: android's project(":core") -> ("com.rudderstack.sdk.kotlin", "core", "1.3.0-SNAPSHOT")
-// e.g., snapshot: adjust's project(":android") -> ("com.rudderstack.sdk.kotlin", "android", "1.3.0-SNAPSHOT")
-fun resolveProjectDependency(dep: org.gradle.api.artifacts.ProjectDependency): Triple<String, String, String> {
-    val isRelease = hasProperty("release")
-    return when (dep.dependencyProject.name) {
-        "core" -> {
-            val version = RudderStackBuildConfig.SDK.Core.VERSION_NAME
-            Triple(
-                RudderStackBuildConfig.SDK.PACKAGE_NAME,
-                RudderStackBuildConfig.SDK.Core.PublishConfig.artifactId,
-                if (isRelease) version else "$version-SNAPSHOT",
-            )
-        }
-        "android" -> {
-            val version = RudderStackBuildConfig.SDK.Android.VERSION_NAME
-            Triple(
-                RudderStackBuildConfig.SDK.PACKAGE_NAME,
-                RudderStackBuildConfig.SDK.Android.PublishConfig.artifactId,
-                if (isRelease) "[$version, ${computeNextMajor(version)})" else "$version-SNAPSHOT",
-            )
-        }
-        else -> throw IllegalArgumentException("Unexpected project dependency: ${dep.dependencyProject.name}")
-    }
-}
+// ── Publication ─────────────────────────────────────────────────────────────────
 
-// Set project.version so jar/aar filenames match the module's own version
-version = getModuleConfig().version
+// Snapshot suffix applied here — the only place build mode affects the version.
+val moduleConfig = getModuleConfig(project.name)
+val publishVersion = if (isRelease) moduleConfig.version else "${moduleConfig.version}-SNAPSHOT"
+
+version = publishVersion
 
 configure<PublishingExtension> {
     publications {
         register<MavenPublication>("release") {
-            val config = getModuleConfig()
+            val config = moduleConfig.copy(version = publishVersion)
 
             groupId = config.groupId
             artifactId = config.artifactId
             version = config.version
 
-            // Add the artifact (jar for core, aar for android/integrations)
+            // Artifact (jar for core, aar for android/integrations)
             if (config.pomPackaging == "jar") {
                 artifact("${layout.buildDirectory.get()}/libs/${project.name}-${version}.jar") {
                     builtBy(tasks.getByName("assemble"))
@@ -116,11 +115,10 @@ configure<PublishingExtension> {
                 }
             }
 
-            // Add sources and javadoc jars
             artifact(tasks.getByName("javadocJar"))
             artifact(tasks.getByName("sourcesJar"))
 
-            // Add pom configuration
+            // POM metadata
             pom {
                 name.set(RudderStackBuildConfig.POM.NAME)
                 packaging = config.pomPackaging
@@ -148,8 +146,8 @@ configure<PublishingExtension> {
                     developerConnection.set(RudderStackBuildConfig.POM.SCM_DEV_CONNECTION)
                 }
 
-                // Manually build POM dependencies to handle project dependencies correctly.
-                // ProjectDependency instances are resolved to Maven coordinates via resolveProjectDependency(),
+                // POM dependencies — manually built to handle project dependencies correctly.
+                // ProjectDependency instances are resolved via resolveProjectDependency(),
                 // while external dependencies are written as-is.
                 withXml {
                     val dependenciesNode = asNode().appendNode("dependencies")
@@ -158,10 +156,11 @@ configure<PublishingExtension> {
                         if (dep.name == "unspecified") return
 
                         if (dep is org.gradle.api.artifacts.ProjectDependency) {
-                            val (depGroupId, depArtifactId, depVersion) = resolveProjectDependency(dep)
+                            val depConfig = getModuleConfig(dep.dependencyProject.name)
+                            val depVersion = resolveDepVersion(dep.dependencyProject.name, isApiDep = scope == "compile")
                             val dependencyNode = dependenciesNode.appendNode("dependency")
-                            dependencyNode.appendNode("groupId", depGroupId)
-                            dependencyNode.appendNode("artifactId", depArtifactId)
+                            dependencyNode.appendNode("groupId", depConfig.groupId)
+                            dependencyNode.appendNode("artifactId", depConfig.artifactId)
                             dependencyNode.appendNode("version", depVersion)
                             dependencyNode.appendNode("scope", scope)
                         } else {
@@ -174,12 +173,42 @@ configure<PublishingExtension> {
                         }
                     }
 
-                    configurations.findByName("api")?.dependencies?.forEach { dep ->
-                        addDependency(dep, "compile")
+                    val addedDeps = mutableSetOf<String>()
+
+                    fun addDependencyIfNew(dep: org.gradle.api.artifacts.Dependency, scope: String) {
+                        val key = "${dep.group}:${dep.name}"
+                        if (key in addedDeps) return
+                        addedDeps.add(key)
+                        addDependency(dep, scope)
                     }
 
+                    // 1. Declared api dependencies (scope: compile)
+                    configurations.findByName("api")?.dependencies?.forEach { dep ->
+                        addDependencyIfNew(dep, "compile")
+                    }
+
+                    // 2. Kotlin plugin dependencies (scope: compile)
+                    //    The Kotlin plugin adds kotlin-stdlib to apiDependenciesMetadata
+                    //    rather than api directly. We resolve this configuration to pick
+                    //    up those transitive compile dependencies.
+                    configurations.findByName("apiDependenciesMetadata")
+                        ?.resolvedConfiguration
+                        ?.firstLevelModuleDependencies
+                        ?.forEach { resolved ->
+                            val key = "${resolved.moduleGroup}:${resolved.moduleName}"
+                            if (key !in addedDeps) {
+                                addedDeps.add(key)
+                                val dependencyNode = dependenciesNode.appendNode("dependency")
+                                dependencyNode.appendNode("groupId", resolved.moduleGroup)
+                                dependencyNode.appendNode("artifactId", resolved.moduleName)
+                                dependencyNode.appendNode("version", resolved.moduleVersion)
+                                dependencyNode.appendNode("scope", "compile")
+                            }
+                        }
+
+                    // 3. Declared implementation dependencies (scope: runtime)
                     configurations.findByName("implementation")?.dependencies?.forEach { dep ->
-                        addDependency(dep, "runtime")
+                        addDependencyIfNew(dep, "runtime")
                     }
                 }
             }
@@ -187,7 +216,8 @@ configure<PublishingExtension> {
     }
 }
 
-// Signing configuration
+// ── Signing ─────────────────────────────────────────────────────────────────────
+
 configure<SigningExtension> {
     val signingKeyId = System.getenv("SIGNING_KEY_ID")
     val signingKey = System.getenv("SIGNING_PRIVATE_KEY_BASE64")
@@ -196,15 +226,21 @@ configure<SigningExtension> {
     sign(extensions.getByType<PublishingExtension>().publications)
 }
 
-tasks.getByName("publish") {
-    dependsOn("build")
-}
+// ── Task Dependencies ───────────────────────────────────────────────────────────
 
-tasks.getByName("publishToMavenLocal") {
-    dependsOn("build")
-}
+tasks.getByName("publish") { dependsOn("build") }
+tasks.getByName("publishToMavenLocal") { dependsOn("build") }
+tasks.getByName("publishToSonatype") { dependsOn("publish") }
 
-tasks.getByName("publishToSonatype") {
-    dependsOn("publish")
-}
+// ── POM Verification ────────────────────────────────────────────────────────────
 
+// Prints the generated POM XML to stdout for CI dry-runs.
+// e.g., ./gradlew :core:printPom -Prelease
+// e.g., ./gradlew :integrations:adjust:printPom -PsnapshotModules=core,android
+tasks.register("printPom") {
+    dependsOn("generatePomFileForReleasePublication")
+    doLast {
+        val pomFile = layout.buildDirectory.file("publications/release/pom-default.xml").get().asFile
+        println(pomFile.readText())
+    }
+}

--- a/scripts/releases/bump-versions.sh
+++ b/scripts/releases/bump-versions.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Bumps version numbers in RudderStackBuildConfig.kt and gradle.properties
+# based on the affected modules pipe format.
+#
+# Input: file path or stdin containing: module|bump|oldVersion|newVersion
+# Output: modified RudderStackBuildConfig.kt and gradle.properties
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+# --- Input ---
+
+input="${1:--}"
+if [[ "$input" == "-" ]]; then
+    affected=$(cat)
+else
+    affected=$(cat "$input")
+fi
+
+[[ -z "$affected" ]] && exit 0
+
+# --- Bump module versions in RudderStackBuildConfig.kt ---
+
+monorepo_bump="minor"
+
+while IFS='|' read -r module bump old_version new_version; do
+    [[ -z "$module" ]] && continue
+    validate_module_name "$module"
+
+    old_escaped=$(escape_sed "$old_version")
+    new_escaped=$(escape_sed "$new_version")
+    module_escaped=$(escape_sed "$module")
+
+    if [[ "$module" == "android" && "$bump" == "major" ]]; then
+        monorepo_bump="major"
+    fi
+
+    case "$module" in
+        core)
+            # Match inside `object Core {` block — update VERSION_NAME
+            sed_inplace -E "/object Core \{/,/object PublishConfig/ s/(VERSION_NAME = \")${old_escaped}(\")/\1${new_version}\2/" "$BUILD_CONFIG_PATH"
+            ;;
+        android)
+            # Match inside `object Android {` block — update VERSION_NAME
+            sed_inplace -E "/object Android \{/,/object PublishConfig/ s/(VERSION_NAME = \")${old_escaped}(\")/\1${new_version}\2/" "$BUILD_CONFIG_PATH"
+            # Increment VERSION_CODE
+            current_code=$(grep -A5 'object Android {' "$BUILD_CONFIG_PATH" | grep 'VERSION_CODE' | sed -E 's/.*"([0-9]+)".*/\1/')
+            if [[ -z "$current_code" || ! "$current_code" =~ ^[0-9]+$ ]]; then
+                echo "Error: could not parse VERSION_CODE for module $module" >&2
+                exit 1
+            fi
+            current_code_escaped=$(escape_sed "$current_code")
+            new_code=$((current_code + 1))
+            sed_inplace -E "/object Android \{/,/object PublishConfig/ s/(VERSION_CODE = \")${current_code_escaped}(\")/\1${new_code}\2/" "$BUILD_CONFIG_PATH"
+            ;;
+        *)
+            # Integration module — match on moduleName = "module"
+            sed_inplace -E "/moduleName.*=.*\"${module_escaped}\"/,/override val pomPackaging/ s/(versionName.*=.*\")${old_escaped}(\")/\1${new_version}\2/" "$BUILD_CONFIG_PATH"
+            # Increment versionCode
+            current_code=$(awk "/moduleName.*\"${module_escaped}\"/,/pomPackaging/" "$BUILD_CONFIG_PATH" | grep 'versionCode' | sed -E 's/.*"([0-9]+)".*/\1/')
+            if [[ -z "$current_code" || ! "$current_code" =~ ^[0-9]+$ ]]; then
+                echo "Error: could not parse versionCode for module $module" >&2
+                exit 1
+            fi
+            current_code_escaped=$(escape_sed "$current_code")
+            new_code=$((current_code + 1))
+            sed_inplace -E "/moduleName.*=.*\"${module_escaped}\"/,/override val pomPackaging/ s/(versionCode.*=.*\")${current_code_escaped}(\")/\1${new_code}\2/" "$BUILD_CONFIG_PATH"
+            ;;
+    esac
+
+done <<< "$affected"
+
+# --- Bump monorepo SDK_VERSION in gradle.properties ---
+
+current_sdk_version=$(grep '^SDK_VERSION=' "$GRADLE_PROPERTIES_PATH" | cut -d'=' -f2)
+new_sdk_version=$(bump_version "$current_sdk_version" "$monorepo_bump")
+sed_inplace "s/^SDK_VERSION=.*/SDK_VERSION=${new_sdk_version}/" "$GRADLE_PROPERTIES_PATH"

--- a/scripts/releases/common.sh
+++ b/scripts/releases/common.sh
@@ -13,11 +13,15 @@ GRADLE_PROPERTIES_PATH="gradle.properties"
 # --- Security helpers ---
 
 escape_sed() {
-    printf '%s' "$1" | sed 's/[.[\/*^$&]/\\&/g'
+    local input="$1"
+    printf '%s' "$input" | sed 's/[.[\/*^$&]/\\&/g'
+    return 0
 }
 
 escape_grep() {
-    printf '%s' "$1" | sed 's/[.[\*^$+?{}()|]/\\&/g'
+    local input="$1"
+    printf '%s' "$input" | sed 's/[.[\*^$+?{}()|]/\\&/g'
+    return 0
 }
 
 validate_module_name() {
@@ -26,6 +30,7 @@ validate_module_name() {
         echo "Error: invalid module name: $name" >&2
         exit 1
     fi
+    return 0
 }
 
 # --- Portable sed -i ---
@@ -36,12 +41,14 @@ sed_inplace() {
     else
         sed -i "$@"
     fi
+    return 0
 }
 
 # --- Monorepo tag ---
 
 find_monorepo_tag() {
     git tag -l 'v*.*.*' --sort=-v:refname | head -1
+    return 0
 }
 
 # --- Dependency chain (session-cached) ---
@@ -63,12 +70,14 @@ get_dependency_chain() {
         fi
     fi
     echo "$_DEPENDENCY_CHAIN_CACHE"
+    return 0
 }
 
 # --- Module discovery ---
 
 get_all_modules() {
     get_dependency_chain | tail -n +2 | cut -d'|' -f1 | tr '\n' ' ' | sed 's/ $//'
+    return 0
 }
 
 get_module_maven_info() {
@@ -76,6 +85,7 @@ get_module_maven_info() {
     local escaped
     escaped=$(escape_grep "$module")
     get_dependency_chain | grep "^${escaped}|" | cut -d'|' -f2-5
+    return 0
 }
 
 get_module_version() {
@@ -83,6 +93,7 @@ get_module_version() {
     local escaped
     escaped=$(escape_grep "$module")
     get_dependency_chain | grep "^${escaped}|" | cut -d'|' -f4 | sed 's/-SNAPSHOT//'
+    return 0
 }
 
 get_module_tag_prefix() {
@@ -94,6 +105,7 @@ get_module_tag_prefix() {
     group_id=$(echo "$info" | cut -d'|' -f2)
     artifact_id=$(echo "$info" | cut -d'|' -f3)
     echo "${group_id}.${artifact_id}"
+    return 0
 }
 
 # --- Dependency graph ---
@@ -118,6 +130,7 @@ get_dependents() {
             echo "$name"
         fi
     done | tr '\n' ' ' | sed 's/ $//'
+    return 0
 }
 
 # --- Version utilities ---
@@ -138,24 +151,28 @@ bump_version() {
         patch) echo "${major}.${minor}.$((patch + 1))" ;;
         *) echo "Error: invalid bump type: $bump_type" >&2; exit 1 ;;
     esac
+    return 0
 }
 
 max_bump() {
     local a="$1"
     local b="$2"
     _bump_rank() {
-        case "$1" in
+        local val="$1"
+        case "$val" in
             major) echo 3 ;; minor) echo 2 ;; patch) echo 1 ;; *) echo 0 ;;
         esac
+        return 0
     }
     local rank_a rank_b
     rank_a=$(_bump_rank "$a")
     rank_b=$(_bump_rank "$b")
-    if [ "$rank_a" -ge "$rank_b" ]; then
+    if [[ "$rank_a" -ge "$rank_b" ]]; then
         echo "$a"
     else
         echo "$b"
     fi
+    return 0
 }
 
 # --- Path mapping ---
@@ -182,4 +199,5 @@ module_to_gradle_path() {
         core|android) echo ":${module}" ;;
         *) echo ":integrations:${module}" ;;
     esac
+    return 0
 }

--- a/scripts/releases/common.sh
+++ b/scripts/releases/common.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Shared utilities for release automation scripts.
+# Sourced by all other scripts in this directory.
+
+set -euo pipefail
+
+# --- Constants ---
+
+REPO_URL="https://github.com/rudderlabs/rudder-sdk-kotlin"
+BUILD_CONFIG_PATH="buildSrc/src/main/kotlin/RudderStackBuildConfig.kt"
+GRADLE_PROPERTIES_PATH="gradle.properties"
+
+# --- Security helpers ---
+
+escape_sed() {
+    printf '%s' "$1" | sed 's/[.[\/*^$&]/\\&/g'
+}
+
+escape_grep() {
+    printf '%s' "$1" | sed 's/[.[\*^$+?{}()|]/\\&/g'
+}
+
+validate_module_name() {
+    local name="$1"
+    if [[ ! "$name" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        echo "Error: invalid module name: $name" >&2
+        exit 1
+    fi
+}
+
+# --- Portable sed -i ---
+
+sed_inplace() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
+# --- Monorepo tag ---
+
+find_monorepo_tag() {
+    git tag -l 'v*.*.*' --sort=-v:refname | head -1
+}
+
+# --- Dependency chain (session-cached) ---
+
+_DEPENDENCY_CHAIN_CACHE=""
+
+get_dependency_chain() {
+    if [[ -z "$_DEPENDENCY_CHAIN_CACHE" ]]; then
+        local output
+        output=$(./gradlew -q printDependencyChain 2>&1) || {
+            echo "Error: Gradle printDependencyChain failed:" >&2
+            echo "$output" >&2
+            exit 1
+        }
+        _DEPENDENCY_CHAIN_CACHE=$(echo "$output" | grep '|')
+        if [[ -z "$_DEPENDENCY_CHAIN_CACHE" ]]; then
+            echo "Error: no dependency chain data found" >&2
+            exit 1
+        fi
+    fi
+    echo "$_DEPENDENCY_CHAIN_CACHE"
+}
+
+# --- Module discovery ---
+
+get_all_modules() {
+    get_dependency_chain | tail -n +2 | cut -d'|' -f1 | tr '\n' ' ' | sed 's/ $//'
+}
+
+get_module_maven_info() {
+    local module="$1"
+    local escaped
+    escaped=$(escape_grep "$module")
+    get_dependency_chain | grep "^${escaped}|" | cut -d'|' -f2-5
+}
+
+get_module_version() {
+    local module="$1"
+    local escaped
+    escaped=$(escape_grep "$module")
+    get_dependency_chain | grep "^${escaped}|" | cut -d'|' -f4 | sed 's/-SNAPSHOT//'
+}
+
+get_module_tag_prefix() {
+    local module="$1"
+    local escaped info
+    escaped=$(escape_grep "$module")
+    info=$(get_dependency_chain | grep "^${escaped}|")
+    local group_id artifact_id
+    group_id=$(echo "$info" | cut -d'|' -f2)
+    artifact_id=$(echo "$info" | cut -d'|' -f3)
+    echo "${group_id}.${artifact_id}"
+}
+
+# --- Dependency graph ---
+
+get_module_deps() {
+    local module="$1"
+    local escaped deps_field
+    escaped=$(escape_grep "$module")
+    deps_field=$(get_dependency_chain | grep "^${escaped}|" | cut -d'|' -f6)
+    if [[ -z "$deps_field" ]]; then
+        return
+    fi
+    echo "$deps_field" | tr ',' '\n' | cut -d':' -f1 | tr '\n' ' ' | sed 's/ $//'
+}
+
+get_dependents() {
+    local module="$1"
+    local escaped
+    escaped=$(escape_grep "$module")
+    get_dependency_chain | tail -n +2 | while IFS='|' read -r name _ _ _ _ deps; do
+        if [[ -n "$deps" ]] && echo "$deps" | tr ',' '\n' | cut -d':' -f1 | grep -qx "$escaped"; then
+            echo "$name"
+        fi
+    done | tr '\n' ' ' | sed 's/ $//'
+}
+
+# --- Version utilities ---
+
+bump_version() {
+    local version="${1%%-*}"  # Strip any suffix like -SNAPSHOT
+    local bump_type="$2"
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "Error: invalid version format: $version" >&2
+        exit 1
+    fi
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "$version"
+
+    case "$bump_type" in
+        major) echo "$((major + 1)).0.0" ;;
+        minor) echo "${major}.$((minor + 1)).0" ;;
+        patch) echo "${major}.${minor}.$((patch + 1))" ;;
+        *) echo "Error: invalid bump type: $bump_type" >&2; exit 1 ;;
+    esac
+}
+
+max_bump() {
+    local a="$1"
+    local b="$2"
+    _bump_rank() {
+        case "$1" in
+            major) echo 3 ;; minor) echo 2 ;; patch) echo 1 ;; *) echo 0 ;;
+        esac
+    }
+    local rank_a rank_b
+    rank_a=$(_bump_rank "$a")
+    rank_b=$(_bump_rank "$b")
+    if [ "$rank_a" -ge "$rank_b" ]; then
+        echo "$a"
+    else
+        echo "$b"
+    fi
+}
+
+# --- Path mapping ---
+
+file_to_module() {
+    local filepath="$1"
+    local module=""
+    case "$filepath" in
+        core/*) module="core" ;;
+        android/*) module="android" ;;
+        integrations/*/*)
+            module=$(echo "$filepath" | cut -d'/' -f2)
+            ;;
+        *) echo ""; return ;;
+    esac
+    validate_module_name "$module"
+    echo "$module"
+}
+
+module_to_gradle_path() {
+    local module="$1"
+    validate_module_name "$module"
+    case "$module" in
+        core|android) echo ":${module}" ;;
+        *) echo ":integrations:${module}" ;;
+    esac
+}

--- a/scripts/releases/create-backmerge-pr.sh
+++ b/scripts/releases/create-backmerge-pr.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Creates a back-merge PR from main into develop after a release.
+#
+# Usage: create-backmerge-pr.sh <version>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+version="${1:?monorepo version required}"
+
+# --- Check for existing PR ---
+
+existing_pr=$(gh pr list --base develop --head main --state open --json number -q '.[0].number')
+
+if [[ -n "${existing_pr}" ]]; then
+  echo "Back-merge PR already exists: #${existing_pr}" >&2
+  echo "https://github.com/${GITHUB_REPOSITORY}/pull/${existing_pr}"
+  exit 0
+fi
+
+# --- Create back-merge PR ---
+
+body_file=$(mktemp)
+cat > "$body_file" <<TEMPLATE
+:crown: **Automated Post-Release PR**
+
+This pull request was created automatically by the GitHub Actions workflow. It merges changes from the \`main\` branch into the \`develop\` branch after a release has been completed.
+
+This ensures that the \`develop\` branch stays up to date with all release-related changes from the \`main\` branch.
+
+### Details
+- **Monorepo Release Version**: v${version}
+
+---
+Please review and merge it before closing the release ticket. :rocket:
+TEMPLATE
+
+gh pr create \
+  --base develop \
+  --head main \
+  --title "chore(release): merge main into develop" \
+  --body-file "$body_file"
+
+rm -f "$body_file"

--- a/scripts/releases/create-github-releases.sh
+++ b/scripts/releases/create-github-releases.sh
@@ -27,6 +27,7 @@ changelog_path_for_module() {
         core|android) echo "${module}/CHANGELOG.md" ;;
         *) echo "integrations/${module}/CHANGELOG.md" ;;
     esac
+    return 0
 }
 
 extract_latest_changelog_entry() {

--- a/scripts/releases/create-github-releases.sh
+++ b/scripts/releases/create-github-releases.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Creates GitHub releases for each bumped module.
+#
+# Input: file path or stdin containing: module|bump|oldVersion|newVersion
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+# --- Input ---
+
+input="${1:--}"
+if [[ "$input" == "-" ]]; then
+    affected=$(cat)
+else
+    affected=$(cat "$input")
+fi
+
+[[ -z "$affected" ]] && exit 0
+
+# --- Helpers ---
+
+changelog_path_for_module() {
+    local module="$1"
+    case "$module" in
+        core|android) echo "${module}/CHANGELOG.md" ;;
+        *) echo "integrations/${module}/CHANGELOG.md" ;;
+    esac
+}
+
+extract_latest_changelog_entry() {
+    local changelog="$1"
+    [[ ! -f "$changelog" ]] && return
+
+    # Extract content between first '# [' heading and the second '# [' heading
+    # (or end of file if only one entry exists)
+    awk '
+        /^# \[/ {
+            if (found) { exit }
+            found = 1
+            print
+            next
+        }
+        found { print }
+    ' "$changelog"
+}
+
+# --- Create releases ---
+
+while IFS='|' read -r module bump old_version new_version; do
+    [[ -z "$module" ]] && continue
+
+    tag_prefix=$(get_module_tag_prefix "$module")
+    tag="${tag_prefix}@v${new_version}"
+    changelog=$(changelog_path_for_module "$module")
+    changelog_body=$(extract_latest_changelog_entry "$changelog")
+
+    # Only mark Android as "Latest" — integrations and core don't take the badge
+    latest_flag="--latest=false"
+    if [[ "$module" == "android" ]]; then
+        latest_flag="--latest"
+    fi
+
+    if gh release view "$tag" >/dev/null 2>&1; then
+        echo "Release $tag already exists, skipping"
+        continue
+    fi
+
+    echo "Creating GitHub release: $tag"
+    gh release create "$tag" \
+        --title "$tag" \
+        --notes "${changelog_body:-No changelog available.}" \
+        "$latest_flag"
+
+done <<< "$affected"

--- a/scripts/releases/create-release-pr.sh
+++ b/scripts/releases/create-release-pr.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Creates a GitHub PR for a release branch targeting main.
+#
+# Usage: create-release-pr.sh <release_branch> <version> <ticket_id> <affected_modules_file>
+
+set -euo pipefail
+
+release_branch="${1:?release branch name required}"
+version="${2:?monorepo version required}"
+ticket_id="${3:?ticket ID required}"
+affected_modules_file="${4:?affected modules file path required}"
+
+# --- Build version table ---
+
+version_table="| Module | Old Version | New Version |
+|--------|-------------|-------------|
+"
+
+while IFS='|' read -r module bump old_ver new_ver; do
+    version_table+="| ${module} | ${old_ver} | ${new_ver} |
+"
+done < "$affected_modules_file"
+
+# --- Create PR ---
+
+body_file=$(mktemp)
+cat > "$body_file" <<'TEMPLATE'
+:crown: **Automated Release PR**
+
+This pull request was created automatically by the GitHub Actions workflow. It merges the release branch into the `main` branch.
+
+This ensures that the latest release branch changes are incorporated into the `main` branch for production.
+
+### Details
+TEMPLATE
+{
+    echo "- **Monorepo Release Version**: v${version}"
+    echo "- **Release Branch**: \`${release_branch}\`"
+    echo "- **Related Ticket**: [${ticket_id}](https://linear.app/rudderstack/issue/${ticket_id})"
+    echo ""
+    echo "### Version updates"
+    echo ""
+    printf "%s" "$version_table"
+    echo ""
+    echo "---"
+    echo "Please review and merge when ready. :rocket:"
+} >> "$body_file"
+
+gh pr create \
+    --base main \
+    --head "$release_branch" \
+    --title "chore(release): merge ${release_branch} into main" \
+    --body-file "$body_file"
+
+rm -f "$body_file"

--- a/scripts/releases/create-tags.sh
+++ b/scripts/releases/create-tags.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Creates lightweight tags for each bumped module and the monorepo.
+# Tags point to the merge commit SHA (already verified/signed by GitHub),
+# so all tags inherit the "Verified" badge on the tags page.
+#
+# Input: file path ($1) or stdin ("-") containing: module|bump|oldVersion|newVersion
+#
+# Requires: GH_TOKEN env var, GITHUB_REPOSITORY env var.
+
+set -euo pipefail
+set -f
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+# --- Input ---
+
+input="${1:--}"
+if [[ "$input" == "-" ]]; then
+    affected=$(cat)
+else
+    affected=$(cat "$input")
+fi
+
+[[ -z "$affected" ]] && exit 0
+
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+# Use the merge commit SHA — already signed/verified by GitHub
+MERGE_SHA=$(git rev-parse HEAD)
+
+create_lightweight_tag() {
+    local tag="$1"
+
+    if gh api "repos/${REPO}/git/ref/tags/${tag}" >/dev/null 2>&1; then
+        echo "Warning: tag ${tag} already exists on remote, skipping"
+        return
+    fi
+
+    gh api "repos/${REPO}/git/refs" \
+        --method POST \
+        -f "ref=refs/tags/${tag}" \
+        -f "sha=${MERGE_SHA}" > /dev/null
+
+    echo "Tagged: ${tag}"
+}
+
+# --- Create per-module tags ---
+
+while IFS='|' read -r module bump old_version new_version; do
+    [[ -z "$module" ]] && continue
+
+    tag_prefix=$(get_module_tag_prefix "$module")
+    create_lightweight_tag "${tag_prefix}@v${new_version}"
+done <<< "$affected"
+
+# --- Create monorepo tag ---
+
+sdk_version=$(grep '^SDK_VERSION=' "$GRADLE_PROPERTIES_PATH" | cut -d'=' -f2)
+create_lightweight_tag "v${sdk_version}"

--- a/scripts/releases/detect-affected-modules.sh
+++ b/scripts/releases/detect-affected-modules.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Detects which modules need a version bump based on conventional commits
+# since the last monorepo tag. Outputs affected modules in dependency order.
+#
+# Output format: module|bump|oldVersion|newVersion
+
+set -euo pipefail
+set -f
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+# --- Configurable bump rules ---
+# Add/remove commit types to control which changes trigger bumps.
+
+MAJOR_TYPES="feat!"
+MINOR_TYPES="feat"
+PATCH_TYPES="fix refactor chore"
+
+# --- Key-value store (bash 3.2 compatible) ---
+# Uses a flat string: "key1=val1 key2=val2"
+
+_KV_BUMPS=""
+
+_kv_get() {
+    local key="$1" store="$2"
+    local val
+    val=$(echo "$store" | tr ' ' '\n' | grep "^${key}=" | tail -1 | cut -d'=' -f2)
+    echo "${val:-none}"
+}
+
+_kv_set() {
+    local key="$1" val="$2"
+    # Remove existing entry, then append
+    _KV_BUMPS=$(echo "$_KV_BUMPS" | tr ' ' '\n' | grep -v "^${key}=" | tr '\n' ' ')
+    _KV_BUMPS="${_KV_BUMPS}${key}=${val} "
+}
+
+# --- Helpers ---
+
+get_bump_level() {
+    local type="$1"
+    local breaking="$2"
+    # Build the lookup key: "feat!" if breaking, "feat" otherwise
+    local lookup="$type"
+    if [[ "$breaking" == "true" ]]; then
+        lookup="${type}!"
+    fi
+
+    for t in $MAJOR_TYPES; do
+        if [[ "$lookup" == "$t" ]]; then echo "major"; return; fi
+    done
+    for t in $MINOR_TYPES; do
+        if [[ "$lookup" == "$t" ]]; then echo "minor"; return; fi
+    done
+    for t in $PATCH_TYPES; do
+        if [[ "$lookup" == "$t" ]]; then echo "patch"; return; fi
+    done
+
+    # Breaking types not in any list fall through to their non-breaking level
+    if [[ "$breaking" == "true" ]]; then
+        for t in $MINOR_TYPES; do
+            if [[ "$type" == "$t" ]]; then echo "minor"; return; fi
+        done
+        for t in $PATCH_TYPES; do
+            if [[ "$type" == "$t" ]]; then echo "patch"; return; fi
+        done
+    fi
+
+    echo "none"
+}
+
+get_cascade_bump() {
+    local upstream_bump="$1"
+    case "$upstream_bump" in
+        major) echo "major" ;;
+        minor|patch) echo "patch" ;;
+        *) echo "none" ;;
+    esac
+}
+
+# --- Main ---
+
+baseline=$(find_monorepo_tag)
+if [[ -z "$baseline" ]]; then
+    echo "Error: no monorepo tag found" >&2
+    exit 1
+fi
+
+commit_count=$(git rev-list --count --no-merges "${baseline}..HEAD")
+if [[ "$commit_count" -gt 1000 ]]; then
+    echo "Error: too many commits since last tag ($commit_count). Check baseline tag." >&2
+    exit 1
+fi
+
+# Step 1: Parse commits and determine direct bumps per module
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    commit_hash="${line%% *}"
+    subject="${line#* }"
+
+    # Parse conventional commit: type(scope)!: description
+    breaking="false"
+    if echo "$subject" | grep -qE '^[a-zA-Z]+(\(.+\))?!: '; then
+        breaking="true"
+    fi
+
+    type=$(echo "$subject" | sed -E 's/^([a-zA-Z]+)(\(.+\))?(!)?: .+/\1/')
+    # Verify it actually matched a conventional commit pattern
+    if [[ "$type" == "$subject" ]]; then
+        continue
+    fi
+
+    bump=$(get_bump_level "$type" "$breaking")
+    [[ "$bump" == "none" ]] && continue
+
+    # Get changed files for this commit
+    while IFS= read -r filepath; do
+        [[ -z "$filepath" ]] && continue
+        module=$(file_to_module "$filepath")
+        [[ -z "$module" ]] && continue
+
+        current=$(_kv_get "$module" "$_KV_BUMPS")
+        _kv_set "$module" "$(max_bump "$current" "$bump")"
+    done < <(git diff-tree --no-commit-id --name-only -r "$commit_hash")
+
+done < <(git log --no-merges --format="%H %s" "${baseline}..HEAD")
+
+# Step 2: Build topological order, then cascade in that order
+chain=$(get_dependency_chain)
+ordered_modules=""
+visited_modules=""
+
+topo_visit() {
+    local mod="$1"
+    echo "$visited_modules" | tr ' ' '\n' | grep -qx "$mod" && return
+    visited_modules="${visited_modules}${mod} "
+
+    local deps
+    deps=$(get_module_deps "$mod")
+    for d in $deps; do
+        topo_visit "$d"
+    done
+    ordered_modules="${ordered_modules}${mod} "
+}
+
+while IFS='|' read -r name _rest; do
+    [[ "$name" == "name" ]] && continue
+    topo_visit "$name"
+done <<< "$chain"
+
+# Cascade in topological order (upstream processed before downstream)
+for module in $ordered_modules; do
+    bump=$(_kv_get "$module" "$_KV_BUMPS")
+    [[ "$bump" == "none" ]] && continue
+
+    cascade=$(get_cascade_bump "$bump")
+    [[ "$cascade" == "none" ]] && continue
+
+    dependents=$(get_dependents "$module")
+    for dep in $dependents; do
+        current=$(_kv_get "$dep" "$_KV_BUMPS")
+        _kv_set "$dep" "$(max_bump "$current" "$cascade")"
+    done
+done
+
+# Step 3: Output in dependency order
+for module in $ordered_modules; do
+    bump=$(_kv_get "$module" "$_KV_BUMPS")
+    [[ "$bump" == "none" ]] && continue
+
+    old_version=$(get_module_version "$module")
+    new_version=$(bump_version "$old_version" "$bump")
+    echo "${module}|${bump}|${old_version}|${new_version}"
+done

--- a/scripts/releases/detect-affected-modules.sh
+++ b/scripts/releases/detect-affected-modules.sh
@@ -27,6 +27,7 @@ _kv_get() {
     local val
     val=$(echo "$store" | tr ' ' '\n' | grep "^${key}=" | tail -1 | cut -d'=' -f2)
     echo "${val:-none}"
+    return 0
 }
 
 _kv_set() {
@@ -34,6 +35,7 @@ _kv_set() {
     # Remove existing entry, then append
     _KV_BUMPS=$(echo "$_KV_BUMPS" | tr ' ' '\n' | grep -v "^${key}=" | tr '\n' ' ')
     _KV_BUMPS="${_KV_BUMPS}${key}=${val} "
+    return 0
 }
 
 # --- Helpers ---
@@ -77,6 +79,7 @@ get_cascade_bump() {
         minor|patch) echo "patch" ;;
         *) echo "none" ;;
     esac
+    return 0
 }
 
 # --- Main ---

--- a/scripts/releases/generate-changelog.sh
+++ b/scripts/releases/generate-changelog.sh
@@ -10,7 +10,8 @@ source "${SCRIPT_DIR}/common.sh"
 SECTION_ORDER="breaking feat fix refactor chore deps"
 
 section_heading() {
-    case "$1" in
+    local type="$1"
+    case "$type" in
         breaking) echo "## ⚠ Breaking Changes" ;;
         feat)     echo "## Features" ;;
         fix)      echo "## Bug Fixes" ;;
@@ -19,6 +20,7 @@ section_heading() {
         deps)     echo "## Dependency Updates" ;;
         *)        echo "## Other" ;;
     esac
+    return 0
 }
 
 sanitize_changelog_entry() {
@@ -34,6 +36,7 @@ sanitize_changelog_entry() {
     escaped_url=$(echo "$REPO_URL" | sed 's/[.\/]/\\&/g')
     text=$(echo "$text" | perl -pe "s/\[([^\]]+)\]\((?!${escaped_url})([^)]*)\)/\$1/g")
     echo "$text"
+    return 0
 }
 
 input="${1:--}"

--- a/scripts/releases/generate-changelog.sh
+++ b/scripts/releases/generate-changelog.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Generates CHANGELOG.md entries for affected modules.
+# Input: file path or stdin containing: module|bump|oldVersion|newVersion
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+# --- Configurable section mapping (order defines display order) ---
+SECTION_ORDER="breaking feat fix refactor chore deps"
+
+section_heading() {
+    case "$1" in
+        breaking) echo "## ⚠ Breaking Changes" ;;
+        feat)     echo "## Features" ;;
+        fix)      echo "## Bug Fixes" ;;
+        refactor) echo "## Refactors" ;;
+        chore)    echo "## Chores" ;;
+        deps)     echo "## Dependency Updates" ;;
+        *)        echo "## Other" ;;
+    esac
+}
+
+sanitize_changelog_entry() {
+    local text="$1"
+    # Strip HTML tags
+    text=$(echo "$text" | sed 's/<[^>]*>//g')
+    # Strip markdown images (could be used for tracking pixels)
+    text=$(echo "$text" | sed 's/!\[[^]]*\]([^)]*)//g')
+    # Strip markdown link reference definitions
+    text=$(echo "$text" | sed '/^\[.*\]:.*$/d')
+    # Strip markdown links that don't point to the repo URL (replace [text](url) with just text)
+    local escaped_url
+    escaped_url=$(echo "$REPO_URL" | sed 's/[.\/]/\\&/g')
+    text=$(echo "$text" | perl -pe "s/\[([^\]]+)\]\((?!${escaped_url})([^)]*)\)/\$1/g")
+    echo "$text"
+}
+
+input="${1:--}"
+if [[ "$input" == "-" ]]; then
+    affected=$(cat)
+else
+    affected=$(cat "$input")
+fi
+
+[[ -z "$affected" ]] && exit 0
+
+baseline=$(find_monorepo_tag)
+
+commit_data=""
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    commit_hash="${line%% *}"
+    subject="${line#* }"
+
+    files=$(git diff-tree --no-commit-id --name-only -r "$commit_hash")
+    modules_for_commit=""
+    while IFS= read -r filepath; do
+        [[ -z "$filepath" ]] && continue
+        mod=$(file_to_module "$filepath")
+        [[ -z "$mod" ]] && continue
+        # Avoid duplicate module entries per commit
+        if ! echo "$modules_for_commit" | tr ',' '\n' | grep -qx "$mod"; then
+            modules_for_commit="${modules_for_commit:+${modules_for_commit},}${mod}"
+        fi
+    done <<< "$files"
+
+    [[ -z "$modules_for_commit" ]] && continue
+    # Store: hash|subject|modules
+    commit_data="${commit_data}${commit_hash}|${subject}|${modules_for_commit}
+"
+done < <(git log --no-merges --format="%H %s" "${baseline}..HEAD")
+
+while IFS='|' read -r module bump old_version new_version; do
+    [[ -z "$module" ]] && continue
+    validate_module_name "$module"
+
+    tag_prefix=$(get_module_tag_prefix "$module")
+    today=$(date +%Y-%m-%d)
+
+    # Determine module directory for CHANGELOG.md
+    case "$module" in
+        core|android) changelog_dir="$module" ;;
+        *) changelog_dir="integrations/$module" ;;
+    esac
+    changelog_path="${changelog_dir}/CHANGELOG.md"
+
+    # Collect commits for this module
+    module_commits=""
+    while IFS= read -r cline; do
+        [[ -z "$cline" ]] && continue
+        c_hash=$(echo "$cline" | cut -d'|' -f1)
+        c_subject=$(echo "$cline" | cut -d'|' -f2)
+        c_modules=$(echo "$cline" | cut -d'|' -f3)
+
+        if echo "$c_modules" | tr ',' '\n' | grep -qx "$module"; then
+            module_commits="${module_commits}${c_hash}|${c_subject}
+"
+        fi
+    done <<< "$commit_data"
+
+    # Build sections
+    sections=""
+    has_content=false
+
+    if [[ -n "$module_commits" ]]; then
+        for section_type in $SECTION_ORDER; do
+            [[ "$section_type" == "deps" ]] && continue
+            section_entries=""
+
+            while IFS= read -r cline; do
+                [[ -z "$cline" ]] && continue
+                c_hash=$(echo "$cline" | cut -d'|' -f1)
+                c_subject=$(echo "$cline" | cut -d'|' -f2)
+                short_hash="${c_hash:0:7}"
+
+                # Parse conventional commit
+                breaking="false"
+                if echo "$c_subject" | grep -qE '^[a-zA-Z]+(\(.+\))?!: '; then
+                    breaking="true"
+                fi
+
+                type=$(echo "$c_subject" | sed -E 's/^([a-zA-Z]+)(\(.+\))?(!)?: .+/\1/')
+                [[ "$type" == "$c_subject" ]] && continue
+
+                scope=$(echo "$c_subject" | sed -E 's/^[a-zA-Z]+\(([^)]+)\)(!)?: .+/\1/')
+                [[ "$scope" == "$c_subject" ]] && scope=""
+
+                desc=$(echo "$c_subject" | sed -E 's/^[a-zA-Z]+(\([^)]+\))?(!)?: (.+)/\3/')
+                # Sanitize desc before further processing
+                desc=$(sanitize_changelog_entry "$desc")
+                # Capitalise first letter
+                desc="$(echo "${desc:0:1}" | tr '[:lower:]' '[:upper:]')${desc:1}"
+                # Linkify PR references (#123)
+                desc=$(echo "$desc" | sed -E "s|#([0-9]+)|[#\1](${REPO_URL}/pull/\1)|g")
+
+                # Determine if this commit belongs in this section
+                match=false
+                if [[ "$section_type" == "breaking" && "$breaking" == "true" ]]; then
+                    match=true
+                elif [[ "$section_type" == "$type" ]]; then
+                    match=true
+                fi
+
+                if [[ "$match" == "true" ]]; then
+                    if [[ -n "$scope" ]]; then
+                        section_entries="${section_entries}- **${scope}:** ${desc} ([${short_hash}](${REPO_URL}/commit/${c_hash}))
+"
+                    else
+                        section_entries="${section_entries}- ${desc} ([${short_hash}](${REPO_URL}/commit/${c_hash}))
+"
+                    fi
+                fi
+            done <<< "$module_commits"
+
+            if [[ -n "$section_entries" ]]; then
+                heading=$(section_heading "$section_type")
+                sections="${sections}
+${heading}
+
+${section_entries}"
+                has_content=true
+            fi
+        done
+    fi
+
+    # Dependency updates — always check if upstream deps were bumped
+    deps=$(get_module_deps "$module")
+    dep_entries=""
+    for dep in $deps; do
+        dep_old=$(echo "$affected" | grep "^${dep}|" | cut -d'|' -f3 || true)
+        dep_new=$(echo "$affected" | grep "^${dep}|" | cut -d'|' -f4 || true)
+        if [[ -n "$dep_old" && -n "$dep_new" ]]; then
+            dep_entries="${dep_entries}  - dependencies
+    - @rudderstack/${dep} bumped from ${dep_old} to ${dep_new}
+"
+        fi
+    done
+
+    if [[ -n "$dep_entries" ]]; then
+        heading=$(section_heading "deps")
+        sections="${sections}
+${heading}
+
+- The following workspace dependencies were updated
+${dep_entries}"
+    fi
+
+    # Build the full entry
+    entry="# [${new_version}](${REPO_URL}/compare/${tag_prefix}@v${old_version}...${tag_prefix}@v${new_version}) (${today})
+${sections}"
+
+    # Ensure changelog exists with header
+    if [[ ! -f "$changelog_path" ]]; then
+        mkdir -p "$changelog_dir"
+        printf "# Changelog\n\nAll notable changes to this project will be documented in this file.\n" > "$changelog_path"
+    fi
+
+    # Prepend entry after the 3-line header
+    header=$(head -3 "$changelog_path")
+    rest=$(tail -n +4 "$changelog_path")
+    printf "%s\n\n%s\n%s\n" "$header" "$entry" "$rest" > "$changelog_path"
+
+done <<< "$affected"

--- a/scripts/releases/publish-module.sh
+++ b/scripts/releases/publish-module.sh
@@ -43,4 +43,8 @@ case "$mode" in
     release)
         ./gradlew "${gradle_path}:publishToSonatype" -Prelease closeAndReleaseSonatypeStagingRepository
         ;;
+    *)
+        echo "Error: unexpected mode: ${mode}" >&2
+        exit 1
+        ;;
 esac

--- a/scripts/releases/publish-module.sh
+++ b/scripts/releases/publish-module.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Publishes a single module to Maven via Gradle.
+#
+# Usage:
+#   publish-module.sh <module> <mode> [snapshotModules]
+#
+#   module          — module name (e.g. "adjust", "core", "android")
+#   mode            — "snapshot" or "release"
+#   snapshotModules — comma-separated list of snapshot modules (snapshot mode only,
+#                     e.g. "core,android,adjust")
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+module="${1:-}"
+mode="${2:-}"
+snapshot_modules="${3:-}"
+
+if [[ -z "$module" ]]; then
+    echo "Error: module name is required as \$1" >&2
+    exit 1
+fi
+
+if [[ -z "$mode" ]]; then
+    echo "Error: mode is required as \$2 (\"snapshot\" or \"release\")" >&2
+    exit 1
+fi
+
+if [[ "$mode" != "snapshot" && "$mode" != "release" ]]; then
+    echo "Error: mode must be \"snapshot\" or \"release\", got \"${mode}\"" >&2
+    exit 1
+fi
+
+gradle_path="$(module_to_gradle_path "$module")"
+
+case "$mode" in
+    snapshot)
+        ./gradlew "${gradle_path}:publishToSonatype" -PsnapshotModules="${snapshot_modules}"
+        ;;
+    release)
+        ./gradlew "${gradle_path}:publishToSonatype" -Prelease closeAndReleaseSonatypeStagingRepository
+        ;;
+esac

--- a/scripts/releases/read-affected-modules.sh
+++ b/scripts/releases/read-affected-modules.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Reads affected modules by comparing current versions in code against
+# the last tagged versions. No commit parsing needed — just a version diff.
+#
+# Output format: module|bump|oldVersion|newVersion (compatible with create-tags.sh etc.)
+
+set -euo pipefail
+set -f
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+chain=$(get_dependency_chain)
+
+while IFS='|' read -r name _ _ _ _ _; do
+    [[ "$name" == "name" ]] && continue
+
+    tag_prefix=$(get_module_tag_prefix "$name")
+    current_version=$(get_module_version "$name")
+
+    # Find the latest tag for this module
+    latest_tag=$(git tag -l "${tag_prefix}@v*" --sort=-v:refname | head -1)
+
+    if [[ -z "$latest_tag" ]]; then
+        # No tag exists — this module is new, treat as affected
+        echo "${name}|new||${current_version}"
+        continue
+    fi
+
+    # Extract version from tag: com.rudderstack.sdk.kotlin.core@v6.0.0 → 6.0.0
+    tagged_version="${latest_tag##*@v}"
+
+    if [[ "$tagged_version" != "$current_version" ]]; then
+        echo "${name}|bumped|${tagged_version}|${current_version}"
+    fi
+done <<< "$chain"


### PR DESCRIPTION
## Description

The SDK currently lacks automated release tooling — version bumps, changelog generation, tagging, and publishing are manual, error-prone steps. This PR lays the foundation for a fully automated release pipeline by refactoring the Gradle publishing logic and adding a suite of composable shell scripts that handle each stage of the release lifecycle.

The publishing refactor introduces per-module snapshot support (`-PsnapshotModules=core,android`) so individual modules can be snapshot-released without affecting the rest, and a `printDependencyChain` Gradle task that exposes the module dependency graph for scripts to consume. The POM generation logic is simplified with deduplication and proper resolution of Kotlin plugin transitive dependencies.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details
- Refactored `publishing.gradle.kts` to separate module config resolution from version suffixing, making snapshot and release paths explicit
- Added `snapshotModules` Gradle property support — when set, listed modules use `-SNAPSHOT` versions in POM dependencies instead of release ranges
- Added POM dependency deduplication and `apiDependenciesMetadata` resolution to correctly include Kotlin plugin transitive dependencies (e.g., kotlin-stdlib)
- Added `printDependencyChain` Gradle task that outputs module metadata (groupId, artifactId, version, packaging, inter-project deps) in a pipe-delimited format
- Added `printPom` Gradle task for CI dry-run POM verification
- Created 10 release scripts in `scripts/releases/` built on a shared `common.sh` utilities library:
  - **detect-affected-modules**: analyses git diff to determine which modules changed and what semver bump each needs
  - **bump-versions**: updates `RudderStackBuildConfig.kt` and `gradle.properties` with new version numbers
  - **generate-changelog**: produces per-module `CHANGELOG.md` entries from conventional commits
  - **create-tags / create-github-releases**: creates per-module and monorepo tags via GitHub API, plus GitHub releases with changelog bodies
  - **publish-module**: publishes a single module to Maven Central via Gradle
  - **create-release-pr / create-backmerge-pr**: automates release and post-release PR creation

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
- Run `./gradlew printDependencyChain` and verify it outputs the correct module dependency graph with groupId, artifactId, version, packaging, and dependency relationships
- Run `./gradlew :core:printPom -Prelease` and `./gradlew :integrations:adjust:printPom -PsnapshotModules=core,android` to verify POM generation under release and snapshot modes
- Run `./scripts/releases/detect-affected-modules.sh` against a branch with known module changes and verify the output format (`module|bump|oldVersion|newVersion`)
- Verify existing POM verification tests still pass: `./gradlew :core:test :android:test`

## Breaking Changes

None. Publishing behaviour is unchanged for existing release and snapshot flows. The `snapshotModules` property is opt-in and only used by the new release workflows (introduced in a follow-up PR).

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)

N/A

## Additional Context

This is Part 1 of the release automation pipeline. Part 2 (GitHub Actions workflows and Slack notification action) will be raised as a separate PR that depends on these scripts and Gradle tasks.
