### PR TITLE
ci: use matrix strategy for release publishing

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -144,6 +144,10 @@ jobs:
     needs: detect-modules
     if: needs.detect-modules.outputs.has_modules == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: ${{ fromJson(needs.detect-modules.outputs.matrix) }}
+      fail-fast: false
     steps:
       - name: Harden the runner
         uses: step-security/harden-runner@a90bcbc6539c36a85cdfeb73f7e2f433735f215b # v2.15.0
@@ -160,24 +164,17 @@ jobs:
           java-version: '17'
           cache: gradle
 
-      - name: Publish all affected modules
+      - name: Publish ${{ matrix.module }}
         shell: bash
         env:
-          MODULES: ${{ needs.detect-modules.outputs.matrix }}
+          MODULE: ${{ matrix.module }}
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PRIVATE_KEY_BASE64: ${{ secrets.SIGNING_PRIVATE_KEY_BASE64 }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
         run: |
-          source scripts/releases/common.sh
-          tasks=""
-          for module in $(echo "$MODULES" | jq -r '.[]'); do
-            gradle_path="$(module_to_gradle_path "$module")"
-            tasks="$tasks ${gradle_path}:publishToSonatype"
-          done
-          echo "Publishing tasks:$tasks"
-          ./gradlew $tasks -Prelease closeAndReleaseSonatypeStagingRepository
+          ./scripts/releases/publish-module.sh "$MODULE" release
 
   back-merge:
     needs: detect-modules


### PR DESCRIPTION
## Description

The release workflow (`publish-new-release.yml`) was publishing all 7 modules in a single Gradle invocation, creating one Sonatype staging repository containing artifacts from multiple namespaces. Maven Central's new portal rejects this during close with: "Deployment contains files for multiple namespaces: com.rudderstack, com.rudderstack.integration.kotlin, com.rudderstack.sdk.kotlin".

This switches the `publish-release` job to a per-module matrix strategy (matching the snapshot workflow pattern), so each module publishes in its own job with its own staging repo. Each Gradle invocation creates, publishes to, and closes its own staging repo independently — no cross-job interference.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Added `strategy.matrix` to the `publish-release` job, iterating over the detected modules with `fail-fast: false`
- Replaced the combined Gradle invocation with `publish-module.sh "$MODULE" release` per matrix job
- Reuses the existing `publish-module.sh` script — no new scripts or changes to the publishing logic 

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [ ] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?

1. Trigger the publish workflow with a release PR merge
2. Verify that each module gets its own matrix job in GitHub Actions
3. Verify each job creates its own Sonatype staging repo, publishes, and closes independently
4. Confirm all modules appear on Maven Central after the workflow completes

## Breaking Changes

None. The downstream `notify-slack` and other jobs already wait for all matrix jobs via `needs: [publish-release]`.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Additional Context

- Linear ticket: SDK-4719
- Failed run: https://github.com/rudderlabs/rudder-sdk-kotlin/actions/runs/24066119852/job/70192588599
- The `gradle-nexus/publish-plugin` (v2.0.0) tracks staging repo IDs in-memory per Gradle JVM, so parallel matrix jobs are safe — each closes only its own repo by explicit ID, no search involved.