### PR TITLE
chore: add dependabot configuration for gradle and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,96 @@
+version: 2
+updates:
+  # GitHub Actions - group all action updates into a single PR
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      timezone: "UTC"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions-deps:
+        patterns:
+          - "*"
+
+  # Gradle dependencies
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      timezone: "UTC"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "gradle"
+    open-pull-requests-limit: 10
+    groups:
+      # Kotlin compiler + kotlinx libraries should move together
+      kotlin-and-kotlinx:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx*"
+
+      # All AndroidX dependencies grouped
+      androidx:
+        patterns:
+          - "androidx.*"
+
+      # Test dependencies grouped
+      testing:
+        patterns:
+          - "org.junit*"
+          - "io.mockk*"
+          - "org.skyscreamer*"
+
+      # Build tooling and Gradle plugins
+      build-plugins:
+        patterns:
+          - "com.android.tools.build*"
+          - "io.gitlab.arturbosch.detekt*"
+          - "io.github.gradle-nexus*"
+
+      # Integration SDKs - minor and patch only (strictly versioned)
+      integrations:
+        patterns:
+          - "com.adjust.sdk*"
+          - "com.appsflyer*"
+          - "com.google.firebase*"
+          - "com.facebook.android*"
+          - "com.braze*"
+          - "com.android.installreferrer*"
+        update-types:
+          - "minor"
+          - "patch"
+
+      # Sample app dependencies
+      sample-app-deps:
+        patterns:
+          - "com.google.android.gms*"
+          - "com.jakewharton.timber*"
+
+    # Ignore major updates for integration SDKs (they have strictly bounded version ranges)
+    ignore:
+      - dependency-name: "com.adjust.sdk*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "com.appsflyer*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "com.google.firebase*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "com.facebook.android*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "com.braze*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "com.android.installreferrer*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Description
Add Dependabot configuration to automate dependency update monitoring for both Gradle dependencies and GitHub Actions. This standardizes dependency management in line with the strategy defined in SDK-4510, reducing manual effort and ensuring consistent update cadence across the SDK ecosystem.

Resolves [SDK-4515](https://linear.app/rudderstack/issue/SDK-4515/dependabot-usage-for-kotlin)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- Added `.github/dependabot.yml` with two ecosystems: `github-actions` and `gradle`
- Configured weekly update schedule (Wednesdays, UTC) targeting the `develop` branch
- Defined 7 dependency groups to reduce PR noise:
  - `kotlin-and-kotlinx` — Kotlin compiler + coroutines + serialization (move together for compatibility)
  - `androidx` — all AndroidX libraries grouped
  - `testing` — JUnit, MockK, JSONAssert
  - `build-plugins` — AGP, Detekt, Nexus publish plugin
  - `integrations` — Adjust, AppsFlyer, Firebase, Facebook, Braze (minor/patch only)
  - `sample-app-deps` — Play Services Ads, Timber
  - `github-actions-deps` — all GitHub Actions
- Ignored major version updates for integration SDKs (they use `strictly` bounded version ranges in `libs.versions.toml`)
- Set PR limit to 10 per ecosystem with appropriate labels (`dependencies`, `gradle`, `github-actions`)

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
1. After merging to `develop`, navigate to the repo's **Settings > Code security and analysis > Dependabot** section to verify the configuration is recognized
2. Check **Insights > Dependency graph > Dependabot** tab to see detected ecosystems and scheduled update times
3. Optionally trigger a manual check via the Dependabot tab to verify PRs are created with correct grouping and labels
4. Verify that Dependabot PRs trigger the existing PR Validation workflow (detekt, lint, test, build checks)

## Breaking Changes
None

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
- This is part of the broader initiative [SDK-4510](https://linear.app/rudderstack/issue/SDK-4510) to standardize Dependabot usage across Swift and Kotlin SDKs
- The JS SDK (`rudder-sdk-js`) was used as the reference for best practices (grouping, labels, PR limits, target branch)
- The Android SDK (`rudder-sdk-android`) currently only monitors GitHub Actions with no Gradle coverage — this config addresses that gap for the Kotlin SDK
- Integration SDK major updates are intentionally blocked because they have `strictly` version ranges in `gradle/libs.versions.toml` and require manual wrapper compatibility testing
