### PR TITLE
ci: fix Slack notification formatting in release workflows

### DIFF
--- a/.github/actions/slack-release-notify/action.yml
+++ b/.github/actions/slack-release-notify/action.yml
@@ -123,7 +123,6 @@ runs:
       env:
         CHANNEL_ID: ${{ inputs.channel_id }}
         THREAD_TS: ${{ inputs.thread_ts }}
-        MESSAGE: ${{ inputs.message }}
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_bot_token }}
@@ -133,7 +132,7 @@ runs:
           {
             "channel": "${{ env.CHANNEL_ID }}",
             "thread_ts": "${{ env.THREAD_TS }}",
-            "text": "${{ env.MESSAGE }}"
+            "text": ${{ toJSON(inputs.message) }}
           }
 
     # ──────────────────────────────────────────────
@@ -144,7 +143,6 @@ runs:
       uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
       env:
         CHANNEL_ID: ${{ inputs.channel_id }}
-        MESSAGE: ${{ inputs.message }}
       with:
         method: chat.postMessage
         token: ${{ inputs.slack_bot_token }}
@@ -153,5 +151,5 @@ runs:
         payload: |
           {
             "channel": "${{ env.CHANNEL_ID }}",
-            "text": "${{ env.MESSAGE }}"
+            "text": ${{ toJSON(inputs.message) }}
           }

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -223,15 +223,16 @@ jobs:
             modules_list+="  ${padded_module}${old_ver} -> ${new_ver} (${bump})"$'\n'
           done <<< "$AFFECTED"
 
-          msg=":rocket: Release PR Created: ${PR_URL}"
+          msg=":rocket: *Release PR Created*:"
+          msg+=$'\n'"${PR_URL}"
           msg+=$'\n'
-          msg+=$'\n'"SDK Version: v${VERSION}"
-          msg+=$'\n'"Release Branch: ${BRANCH}"
+          msg+=$'\n'"*SDK Monorepo Version:* v${VERSION}"
+          msg+=$'\n'"*Release Branch:* \`${BRANCH}\`"
           msg+=$'\n'
-          msg+=$'\n'"Affected Modules:"
+          msg+=$'\n'"*Affected Modules:*"
           msg+=$'\n'"${modules_list}"
           msg+=$'\n'":point_right: Review and merge when ready!"
-          msg+=$'\n'"CC: @mobile-sdk @sdk-on-call"
+          msg+=$'\n'"CC: <!subteam^S066Z6BUTAS> <!subteam^S03SW7DM8P3>"
 
           EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "text<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -276,10 +276,11 @@ jobs:
             module_line+="${module} ${new_ver}"
           done <<< "$AFFECTED"
 
-          msg=":rocket: New release: Kotlin SDK"
-          msg+=$'\n'"*Release: <https://github.com/${REPO}/compare/${prev_tag}...v${VERSION}|v${VERSION}>*"
+          msg=":rocket: *New release: Kotlin SDK*"
+          msg+=$'\n'"*Release:* <https://github.com/${REPO}/compare/${prev_tag}...v${VERSION}|v${VERSION}>"
           msg+=$'\n'"${module_line}"
-          msg+=$'\n'"CC: @mobile-sdk @sdk-on-call"
+          msg+=$'\n'
+          msg+=$'\n'"CC: <!subteam^S066Z6BUTAS> <!subteam^S03SW7DM8P3>"
 
           EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "text<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
@@ -312,12 +313,15 @@ jobs:
             module_line+="${module} ${new_ver}"
           done <<< "$AFFECTED"
 
-          msg=":rocket: New release: Kotlin SDK"
-          msg+=$'\n\n'"Published to Maven Central:"
+          msg=":rocket: *New release: Kotlin SDK*"
+          msg+=$'\n'
+          msg+=$'\n'"*Published to Maven Central:*"
           msg+=$'\n'"${module_line}"
-          msg+=$'\n'"Back-merge PR: ${BACKMERGE_PR}"
+          msg+=$'\n'
+          msg+=$'\n'"*Back-merge PR:* <${BACKMERGE_PR}>"
           msg+=$'\n'":point_right: Please review and merge the back-merge PR."
-          msg+=$'\n\n'"CC: @mobile-sdk @sdk-on-call"
+          msg+=$'\n'
+          msg+=$'\n'"CC: <!subteam^S066Z6BUTAS> <!subteam^S03SW7DM8P3>"
 
           EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "text<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -175,20 +175,23 @@ jobs:
           AFFECTED: ${{ needs.detect-modules.outputs.affected }}
         run: |
           if [[ "$IS_FIRST" == "true" ]]; then
-            msg=":package: Snapshot versions published to Maven Central"
-            msg+=$'\n\n'"Modules:"
+            msg=":package: *Snapshot versions published to Maven Central*"
+            msg+=$'\n'
+            msg+=$'\n'"*Modules:*"
             while IFS='|' read -r module bump old_ver new_ver; do
               [[ -z "$module" ]] && continue
               case "$module" in
                 core|android) group="com.rudderstack.sdk.kotlin" ;;
                 *) group="com.rudderstack.integration.kotlin" ;;
               esac
-              msg+=$'\n'"  ${group}:${module}:${new_ver}-SNAPSHOT"
+              msg+=$'\n'"  \`${group}:${module}:${new_ver}-SNAPSHOT\`"
             done <<< "$AFFECTED"
-            msg+=$'\n\n'"CC: @mobile-sdk @sdk-on-call"
+            msg+=$'\n'
+            msg+=$'\n'"CC: <!subteam^S066Z6BUTAS> <!subteam^S03SW7DM8P3>"
           else
-            msg=":package: Snapshots republished"
-            msg+=$'\n\n'"CC: @mobile-sdk @sdk-on-call"
+            msg=":package: *Snapshots republished*"
+            msg+=$'\n'
+            msg+=$'\n'"CC: <!subteam^S066Z6BUTAS> <!subteam^S03SW7DM8P3>"
           fi
 
           EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)


### PR DESCRIPTION
## Description

Slack notifications from release workflows (draft, snapshot, publish) were rendering as unstructured single-line messages with collapsed newlines, plain-text user group mentions that didn't ping anyone, and broken emoji shortcodes.

Root cause: the `slack-release-notify` composite action injected multiline messages into JSON payloads via raw `${{ env.MESSAGE }}` interpolation, which broke the JSON string when the message contained newlines.

Resolves [SDK-4714](https://linear.app/rudderstack/issue/SDK-4714)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

- Use `toJSON(inputs.message)` in the Slack action payload to properly JSON-escape newlines, replacing raw string interpolation
- Add Slack mrkdwn bold formatting (`*text*`) and backtick code formatting to match the JS SDK notification style
- Replace plain-text `@mobile-sdk-eng` / `@sdk-on-call` with proper `<!subteam^ID>` syntax so mentions actually notify the groups
- Wrap bare URLs in explicit Slack link syntax (`<URL>`) to prevent the auto-linker from consuming adjacent `:point_right:` emoji
- Rename "SDK Version" label to "SDK Monorepo Version"

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?

- Trigger the draft-new-release workflow and verify the Slack thread message renders with bold labels, proper line breaks, and working `@mobile-sdk-eng` / `@sdk-on-call` group pings
- Push a commit to the release PR and verify the snapshot notification renders with backtick-formatted Maven coordinates and proper spacing
- Merge a release PR and verify the publish notifications (channel + thread) render with structured formatting and the back-merge PR URL doesn't break the `:point_right:` emoji on the next line

## Breaking Changes

None.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Additional Context