### PR TITLE
refactor: update deprecation messages in LoggerAnalytics

### DIFF
--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsConfiguration.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/AnalyticsConfiguration.kt
@@ -23,6 +23,7 @@ interface AnalyticsConfiguration {
     /**
      * The logger instance for this analytics configuration.
      */
+    @InternalRudderApi
     val logger: Logger
 
     /**

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
@@ -36,15 +36,14 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
  * These methods ensure that messages are logged according to the configured log level, providing flexibility
  * and clarity for debugging and tracking events across SDK modules.
  *
- * **DEPRECATION NOTICE**: While this class remains available for backward compatibility with existing integrations,
- * internal SDK components now use instance-based logging via `AnalyticsLogger` to support different log levels
- * per Analytics instance. New internal development should use the instance logger available via `analyticsInstance.logger`.
- * External integrations may continue to use this singleton safely.
+ * **DEPRECATION NOTICE**: This class is deprecated in favor of instance-based logging.
+ * - Pass `logger` and `logLevel` via `Configuration` when initializing the SDK.
+ * - Inside a custom plugin, use the `logger` extension property on the `Plugin` interface to access the per-instance logger.
+ * - This class remains available for backward compatibility but should not be used in new code.
  */
 @Deprecated(
-    message = "LoggerAnalytics is deprecated for internal SDK usage and external clients. " +
-        "Use analyticsInstance.logger instead " +
-        "for instance-based logging. External integrations may continue using this safely for backward compatibility.",
+    message = "LoggerAnalytics is deprecated. Pass logger and logLevel via Configuration instead. " +
+        "Inside a custom plugin, use the Plugin.logger extension property for instance-based logging.",
     level = DeprecationLevel.WARNING
 )
 object LoggerAnalytics {
@@ -102,7 +101,7 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use analyticsInstance.logger.verbose() instead for instance-based logging",
+        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
         level = DeprecationLevel.WARNING
     )
     fun verbose(log: String) {
@@ -117,7 +116,7 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use analyticsInstance.logger.debug() instead for instance-based logging",
+        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
         level = DeprecationLevel.WARNING
     )
     fun debug(log: String) {
@@ -132,7 +131,7 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use analyticsInstance.logger.info() instead for instance-based logging",
+        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
         level = DeprecationLevel.WARNING
     )
     fun info(log: String) {
@@ -147,7 +146,7 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use analyticsInstance.logger.warn() instead for instance-based logging",
+        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
         level = DeprecationLevel.WARNING
     )
     fun warn(log: String) {
@@ -163,7 +162,7 @@ object LoggerAnalytics {
      * @param throwable An optional exception to log alongside the error message.
      */
     @Deprecated(
-        message = "Use analyticsInstance.logger.error() instead for instance-based logging",
+        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
         level = DeprecationLevel.WARNING
     )
     @JvmOverloads

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
@@ -4,42 +4,37 @@ import com.rudderstack.sdk.kotlin.core.internals.logger.Logger.Companion.DEFAULT
 import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
 
 /**
- * `LoggerAnalytics` is a singleton class that manages the logging instance for the SDK, supporting configurable
- * logger types and log levels. It allows setting up either an Android or Kotlin logger, providing consistent
- * logging across different environments.
+ * `LoggerAnalytics` is a singleton class that was previously used to manage the logging instance for the SDK.
  *
- * ### Setup
- * Use the `setLogger` method to configure the logger instance:
+ * **DEPRECATED**: This class is deprecated in favor of instance-based logging. Migrate as follows:
  *
- * ```kotlin
- * LoggerAnalytics.setLogger(logger = AndroidLogger())
- * // Or for Kotlin environments
- * LoggerAnalytics.setLogger(logger = KotlinLogger())
- * ```
- * Use `logLevel` to set the desired log level:
+ * ### Configuring logger and log level
+ * Pass `logger` and `logLevel` via `Configuration` when initializing the SDK:
  *
  * ```kotlin
- * LoggerAnalytics.logLevel = Logger.LogLevel.VERBOSE
+ * Analytics(
+ *     configuration = Configuration(
+ *         writeKey = "YOUR_WRITE_KEY",
+ *         dataPlaneUrl = "YOUR_DATA_PLANE_URL",
+ *         logger = AndroidLogger(),
+ *         logLevel = Logger.LogLevel.VERBOSE
+ *     )
+ * )
  * ```
  *
- * ### Usage
- * Once configured, log messages at various levels as shown below:
+ * ### Logging inside a custom plugin
+ * Use the `logger` extension property on the `Plugin` interface:
  *
  * ```kotlin
- * LoggerAnalytics.verbose("This is a verbose message")
- * LoggerAnalytics.debug("This is a debug message")
- * LoggerAnalytics.info("This is an info message")
- * LoggerAnalytics.warn("This is a warning message")
- * LoggerAnalytics.error("This is an error message", throwable)
+ * class MyPlugin : Plugin {
+ *     override fun intercept(event: Event): Event {
+ *         logger.verbose("Processing event")
+ *         return event
+ *     }
+ * }
  * ```
  *
- * These methods ensure that messages are logged according to the configured log level, providing flexibility
- * and clarity for debugging and tracking events across SDK modules.
- *
- * **DEPRECATION NOTICE**: This class is deprecated in favor of instance-based logging.
- * - Pass `logger` and `logLevel` via `Configuration` when initializing the SDK.
- * - Inside a custom plugin, use the `logger` extension property on the `Plugin` interface to access the per-instance logger.
- * - This class remains available for backward compatibility but should not be used in new code.
+ * This class remains available for backward compatibility but should not be used in new code.
  */
 @Deprecated(
     message = "LoggerAnalytics is deprecated. Pass logger and logLevel via Configuration instead. " +
@@ -101,7 +96,7 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
+        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.verbose(log).",
         level = DeprecationLevel.WARNING
     )
     fun verbose(log: String) {
@@ -116,7 +111,7 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
+        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.debug(log).",
         level = DeprecationLevel.WARNING
     )
     fun debug(log: String) {
@@ -131,7 +126,7 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
+        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.info(log).",
         level = DeprecationLevel.WARNING
     )
     fun info(log: String) {
@@ -146,7 +141,7 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
+        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.warn(log).",
         level = DeprecationLevel.WARNING
     )
     fun warn(log: String) {
@@ -162,7 +157,7 @@ object LoggerAnalytics {
      * @param throwable An optional exception to log alongside the error message.
      */
     @Deprecated(
-        message = "Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin",
+        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.error(log, throwable).",
         level = DeprecationLevel.WARNING
     )
     @JvmOverloads

--- a/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
+++ b/core/src/main/kotlin/com/rudderstack/sdk/kotlin/core/internals/logger/LoggerAnalytics.kt
@@ -23,7 +23,8 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
  * ```
  *
  * ### Logging inside a custom plugin
- * Use the `logger` extension property on the `Plugin` interface:
+ * Use the `logger` extension property available on the `Plugin` interface.
+ * Inside a plugin, simply call `logger` directly:
  *
  * ```kotlin
  * class MyPlugin : Plugin {
@@ -38,7 +39,7 @@ import com.rudderstack.sdk.kotlin.core.internals.utils.InternalRudderApi
  */
 @Deprecated(
     message = "LoggerAnalytics is deprecated. Pass logger and logLevel via Configuration instead. " +
-        "Inside a custom plugin, use the Plugin.logger extension property for instance-based logging.",
+        "Inside a custom plugin, use the `logger` extension property available on the Plugin interface.",
     level = DeprecationLevel.WARNING
 )
 object LoggerAnalytics {
@@ -96,7 +97,8 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.verbose(log).",
+        message = "Use instance-based logging instead. Configure logger and logLevel via Configuration, " +
+            "then inside a custom plugin, call logger.verbose(log).",
         level = DeprecationLevel.WARNING
     )
     fun verbose(log: String) {
@@ -111,7 +113,8 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.debug(log).",
+        message = "Use instance-based logging instead. Configure logger and logLevel via Configuration, " +
+            "then inside a custom plugin, call logger.debug(log).",
         level = DeprecationLevel.WARNING
     )
     fun debug(log: String) {
@@ -126,7 +129,8 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.info(log).",
+        message = "Use instance-based logging instead. Configure logger and logLevel via Configuration, " +
+            "then inside a custom plugin, call logger.info(log).",
         level = DeprecationLevel.WARNING
     )
     fun info(log: String) {
@@ -141,7 +145,8 @@ object LoggerAnalytics {
      * @param log The message to log.
      */
     @Deprecated(
-        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.warn(log).",
+        message = "Use instance-based logging instead. Configure logger and logLevel via Configuration, " +
+            "then inside a custom plugin, call logger.warn(log).",
         level = DeprecationLevel.WARNING
     )
     fun warn(log: String) {
@@ -157,7 +162,8 @@ object LoggerAnalytics {
      * @param throwable An optional exception to log alongside the error message.
      */
     @Deprecated(
-        message = "Use instance-based logging instead. Inside a custom plugin, call Plugin.logger.error(log, throwable).",
+        message = "Use instance-based logging instead. Configure logger and logLevel via Configuration, " +
+            "then inside a custom plugin, call logger.error(log, throwable).",
         level = DeprecationLevel.WARNING
     )
     @JvmOverloads


### PR DESCRIPTION
## Description

Update the deprecation messages in `LoggerAnalytics` to correctly guide developers toward `Plugin.logger` extension property instead of `analyticsInstance.logger`, which is an internal API. Also mark `AnalyticsConfiguration.logger` as `@InternalRudderApi` since direct access to `analytics.logger` outside of the SDK or a custom plugin is not part of the public API.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactor/optimization

## Implementation Details

- Updated the class-level `@Deprecated` annotation and KDoc on `LoggerAnalytics` to recommend passing `logger` and `logLevel` via `Configuration`, and using `Plugin.logger` inside custom plugins.
- Updated all method-level `@Deprecated` annotations (`verbose`, `debug`, `info`, `warn`, `error`) from `"Use analyticsInstance.logger.X()"` to `"Use the Plugin.logger extension property instead for instance-based logging inside a custom plugin"`.
- Added `@InternalRudderApi` annotation to `AnalyticsConfiguration.logger` to prevent external consumers from directly accessing `analytics.logger` outside of the SDK.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?

1. Use `LoggerAnalytics` in consuming code — verify the deprecation warning now mentions `Plugin.logger` and `Configuration` instead of `analyticsInstance.logger`.
2. Attempt to access `analytics.logger` from external consumer code — verify it shows an `@InternalRudderApi` opt-in warning.
3. Access `logger` inside a custom plugin via the `Plugin.logger` extension — verify it works without any warnings.

## Breaking Changes

None. The `@InternalRudderApi` annotation on `AnalyticsConfiguration.logger` adds an opt-in requirement but does not remove the API. Existing code using `analytics.logger` will see a compiler warning but will continue to compile.

## Maintainers Checklist

- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)

N/A

## Additional Context

The `analytics.logger` property was inadvertently left without `@InternalRudderApi`. The intended public API for accessing the logger outside the SDK is solely through the `Plugin.logger` extension property, which is available inside any custom plugin after it has been added to an `Analytics` instance.
