### PR TITLE
feat: braze ecommerce events onboarding

### DIFF
--- a/integrations/braze/README.md
+++ b/integrations/braze/README.md
@@ -61,7 +61,7 @@ class MyApplication : Application() {
 
 ## Recommended ecommerce events
 
-When the **`useRecommendedEcommerceEvents`** flag is enabled on the Braze destination, supported RudderStack
+When the **`useEcommerceRecommendedEvents`** flag is enabled on the Braze destination, supported RudderStack
 ecommerce track events are mapped to [Braze recommended events](https://www.braze.com/docs/user_guide/data/activation/events/recommended_events)
 (`ecommerce.*`) and sent via `logCustomEvent`. The flag defaults to off; when off, behaviour is unchanged.
 

--- a/integrations/braze/README.md
+++ b/integrations/braze/README.md
@@ -84,7 +84,7 @@ Notes:
 - Events are never dropped on incomplete data: missing Braze-required fields are logged as a warning and the event
   is still sent (`0` and `false` are treated as valid values).
 - Field values are coerced to the type Braze expects where possible (e.g. a numeric string `"29.99"` → `29.99`,
-  an integer → float, a number → string). When a value cannot be coerced (e.g. `quantity` as `2.5`), a warning is
-  logged and the value is sent as-is.
+  a number → string). When a value cannot be coerced (e.g. `quantity` as `2.5`), a warning is logged and the
+  value is sent as-is.
 - Properties not covered by the mapping are forwarded under `metadata` (event level) and `products[].metadata`
   (per product).

--- a/integrations/braze/README.md
+++ b/integrations/braze/README.md
@@ -58,3 +58,30 @@ class MyApplication : Application() {
     }
 }
 ```
+
+## Recommended ecommerce events
+
+When the **`useRecommendedEcommerceEvents`** flag is enabled on the Braze destination, supported RudderStack
+ecommerce track events are mapped to [Braze recommended events](https://www.braze.com/docs/user_guide/data/activation/events/recommended_events)
+(`ecommerce.*`) and sent via `logCustomEvent`. The flag defaults to off; when off, behaviour is unchanged.
+
+| RudderStack event | Braze event | Action |
+|---|---|---|
+| Product Viewed | `ecommerce.product_viewed` | — |
+| Product Added | `ecommerce.cart_updated` | `add` |
+| Product Removed | `ecommerce.cart_updated` | `remove` |
+| Checkout Started | `ecommerce.checkout_started` | — |
+| Order Completed | `ecommerce.order_placed` | — |
+| Order Refunded | `ecommerce.order_refunded` | — |
+| Order Cancelled | `ecommerce.order_cancelled` | — |
+
+Notes:
+
+- `Cart Viewed` and `Cart Updated` are not mapped — they continue to flow through the generic custom-event path.
+- When the flag is enabled, `Order Completed` emits a single `ecommerce.order_placed` event instead of one purchase
+  per product via the legacy `logPurchase` path.
+- The `source` field is always set to `android`.
+- Events are never dropped on incomplete data: missing Braze-required fields are logged as a warning and the event
+  is still sent (`0` and `false` are treated as valid values).
+- Properties not covered by the mapping are forwarded under `metadata` (event level) and `products[].metadata`
+  (per product).

--- a/integrations/braze/README.md
+++ b/integrations/braze/README.md
@@ -83,5 +83,8 @@ Notes:
 - The `source` field is always set to `android`.
 - Events are never dropped on incomplete data: missing Braze-required fields are logged as a warning and the event
   is still sent (`0` and `false` are treated as valid values).
+- Field values are coerced to the type Braze expects where possible (e.g. a numeric string `"29.99"` → `29.99`,
+  an integer → float, a number → string). When a value cannot be coerced (e.g. `quantity` as `2.5`), a warning is
+  logged and the value is sent as-is.
 - Properties not covered by the mapping are forwarded under `metadata` (event level) and `products[].metadata`
   (per product).

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
@@ -93,7 +93,7 @@ class BrazeIntegration : StandardIntegration, IntegrationPlugin(), ActivityLifec
         }
 
         val ecommerceMapping = getEcommerceMapping(payload.event)
-        if (brazeConfig.useRecommendedEcommerceEvents && ecommerceMapping != null) {
+        if (brazeConfig.useEcommerceRecommendedEvents && ecommerceMapping != null) {
             handleRecommendedEcommerceEvent(payload, ecommerceMapping)
             return
         }

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
@@ -120,13 +120,21 @@ class BrazeIntegration : StandardIntegration, IntegrationPlugin(), ActivityLifec
     private fun handleRecommendedEcommerceEvent(payload: TrackEvent): Boolean {
         val mapping = getEcommerceMapping(payload.event) ?: return false
 
+        val brazeInstance = this.braze ?: run {
+            analytics.logger.verbose(
+                "BrazeIntegration: Braze is not initialized, dropping recommended ecommerce event " +
+                    "'${mapping.brazeEvent}' for RudderStack event '${payload.event}'."
+            )
+            return true
+        }
+
         val properties = buildEcommerceEventProperties(
             properties = payload.properties,
             brazeEvent = mapping.brazeEvent,
             action = mapping.action,
             logger = analytics.logger,
         )
-        this.braze?.logCustomEvent(mapping.brazeEvent, initBrazeProperties(properties))
+        brazeInstance.logCustomEvent(mapping.brazeEvent, initBrazeProperties(properties))
         analytics.logger.verbose(
             "BrazeIntegration: Recommended ecommerce event '${mapping.brazeEvent}' " +
                 "sent for RudderStack event '${payload.event}'."

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
@@ -92,7 +92,9 @@ class BrazeIntegration : StandardIntegration, IntegrationPlugin(), ActivityLifec
             return
         }
 
-        if (brazeConfig.useRecommendedEcommerceEvents && handleRecommendedEcommerceEvent(payload)) {
+        val ecommerceMapping = getEcommerceMapping(payload.event)
+        if (brazeConfig.useRecommendedEcommerceEvents && ecommerceMapping != null) {
+            handleRecommendedEcommerceEvent(payload, ecommerceMapping)
             return
         }
 
@@ -113,19 +115,14 @@ class BrazeIntegration : StandardIntegration, IntegrationPlugin(), ActivityLifec
 
     /**
      * Maps a supported RudderStack ecommerce event to a Braze recommended event and logs it.
-     *
-     * @return `true` if the event was handled as a recommended ecommerce event; `false` to fall through
-     * to the legacy track handling.
      */
-    private fun handleRecommendedEcommerceEvent(payload: TrackEvent): Boolean {
-        val mapping = getEcommerceMapping(payload.event) ?: return false
-
+    private fun handleRecommendedEcommerceEvent(payload: TrackEvent, mapping: EcommerceMapping) {
         val brazeInstance = this.braze ?: run {
             analytics.logger.verbose(
                 "BrazeIntegration: Braze is not initialized, dropping recommended ecommerce event " +
                     "'${mapping.brazeEvent}' for RudderStack event '${payload.event}'."
             )
-            return true
+            return
         }
 
         val properties = buildEcommerceEventProperties(
@@ -139,7 +136,6 @@ class BrazeIntegration : StandardIntegration, IntegrationPlugin(), ActivityLifec
             "BrazeIntegration: Recommended ecommerce event '${mapping.brazeEvent}' " +
                 "sent for RudderStack event '${payload.event}'."
         )
-        return true
     }
 
     private fun handleInstallAttributedEvent(payload: TrackEvent) {

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/BrazeIntegration.kt
@@ -92,6 +92,10 @@ class BrazeIntegration : StandardIntegration, IntegrationPlugin(), ActivityLifec
             return
         }
 
+        if (brazeConfig.useRecommendedEcommerceEvents && handleRecommendedEcommerceEvent(payload)) {
+            return
+        }
+
         when (payload.event) {
             INSTALL_ATTRIBUTED -> {
                 handleInstallAttributedEvent(payload)
@@ -105,6 +109,29 @@ class BrazeIntegration : StandardIntegration, IntegrationPlugin(), ActivityLifec
                 handleCustomEvent(payload)
             }
         }
+    }
+
+    /**
+     * Maps a supported RudderStack ecommerce event to a Braze recommended event and logs it.
+     *
+     * @return `true` if the event was handled as a recommended ecommerce event; `false` to fall through
+     * to the legacy track handling.
+     */
+    private fun handleRecommendedEcommerceEvent(payload: TrackEvent): Boolean {
+        val mapping = getEcommerceMapping(payload.event) ?: return false
+
+        val properties = buildEcommerceEventProperties(
+            properties = payload.properties,
+            brazeEvent = mapping.brazeEvent,
+            action = mapping.action,
+            logger = analytics.logger,
+        )
+        this.braze?.logCustomEvent(mapping.brazeEvent, initBrazeProperties(properties))
+        analytics.logger.verbose(
+            "BrazeIntegration: Recommended ecommerce event '${mapping.brazeEvent}' " +
+                "sent for RudderStack event '${payload.event}'."
+        )
+        return true
     }
 
     private fun handleInstallAttributedEvent(payload: TrackEvent) {

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
@@ -8,6 +8,8 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.longOrNull
 import java.util.Locale
 
 /**
@@ -40,16 +42,31 @@ private const val ACTION_KEY = "action"
 private const val ANDROID_SOURCE = "android"
 
 /**
+ * The type Braze expects for a recommended-event field. Resolved values are coerced to this type where
+ * possible; a value that cannot be coerced is sent verbatim and surfaced via a warning.
+ */
+internal enum class BrazeFieldType {
+    STRING,
+    INTEGER,
+    FLOAT,
+    STRING_ARRAY,
+    ARRAY,
+}
+
+/**
  * A single field mapping entry, mirroring the cloud `Braze<Event>Config.json` shape.
  *
  * @property destKey The Braze field name to write.
  * @property sourceKeys Ordered fallback chain of RudderStack property names; the first resolved value wins.
  * @property brazeRequired When true, a missing value contributes to the validation warning.
+ * @property expectedType The type Braze expects for this field; the value is coerced to it where possible,
+ * otherwise sent verbatim with a warning.
  */
 internal data class FieldMapping(
     val destKey: String,
     val sourceKeys: List<String>,
     val brazeRequired: Boolean,
+    val expectedType: BrazeFieldType = BrazeFieldType.STRING,
 )
 
 /** Result of resolving an RS event name to a Braze recommended event. */
@@ -58,8 +75,12 @@ internal data class EcommerceMapping(
     val action: String? = null,
 )
 
-private fun mapping(destKey: String, vararg sourceKeys: String, brazeRequired: Boolean) =
-    FieldMapping(destKey, sourceKeys.toList(), brazeRequired)
+private fun mapping(
+    destKey: String,
+    vararg sourceKeys: String,
+    brazeRequired: Boolean,
+    type: BrazeFieldType = BrazeFieldType.STRING,
+) = FieldMapping(destKey, sourceKeys.toList(), brazeRequired, type)
 
 // Source keys that are not part of the RudderStack ecommerce spec (`ECommerceParamNames`) and are
 // therefore mirrored verbatim from the Braze recommended-event schema.
@@ -81,70 +102,116 @@ private val PRODUCT_VIEWED_MAPPING = listOf(
     mapping("product_id", ECommerceParamNames.PRODUCT_ID, SKU, brazeRequired = true),
     mapping("product_name", NAME, brazeRequired = true),
     mapping("variant_id", VARIANT, SKU, ECommerceParamNames.PRODUCT_ID, brazeRequired = true),
-    mapping("price", ECommerceParamNames.PRICE, brazeRequired = true),
+    mapping("price", ECommerceParamNames.PRICE, brazeRequired = true, type = BrazeFieldType.FLOAT),
     mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
     mapping("image_url", IMAGE_URL, brazeRequired = false),
     mapping("product_url", URL, brazeRequired = false),
-    mapping("type", TYPE, brazeRequired = false),
+    mapping("type", TYPE, brazeRequired = false, type = BrazeFieldType.STRING_ARRAY),
 )
 
 private val CART_UPDATED_MAPPING = listOf(
     mapping("cart_id", ECommerceParamNames.CART_ID, brazeRequired = true),
-    mapping("total_value", ECommerceParamNames.TOTAL, VALUE, brazeRequired = false),
-    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false),
-    mapping("tax", TAX, brazeRequired = false),
-    mapping("shipping", SHIPPING, brazeRequired = false),
+    mapping("total_value", ECommerceParamNames.TOTAL, VALUE, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping("tax", TAX, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping("shipping", SHIPPING, brazeRequired = false, type = BrazeFieldType.FLOAT),
     mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
 )
 
 private val CHECKOUT_STARTED_MAPPING = listOf(
     mapping("checkout_id", ECommerceParamNames.CHECKOUT_ID, ECommerceParamNames.ORDER_ID, brazeRequired = true),
     mapping("cart_id", ECommerceParamNames.CART_ID, brazeRequired = false),
-    mapping("total_value", ECommerceParamNames.TOTAL, ECommerceParamNames.REVENUE, VALUE, brazeRequired = true),
-    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false),
-    mapping("tax", TAX, brazeRequired = false),
-    mapping("shipping", SHIPPING, brazeRequired = false),
+    mapping(
+        "total_value",
+        ECommerceParamNames.TOTAL,
+        ECommerceParamNames.REVENUE,
+        VALUE,
+        brazeRequired = true,
+        type = BrazeFieldType.FLOAT,
+    ),
+    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping("tax", TAX, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping("shipping", SHIPPING, brazeRequired = false, type = BrazeFieldType.FLOAT),
     mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
 )
 
 private val ORDER_PLACED_MAPPING = listOf(
     mapping("order_id", ECommerceParamNames.ORDER_ID, brazeRequired = true),
-    mapping("total_value", ECommerceParamNames.TOTAL, ECommerceParamNames.REVENUE, VALUE, brazeRequired = true),
+    mapping(
+        "total_value",
+        ECommerceParamNames.TOTAL,
+        ECommerceParamNames.REVENUE,
+        VALUE,
+        brazeRequired = true,
+        type = BrazeFieldType.FLOAT,
+    ),
     mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
     mapping("cart_id", ECommerceParamNames.CART_ID, brazeRequired = false),
-    mapping("tax", TAX, brazeRequired = false),
-    mapping("shipping", SHIPPING, brazeRequired = false),
-    mapping("total_discounts", ECommerceParamNames.DISCOUNT, TOTAL_DISCOUNTS, brazeRequired = false),
-    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false),
-    mapping("discounts", DISCOUNTS, brazeRequired = false),
+    mapping("tax", TAX, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping("shipping", SHIPPING, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping(
+        "total_discounts",
+        ECommerceParamNames.DISCOUNT,
+        TOTAL_DISCOUNTS,
+        brazeRequired = false,
+        type = BrazeFieldType.FLOAT,
+    ),
+    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping("discounts", DISCOUNTS, brazeRequired = false, type = BrazeFieldType.ARRAY),
 )
 
 private val ORDER_REFUNDED_MAPPING = listOf(
     mapping("order_id", ECommerceParamNames.ORDER_ID, brazeRequired = true),
-    mapping("total_value", ECommerceParamNames.TOTAL, ECommerceParamNames.REVENUE, VALUE, brazeRequired = true),
+    mapping(
+        "total_value",
+        ECommerceParamNames.TOTAL,
+        ECommerceParamNames.REVENUE,
+        VALUE,
+        brazeRequired = true,
+        type = BrazeFieldType.FLOAT,
+    ),
     mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
-    mapping("total_discounts", ECommerceParamNames.DISCOUNT, TOTAL_DISCOUNTS, brazeRequired = false),
-    mapping("discounts", DISCOUNTS, brazeRequired = false),
+    mapping(
+        "total_discounts",
+        ECommerceParamNames.DISCOUNT,
+        TOTAL_DISCOUNTS,
+        brazeRequired = false,
+        type = BrazeFieldType.FLOAT,
+    ),
+    mapping("discounts", DISCOUNTS, brazeRequired = false, type = BrazeFieldType.ARRAY),
 )
 
 private val ORDER_CANCELLED_MAPPING = listOf(
     mapping("order_id", ECommerceParamNames.ORDER_ID, brazeRequired = true),
-    mapping("total_value", ECommerceParamNames.TOTAL, ECommerceParamNames.REVENUE, VALUE, brazeRequired = true),
+    mapping(
+        "total_value",
+        ECommerceParamNames.TOTAL,
+        ECommerceParamNames.REVENUE,
+        VALUE,
+        brazeRequired = true,
+        type = BrazeFieldType.FLOAT,
+    ),
     mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
     mapping("cancel_reason", CANCEL_REASON, ECommerceParamNames.REASON, brazeRequired = true),
-    mapping("tax", TAX, brazeRequired = false),
-    mapping("shipping", SHIPPING, brazeRequired = false),
-    mapping("total_discounts", ECommerceParamNames.DISCOUNT, TOTAL_DISCOUNTS, brazeRequired = false),
-    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false),
-    mapping("discounts", DISCOUNTS, brazeRequired = false),
+    mapping("tax", TAX, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping("shipping", SHIPPING, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping(
+        "total_discounts",
+        ECommerceParamNames.DISCOUNT,
+        TOTAL_DISCOUNTS,
+        brazeRequired = false,
+        type = BrazeFieldType.FLOAT,
+    ),
+    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false, type = BrazeFieldType.FLOAT),
+    mapping("discounts", DISCOUNTS, brazeRequired = false, type = BrazeFieldType.ARRAY),
 )
 
 private val ECOMMERCE_PRODUCT_MAPPING = listOf(
     mapping("product_id", ECommerceParamNames.PRODUCT_ID, SKU, brazeRequired = true),
     mapping("product_name", NAME, brazeRequired = true),
     mapping("variant_id", VARIANT, SKU, ECommerceParamNames.PRODUCT_ID, brazeRequired = true),
-    mapping("quantity", ECommerceParamNames.QUANTITY, brazeRequired = true),
-    mapping("price", ECommerceParamNames.PRICE, brazeRequired = true),
+    mapping("quantity", ECommerceParamNames.QUANTITY, brazeRequired = true, type = BrazeFieldType.INTEGER),
+    mapping("price", ECommerceParamNames.PRICE, brazeRequired = true, type = BrazeFieldType.FLOAT),
     mapping("image_url", IMAGE_URL, brazeRequired = false),
     mapping("product_url", URL, brazeRequired = false),
 )
@@ -238,6 +305,9 @@ internal fun buildEcommerceEventProperties(
     // Step 7: single validation warning for any missing Braze-required field.
     logMissingRequiredFields(brazeEvent, eventMapping, productMapping, payload, products, logger)
 
+    // Step 8: warn on any resolved field whose value type still doesn't match Braze's schema after coercion.
+    logTypeMismatchedFields(brazeEvent, eventMapping, productMapping, payload, products, logger)
+
     return JsonObject(payload)
 }
 
@@ -289,9 +359,24 @@ private fun JsonObject.resolveMapping(mapping: List<FieldMapping>): Map<String, 
     mapping.forEach { entry ->
         entry.sourceKeys
             .firstNotNullOfOrNull { key -> this[key]?.takeIf { it.isResolved() } }
-            ?.let { result[entry.destKey] = it }
+            ?.let { result[entry.destKey] = it.coerceToType(entry.expectedType) }
     }
     return result
+}
+
+/**
+ * Coerces a primitive value to the [type] Braze expects, where possible (e.g. numeric string → number,
+ * integer → float, number/boolean → string). Returns the value unchanged when it cannot be coerced
+ * (the residual mismatch is then surfaced by [logTypeMismatchedFields]); arrays/objects are never coerced.
+ */
+private fun JsonElement.coerceToType(type: BrazeFieldType): JsonElement {
+    if (this !is JsonPrimitive) return this
+    return when (type) {
+        BrazeFieldType.STRING -> if (isString) this else JsonPrimitive(content)
+        BrazeFieldType.FLOAT -> doubleOrNull?.let { JsonPrimitive(it) } ?: this
+        BrazeFieldType.INTEGER -> longOrNull?.let { JsonPrimitive(it) } ?: this
+        BrazeFieldType.STRING_ARRAY, BrazeFieldType.ARRAY -> this
+    }
 }
 
 /**
@@ -367,6 +452,55 @@ private fun logMissingRequiredFields(
                 "${missing.distinct()}. Sending the event anyway."
         )
     }
+}
+
+/**
+ * Logs a single warning for any resolved field whose value still does not match the type Braze expects after
+ * coercion (event-level or per-product). The (un-coercible) value is sent verbatim; this surfaces it for visibility.
+ */
+private fun logTypeMismatchedFields(
+    brazeEvent: String,
+    eventMapping: List<FieldMapping>,
+    productMapping: List<FieldMapping>?,
+    payload: Map<String, JsonElement>,
+    products: List<JsonObject>?,
+    logger: Logger,
+) {
+    val mismatched = mutableListOf<String>()
+
+    eventMapping.forEach { entry ->
+        payload[entry.destKey]?.takeIf { !it.matchesType(entry.expectedType) }
+            ?.let { mismatched.add("${entry.destKey} (expected ${entry.expectedType})") }
+    }
+
+    if (productMapping != null && !products.isNullOrEmpty()) {
+        productMapping.forEach { entry ->
+            val hasMismatch = products.any { product ->
+                product[entry.destKey]?.let { !it.matchesType(entry.expectedType) } == true
+            }
+            if (hasMismatch) {
+                mismatched.add("products[].${entry.destKey} (expected ${entry.expectedType})")
+            }
+        }
+    }
+
+    if (mismatched.isNotEmpty()) {
+        logger.warn(
+            "BrazeIntegration: '$brazeEvent' has type-mismatched field(s) (sent as-is): ${mismatched.distinct()}."
+        )
+    }
+}
+
+/**
+ * Returns whether this value matches the [type] Braze expects. `0`/`false` are valid for their respective types;
+ * a numeric written as a string (e.g. `"29.99"`) does not match a numeric type.
+ */
+private fun JsonElement.matchesType(type: BrazeFieldType): Boolean = when (type) {
+    BrazeFieldType.STRING -> this is JsonPrimitive && isString
+    BrazeFieldType.INTEGER -> this is JsonPrimitive && !isString && longOrNull != null
+    BrazeFieldType.FLOAT -> this is JsonPrimitive && !isString && doubleOrNull != null
+    BrazeFieldType.STRING_ARRAY -> this is JsonArray && all { it is JsonPrimitive && it.isString }
+    BrazeFieldType.ARRAY -> this is JsonArray
 }
 
 /**

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
@@ -1,0 +1,345 @@
+package com.rudderstack.integration.kotlin.braze
+
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Braze recommended ecommerce event names.
+ * See https://www.braze.com/docs/user_guide/data/activation/events/recommended_events
+ */
+internal object BrazeEcommerceEvents {
+
+    const val PRODUCT_VIEWED = "ecommerce.product_viewed"
+    const val CART_UPDATED = "ecommerce.cart_updated"
+    const val CHECKOUT_STARTED = "ecommerce.checkout_started"
+    const val ORDER_PLACED = "ecommerce.order_placed"
+    const val ORDER_REFUNDED = "ecommerce.order_refunded"
+    const val ORDER_CANCELLED = "ecommerce.order_cancelled"
+}
+
+/** Action carried by `ecommerce.cart_updated` events. */
+internal object CartUpdatedAction {
+
+    const val ADD = "add"
+    const val REMOVE = "remove"
+}
+
+private const val SOURCE_KEY = "source"
+private const val PRODUCTS_KEY = "products"
+private const val METADATA_KEY = "metadata"
+private const val ACTION_KEY = "action"
+
+/** On Android the Braze `source` field is always `android` (envelope derivation is skipped). */
+private const val ANDROID_SOURCE = "android"
+
+/**
+ * A single field mapping entry, mirroring the cloud `Braze<Event>Config.json` shape.
+ *
+ * @property destKey The Braze field name to write.
+ * @property sourceKeys Ordered fallback chain of RudderStack property names; the first resolved value wins.
+ * @property brazeRequired When true, a missing value contributes to the validation warning.
+ */
+internal data class FieldMapping(
+    val destKey: String,
+    val sourceKeys: List<String>,
+    val brazeRequired: Boolean,
+)
+
+/** Result of resolving an RS event name to a Braze recommended event. */
+internal data class EcommerceMapping(
+    val brazeEvent: String,
+    val action: String? = null,
+)
+
+private fun mapping(destKey: String, vararg sourceKeys: String, brazeRequired: Boolean) =
+    FieldMapping(destKey, sourceKeys.toList(), brazeRequired)
+
+private val PRODUCT_VIEWED_MAPPING = listOf(
+    mapping("product_id", "product_id", "sku", brazeRequired = true),
+    mapping("product_name", "name", brazeRequired = true),
+    mapping("variant_id", "variant", "sku", "product_id", brazeRequired = true),
+    mapping("price", "price", brazeRequired = true),
+    mapping("currency", "currency", brazeRequired = true),
+    mapping("image_url", "image_url", brazeRequired = false),
+    mapping("product_url", "url", brazeRequired = false),
+    mapping("type", "type", brazeRequired = false),
+)
+
+private val CART_UPDATED_MAPPING = listOf(
+    mapping("cart_id", "cart_id", brazeRequired = true),
+    mapping("total_value", "total", "value", brazeRequired = false),
+    mapping("subtotal_value", "subtotal_value", brazeRequired = false),
+    mapping("tax", "tax", brazeRequired = false),
+    mapping("shipping", "shipping", brazeRequired = false),
+    mapping("currency", "currency", brazeRequired = true),
+)
+
+private val CHECKOUT_STARTED_MAPPING = listOf(
+    mapping("checkout_id", "checkout_id", "order_id", brazeRequired = true),
+    mapping("cart_id", "cart_id", brazeRequired = false),
+    mapping("total_value", "total", "revenue", "value", brazeRequired = true),
+    mapping("subtotal_value", "subtotal_value", brazeRequired = false),
+    mapping("tax", "tax", brazeRequired = false),
+    mapping("shipping", "shipping", brazeRequired = false),
+    mapping("currency", "currency", brazeRequired = true),
+)
+
+private val ORDER_PLACED_MAPPING = listOf(
+    mapping("order_id", "order_id", brazeRequired = true),
+    mapping("total_value", "total", "revenue", "value", brazeRequired = true),
+    mapping("currency", "currency", brazeRequired = true),
+    mapping("cart_id", "cart_id", brazeRequired = false),
+    mapping("tax", "tax", brazeRequired = false),
+    mapping("shipping", "shipping", brazeRequired = false),
+    mapping("total_discounts", "discount", "total_discounts", brazeRequired = false),
+    mapping("subtotal_value", "subtotal_value", brazeRequired = false),
+    mapping("discounts", "discounts", brazeRequired = false),
+)
+
+private val ORDER_REFUNDED_MAPPING = listOf(
+    mapping("order_id", "order_id", brazeRequired = true),
+    mapping("total_value", "total", "revenue", "value", brazeRequired = true),
+    mapping("currency", "currency", brazeRequired = true),
+    mapping("total_discounts", "discount", "total_discounts", brazeRequired = false),
+    mapping("discounts", "discounts", brazeRequired = false),
+)
+
+private val ORDER_CANCELLED_MAPPING = listOf(
+    mapping("order_id", "order_id", brazeRequired = true),
+    mapping("total_value", "total", "revenue", "value", brazeRequired = true),
+    mapping("currency", "currency", brazeRequired = true),
+    mapping("cancel_reason", "cancel_reason", "reason", brazeRequired = true),
+    mapping("tax", "tax", brazeRequired = false),
+    mapping("shipping", "shipping", brazeRequired = false),
+    mapping("total_discounts", "discount", "total_discounts", brazeRequired = false),
+    mapping("subtotal_value", "subtotal_value", brazeRequired = false),
+    mapping("discounts", "discounts", brazeRequired = false),
+)
+
+private val ECOMMERCE_PRODUCT_MAPPING = listOf(
+    mapping("product_id", "product_id", "sku", brazeRequired = true),
+    mapping("product_name", "name", brazeRequired = true),
+    mapping("variant_id", "variant", "sku", "product_id", brazeRequired = true),
+    mapping("quantity", "quantity", brazeRequired = true),
+    mapping("price", "price", brazeRequired = true),
+    mapping("image_url", "image_url", brazeRequired = false),
+    mapping("product_url", "url", brazeRequired = false),
+)
+
+private val EVENT_MAPPING_BY_BRAZE_EVENT: Map<String, List<FieldMapping>> = mapOf(
+    BrazeEcommerceEvents.PRODUCT_VIEWED to PRODUCT_VIEWED_MAPPING,
+    BrazeEcommerceEvents.CART_UPDATED to CART_UPDATED_MAPPING,
+    BrazeEcommerceEvents.CHECKOUT_STARTED to CHECKOUT_STARTED_MAPPING,
+    BrazeEcommerceEvents.ORDER_PLACED to ORDER_PLACED_MAPPING,
+    BrazeEcommerceEvents.ORDER_REFUNDED to ORDER_REFUNDED_MAPPING,
+    BrazeEcommerceEvents.ORDER_CANCELLED to ORDER_CANCELLED_MAPPING,
+)
+
+// Case-insensitive RS event name (trimmed, lowercased) → Braze recommended event.
+// `Cart Viewed` and `Cart Updated` are intentionally absent — they fall through to the
+// legacy custom-event path.
+private val EVENT_NAME_TO_BRAZE: Map<String, EcommerceMapping> = mapOf(
+    "product viewed" to EcommerceMapping(BrazeEcommerceEvents.PRODUCT_VIEWED),
+    "product added" to EcommerceMapping(BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.ADD),
+    "product removed" to EcommerceMapping(BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.REMOVE),
+    "checkout started" to EcommerceMapping(BrazeEcommerceEvents.CHECKOUT_STARTED),
+    "order completed" to EcommerceMapping(BrazeEcommerceEvents.ORDER_PLACED),
+    "order refunded" to EcommerceMapping(BrazeEcommerceEvents.ORDER_REFUNDED),
+    "order cancelled" to EcommerceMapping(BrazeEcommerceEvents.ORDER_CANCELLED),
+)
+
+/**
+ * Resolves the Braze recommended event for a given RudderStack event name.
+ * Matching is case-insensitive on the trimmed event name.
+ *
+ * @return The [EcommerceMapping] or `null` when the event is not mapped (caller falls back to the legacy path).
+ */
+internal fun getEcommerceMapping(eventName: String?): EcommerceMapping? =
+    eventName?.trim()?.lowercase()?.let { EVENT_NAME_TO_BRAZE[it] }
+
+/**
+ * Builds the `properties` object for a Braze recommended ecommerce event.
+ *
+ * Never throws on data shape: `0`/`false` are valid values; only `null`/empty-string/empty-array/empty-object
+ * count as missing. A single warning is logged when any Braze-required field is unresolved.
+ *
+ * @param properties The track event properties.
+ * @param brazeEvent The resolved Braze recommended event name.
+ * @param action The `cart_updated` action, or `null` for other events.
+ * @param logger Used to surface the validation warning.
+ * @return The fully assembled Braze event properties.
+ */
+internal fun buildEcommerceEventProperties(
+    properties: JsonObject,
+    brazeEvent: String,
+    action: String?,
+    logger: Logger,
+): JsonObject {
+    val eventMapping = EVENT_MAPPING_BY_BRAZE_EVENT[brazeEvent].orEmpty()
+    val productMapping = if (brazeEvent == BrazeEcommerceEvents.PRODUCT_VIEWED) null else ECOMMERCE_PRODUCT_MAPPING
+    val hasExplicitProductsArray = properties[PRODUCTS_KEY] is JsonArray
+
+    // Step 1+2: event-level field mapping.
+    val payload: MutableMap<String, JsonElement> = properties.resolveMapping(eventMapping).toMutableMap()
+
+    // Step 3: products[] (skipped for product_viewed — flat, single-product event).
+    val products: List<JsonObject>? = productMapping?.let { buildProductsArray(properties, brazeEvent, it) }
+    if (products != null && products.isNotEmpty()) {
+        payload[PRODUCTS_KEY] = JsonArray(products)
+    }
+
+    // Step 4+5: source + action.
+    payload[SOURCE_KEY] = JsonPrimitive(ANDROID_SOURCE)
+    action?.let { payload[ACTION_KEY] = JsonPrimitive(it) }
+
+    // Step 6: route unmapped event-level keys to metadata.
+    val consumedEventKeys = consumedTopLevelKeysForEvent(
+        brazeEvent = brazeEvent,
+        eventMapping = eventMapping,
+        productMapping = productMapping,
+        hasExplicitProductsArray = hasExplicitProductsArray,
+    ).toMutableSet()
+    action?.let { consumedEventKeys.add(ACTION_KEY) }
+    val metadata = properties.pickUnmappedKeys(consumedEventKeys)
+    if (metadata.isNotEmpty()) {
+        payload[METADATA_KEY] = JsonObject(metadata)
+    }
+
+    // Step 7: single validation warning for any missing Braze-required field.
+    logMissingRequiredFields(brazeEvent, eventMapping, productMapping, payload, products, logger)
+
+    return JsonObject(payload)
+}
+
+/**
+ * Builds the `products[]` array.
+ * - `cart_updated` WITHOUT an explicit `products[]`: read top-level product fields directly from [properties]
+ *   into a single-element list (no per-product metadata — unmapped keys flow through event-level metadata).
+ * - all other cases: map each item in `properties.products` and route unmapped per-product keys to `metadata`.
+ */
+private fun buildProductsArray(
+    properties: JsonObject,
+    brazeEvent: String,
+    productMapping: List<FieldMapping>,
+): List<JsonObject> {
+    val rawProducts = properties[PRODUCTS_KEY] as? JsonArray
+
+    if (brazeEvent == BrazeEcommerceEvents.CART_UPDATED && rawProducts == null) {
+        val product = properties.resolveMapping(productMapping)
+        return if (product.isNotEmpty()) listOf(JsonObject(product)) else emptyList()
+    }
+
+    val consumedKeys = productMapping.consumedSourceKeys()
+    return rawProducts.orEmpty()
+        .mapNotNull { it as? JsonObject }
+        .map { item ->
+            val product = item.resolveMapping(productMapping).toMutableMap()
+            val productMetadata = item.pickUnmappedKeys(consumedKeys)
+            if (productMetadata.isNotEmpty()) {
+                product[METADATA_KEY] = JsonObject(productMetadata)
+            }
+            JsonObject(product)
+        }
+        .filter { it.isNotEmpty() }
+}
+
+/**
+ * Resolves a field mapping against this object, keeping only entries whose first non-empty source key resolves.
+ */
+private fun JsonObject.resolveMapping(mapping: List<FieldMapping>): Map<String, JsonElement> {
+    val result = LinkedHashMap<String, JsonElement>()
+    mapping.forEach { entry ->
+        entry.sourceKeys
+            .firstNotNullOfOrNull { key -> this[key]?.takeIf { it.isResolved() } }
+            ?.let { result[entry.destKey] = it }
+    }
+    return result
+}
+
+/**
+ * Returns the subset of this object's keys not present in [consumed], dropping unresolved values.
+ */
+private fun JsonObject.pickUnmappedKeys(consumed: Set<String>): Map<String, JsonElement> {
+    val result = LinkedHashMap<String, JsonElement>()
+    forEach { (key, value) ->
+        if (key !in consumed && value.isResolved()) {
+            result[key] = value
+        }
+    }
+    return result
+}
+
+/**
+ * Computes the message-property keys consumed by the event-level mapping so they don't duplicate into metadata.
+ */
+private fun consumedTopLevelKeysForEvent(
+    brazeEvent: String,
+    eventMapping: List<FieldMapping>,
+    productMapping: List<FieldMapping>?,
+    hasExplicitProductsArray: Boolean,
+): Set<String> {
+    val consumed = mutableSetOf(SOURCE_KEY)
+    consumed.addAll(eventMapping.consumedSourceKeys())
+    if (productMapping != null) {
+        consumed.add(PRODUCTS_KEY)
+    }
+    // cart_updated folds top-level product fields into products[0] only when no explicit products[] is provided.
+    if (brazeEvent == BrazeEcommerceEvents.CART_UPDATED && productMapping != null && !hasExplicitProductsArray) {
+        consumed.addAll(productMapping.consumedSourceKeys())
+    }
+    return consumed
+}
+
+/** All source keys referenced by a mapping. */
+private fun List<FieldMapping>.consumedSourceKeys(): Set<String> = flatMapTo(mutableSetOf()) { it.sourceKeys }
+
+/**
+ * Logs a single warning when the payload is missing any Braze-required field (event-level or per-product),
+ * including an empty `products[]` on a product-bearing event.
+ */
+private fun logMissingRequiredFields(
+    brazeEvent: String,
+    eventMapping: List<FieldMapping>,
+    productMapping: List<FieldMapping>?,
+    payload: Map<String, JsonElement>,
+    products: List<JsonObject>?,
+    logger: Logger,
+) {
+    val missing = mutableListOf<String>()
+
+    eventMapping.filter { it.brazeRequired && payload[it.destKey] == null }
+        .forEach { missing.add(it.destKey) }
+
+    if (productMapping != null) {
+        if (products.isNullOrEmpty()) {
+            missing.add(PRODUCTS_KEY)
+        } else {
+            val missingProductFields = productMapping
+                .filter { entry -> entry.brazeRequired && products.any { it[entry.destKey] == null } }
+                .map { "products[].${it.destKey}" }
+            missing.addAll(missingProductFields)
+        }
+    }
+
+    if (missing.isNotEmpty()) {
+        logger.warn(
+            "BrazeIntegration: '$brazeEvent' is missing Braze-required field(s): " +
+                "${missing.distinct()}. Sending the event anyway."
+        )
+    }
+}
+
+/**
+ * A value is "resolved" iff it is not null/empty: `null`, [JsonNull], empty string, empty array and empty object
+ * count as missing; `0`, `false`, and other primitives are valid.
+ */
+private fun JsonElement.isResolved(): Boolean = when (this) {
+    is JsonNull -> false
+    is JsonPrimitive -> if (isString) content.isNotEmpty() else true
+    is JsonArray -> isNotEmpty()
+    is JsonObject -> isNotEmpty()
+}

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
@@ -1,11 +1,14 @@
 package com.rudderstack.integration.kotlin.braze
 
+import com.rudderstack.sdk.kotlin.core.ecommerce.ECommerceEvents
+import com.rudderstack.sdk.kotlin.core.ecommerce.ECommerceParamNames
 import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import java.util.Locale
 
 /**
  * Braze recommended ecommerce event names.
@@ -29,7 +32,7 @@ internal object CartUpdatedAction {
 }
 
 private const val SOURCE_KEY = "source"
-private const val PRODUCTS_KEY = "products"
+private const val PRODUCTS_KEY = ECommerceParamNames.PRODUCTS
 private const val METADATA_KEY = "metadata"
 private const val ACTION_KEY = "action"
 
@@ -58,76 +61,92 @@ internal data class EcommerceMapping(
 private fun mapping(destKey: String, vararg sourceKeys: String, brazeRequired: Boolean) =
     FieldMapping(destKey, sourceKeys.toList(), brazeRequired)
 
+// Source keys that are not part of the RudderStack ecommerce spec (`ECommerceParamNames`) and are
+// therefore mirrored verbatim from the Braze recommended-event schema.
+private const val SKU = "sku"
+private const val NAME = "name"
+private const val VARIANT = "variant"
+private const val VALUE = "value"
+private const val IMAGE_URL = "image_url"
+private const val URL = "url"
+private const val TYPE = "type"
+private const val SUBTOTAL_VALUE = "subtotal_value"
+private const val TOTAL_DISCOUNTS = "total_discounts"
+private const val DISCOUNTS = "discounts"
+private const val CANCEL_REASON = "cancel_reason"
+private const val TAX = "tax"
+private const val SHIPPING = "shipping"
+
 private val PRODUCT_VIEWED_MAPPING = listOf(
-    mapping("product_id", "product_id", "sku", brazeRequired = true),
-    mapping("product_name", "name", brazeRequired = true),
-    mapping("variant_id", "variant", "sku", "product_id", brazeRequired = true),
-    mapping("price", "price", brazeRequired = true),
-    mapping("currency", "currency", brazeRequired = true),
-    mapping("image_url", "image_url", brazeRequired = false),
-    mapping("product_url", "url", brazeRequired = false),
-    mapping("type", "type", brazeRequired = false),
+    mapping("product_id", ECommerceParamNames.PRODUCT_ID, SKU, brazeRequired = true),
+    mapping("product_name", NAME, brazeRequired = true),
+    mapping("variant_id", VARIANT, SKU, ECommerceParamNames.PRODUCT_ID, brazeRequired = true),
+    mapping("price", ECommerceParamNames.PRICE, brazeRequired = true),
+    mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
+    mapping("image_url", IMAGE_URL, brazeRequired = false),
+    mapping("product_url", URL, brazeRequired = false),
+    mapping("type", TYPE, brazeRequired = false),
 )
 
 private val CART_UPDATED_MAPPING = listOf(
-    mapping("cart_id", "cart_id", brazeRequired = true),
-    mapping("total_value", "total", "value", brazeRequired = false),
-    mapping("subtotal_value", "subtotal_value", brazeRequired = false),
-    mapping("tax", "tax", brazeRequired = false),
-    mapping("shipping", "shipping", brazeRequired = false),
-    mapping("currency", "currency", brazeRequired = true),
+    mapping("cart_id", ECommerceParamNames.CART_ID, brazeRequired = true),
+    mapping("total_value", ECommerceParamNames.TOTAL, VALUE, brazeRequired = false),
+    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false),
+    mapping("tax", TAX, brazeRequired = false),
+    mapping("shipping", SHIPPING, brazeRequired = false),
+    mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
 )
 
 private val CHECKOUT_STARTED_MAPPING = listOf(
-    mapping("checkout_id", "checkout_id", "order_id", brazeRequired = true),
-    mapping("cart_id", "cart_id", brazeRequired = false),
-    mapping("total_value", "total", "revenue", "value", brazeRequired = true),
-    mapping("subtotal_value", "subtotal_value", brazeRequired = false),
-    mapping("tax", "tax", brazeRequired = false),
-    mapping("shipping", "shipping", brazeRequired = false),
-    mapping("currency", "currency", brazeRequired = true),
+    mapping("checkout_id", ECommerceParamNames.CHECKOUT_ID, ECommerceParamNames.ORDER_ID, brazeRequired = true),
+    mapping("cart_id", ECommerceParamNames.CART_ID, brazeRequired = false),
+    mapping("total_value", ECommerceParamNames.TOTAL, ECommerceParamNames.REVENUE, VALUE, brazeRequired = true),
+    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false),
+    mapping("tax", TAX, brazeRequired = false),
+    mapping("shipping", SHIPPING, brazeRequired = false),
+    mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
 )
 
 private val ORDER_PLACED_MAPPING = listOf(
-    mapping("order_id", "order_id", brazeRequired = true),
-    mapping("total_value", "total", "revenue", "value", brazeRequired = true),
-    mapping("currency", "currency", brazeRequired = true),
-    mapping("cart_id", "cart_id", brazeRequired = false),
-    mapping("tax", "tax", brazeRequired = false),
-    mapping("shipping", "shipping", brazeRequired = false),
-    mapping("total_discounts", "discount", "total_discounts", brazeRequired = false),
-    mapping("subtotal_value", "subtotal_value", brazeRequired = false),
-    mapping("discounts", "discounts", brazeRequired = false),
+    mapping("order_id", ECommerceParamNames.ORDER_ID, brazeRequired = true),
+    mapping("total_value", ECommerceParamNames.TOTAL, ECommerceParamNames.REVENUE, VALUE, brazeRequired = true),
+    mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
+    mapping("cart_id", ECommerceParamNames.CART_ID, brazeRequired = false),
+    mapping("tax", TAX, brazeRequired = false),
+    mapping("shipping", SHIPPING, brazeRequired = false),
+    mapping("total_discounts", ECommerceParamNames.DISCOUNT, TOTAL_DISCOUNTS, brazeRequired = false),
+    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false),
+    mapping("discounts", DISCOUNTS, brazeRequired = false),
 )
 
 private val ORDER_REFUNDED_MAPPING = listOf(
-    mapping("order_id", "order_id", brazeRequired = true),
-    mapping("total_value", "total", "revenue", "value", brazeRequired = true),
-    mapping("currency", "currency", brazeRequired = true),
-    mapping("total_discounts", "discount", "total_discounts", brazeRequired = false),
-    mapping("discounts", "discounts", brazeRequired = false),
+    mapping("order_id", ECommerceParamNames.ORDER_ID, brazeRequired = true),
+    mapping("total_value", ECommerceParamNames.TOTAL, ECommerceParamNames.REVENUE, VALUE, brazeRequired = true),
+    mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
+    mapping("total_discounts", ECommerceParamNames.DISCOUNT, TOTAL_DISCOUNTS, brazeRequired = false),
+    mapping("discounts", DISCOUNTS, brazeRequired = false),
 )
 
 private val ORDER_CANCELLED_MAPPING = listOf(
-    mapping("order_id", "order_id", brazeRequired = true),
-    mapping("total_value", "total", "revenue", "value", brazeRequired = true),
-    mapping("currency", "currency", brazeRequired = true),
-    mapping("cancel_reason", "cancel_reason", "reason", brazeRequired = true),
-    mapping("tax", "tax", brazeRequired = false),
-    mapping("shipping", "shipping", brazeRequired = false),
-    mapping("total_discounts", "discount", "total_discounts", brazeRequired = false),
-    mapping("subtotal_value", "subtotal_value", brazeRequired = false),
-    mapping("discounts", "discounts", brazeRequired = false),
+    mapping("order_id", ECommerceParamNames.ORDER_ID, brazeRequired = true),
+    mapping("total_value", ECommerceParamNames.TOTAL, ECommerceParamNames.REVENUE, VALUE, brazeRequired = true),
+    mapping("currency", ECommerceParamNames.CURRENCY, brazeRequired = true),
+    mapping("cancel_reason", CANCEL_REASON, ECommerceParamNames.REASON, brazeRequired = true),
+    mapping("tax", TAX, brazeRequired = false),
+    mapping("shipping", SHIPPING, brazeRequired = false),
+    mapping("total_discounts", ECommerceParamNames.DISCOUNT, TOTAL_DISCOUNTS, brazeRequired = false),
+    mapping("subtotal_value", SUBTOTAL_VALUE, brazeRequired = false),
+    mapping("discounts", DISCOUNTS, brazeRequired = false),
 )
 
 private val ECOMMERCE_PRODUCT_MAPPING = listOf(
-    mapping("product_id", "product_id", "sku", brazeRequired = true),
-    mapping("product_name", "name", brazeRequired = true),
-    mapping("variant_id", "variant", "sku", "product_id", brazeRequired = true),
-    mapping("quantity", "quantity", brazeRequired = true),
-    mapping("price", "price", brazeRequired = true),
-    mapping("image_url", "image_url", brazeRequired = false),
-    mapping("product_url", "url", brazeRequired = false),
+    mapping("product_id", ECommerceParamNames.PRODUCT_ID, SKU, brazeRequired = true),
+    mapping("product_name", NAME, brazeRequired = true),
+    mapping("variant_id", VARIANT, SKU, ECommerceParamNames.PRODUCT_ID, brazeRequired = true),
+    mapping("quantity", ECommerceParamNames.QUANTITY, brazeRequired = true),
+    mapping("price", ECommerceParamNames.PRICE, brazeRequired = true),
+    mapping("image_url", IMAGE_URL, brazeRequired = false),
+    mapping("product_url", URL, brazeRequired = false),
 )
 
 private val EVENT_MAPPING_BY_BRAZE_EVENT: Map<String, List<FieldMapping>> = mapOf(
@@ -139,18 +158,20 @@ private val EVENT_MAPPING_BY_BRAZE_EVENT: Map<String, List<FieldMapping>> = mapO
     BrazeEcommerceEvents.ORDER_CANCELLED to ORDER_CANCELLED_MAPPING,
 )
 
-// Case-insensitive RS event name (trimmed, lowercased) → Braze recommended event.
-// `Cart Viewed` and `Cart Updated` are intentionally absent — they fall through to the
-// legacy custom-event path.
+// Normalized RS event name → Braze recommended event. `Cart Viewed` and `Cart Updated` are
+// intentionally absent — they fall through to the legacy custom-event path.
 private val EVENT_NAME_TO_BRAZE: Map<String, EcommerceMapping> = mapOf(
-    "product viewed" to EcommerceMapping(BrazeEcommerceEvents.PRODUCT_VIEWED),
-    "product added" to EcommerceMapping(BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.ADD),
-    "product removed" to EcommerceMapping(BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.REMOVE),
-    "checkout started" to EcommerceMapping(BrazeEcommerceEvents.CHECKOUT_STARTED),
-    "order completed" to EcommerceMapping(BrazeEcommerceEvents.ORDER_PLACED),
-    "order refunded" to EcommerceMapping(BrazeEcommerceEvents.ORDER_REFUNDED),
-    "order cancelled" to EcommerceMapping(BrazeEcommerceEvents.ORDER_CANCELLED),
-)
+    ECommerceEvents.PRODUCT_VIEWED to EcommerceMapping(BrazeEcommerceEvents.PRODUCT_VIEWED),
+    ECommerceEvents.PRODUCT_ADDED to EcommerceMapping(BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.ADD),
+    ECommerceEvents.PRODUCT_REMOVED to EcommerceMapping(BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.REMOVE),
+    ECommerceEvents.CHECKOUT_STARTED to EcommerceMapping(BrazeEcommerceEvents.CHECKOUT_STARTED),
+    ECommerceEvents.ORDER_COMPLETED to EcommerceMapping(BrazeEcommerceEvents.ORDER_PLACED),
+    ECommerceEvents.ORDER_REFUNDED to EcommerceMapping(BrazeEcommerceEvents.ORDER_REFUNDED),
+    ECommerceEvents.ORDER_CANCELLED to EcommerceMapping(BrazeEcommerceEvents.ORDER_CANCELLED),
+).mapKeys { normalizeEventName(it.key) }
+
+/** Normalizes an RS event name for case-insensitive lookup using a locale-independent transform. */
+private fun normalizeEventName(eventName: String): String = eventName.trim().lowercase(Locale.ROOT)
 
 /**
  * Resolves the Braze recommended event for a given RudderStack event name.
@@ -159,7 +180,7 @@ private val EVENT_NAME_TO_BRAZE: Map<String, EcommerceMapping> = mapOf(
  * @return The [EcommerceMapping] or `null` when the event is not mapped (caller falls back to the legacy path).
  */
 internal fun getEcommerceMapping(eventName: String?): EcommerceMapping? =
-    eventName?.trim()?.lowercase()?.let { EVENT_NAME_TO_BRAZE[it] }
+    eventName?.let { EVENT_NAME_TO_BRAZE[normalizeEventName(it)] }
 
 /**
  * Builds the `properties` object for a Braze recommended ecommerce event.
@@ -181,13 +202,18 @@ internal fun buildEcommerceEventProperties(
 ): JsonObject {
     val eventMapping = EVENT_MAPPING_BY_BRAZE_EVENT[brazeEvent].orEmpty()
     val productMapping = if (brazeEvent == BrazeEcommerceEvents.PRODUCT_VIEWED) null else ECOMMERCE_PRODUCT_MAPPING
-    val hasExplicitProductsArray = properties[PRODUCTS_KEY] is JsonArray
+    // Only an array whose elements are all objects is treated as an explicit products[]. A malformed
+    // array (containing non-object elements) is left unconsumed so it flows through to metadata.
+    val explicitProducts = properties.explicitProductsArray()
+    val hasExplicitProductsArray = explicitProducts != null
 
     // Step 1+2: event-level field mapping.
     val payload: MutableMap<String, JsonElement> = properties.resolveMapping(eventMapping).toMutableMap()
 
     // Step 3: products[] (skipped for product_viewed — flat, single-product event).
-    val products: List<JsonObject>? = productMapping?.let { buildProductsArray(properties, brazeEvent, it) }
+    val products: List<JsonObject>? = productMapping?.let {
+        buildProductsArray(properties, brazeEvent, it, explicitProducts)
+    }
     if (products != null && products.isNotEmpty()) {
         payload[PRODUCTS_KEY] = JsonArray(products)
     }
@@ -219,23 +245,24 @@ internal fun buildEcommerceEventProperties(
  * Builds the `products[]` array.
  * - `cart_updated` WITHOUT an explicit `products[]`: read top-level product fields directly from [properties]
  *   into a single-element list (no per-product metadata — unmapped keys flow through event-level metadata).
- * - all other cases: map each item in `properties.products` and route unmapped per-product keys to `metadata`.
+ * - all other cases: map each item in [explicitProducts] and route unmapped per-product keys to `metadata`.
+ *
+ * @param explicitProducts The validated array-of-objects `products[]`, or `null` when absent/malformed.
  */
 private fun buildProductsArray(
     properties: JsonObject,
     brazeEvent: String,
     productMapping: List<FieldMapping>,
+    explicitProducts: JsonArray?,
 ): List<JsonObject> {
-    val rawProducts = properties[PRODUCTS_KEY] as? JsonArray
-
-    if (brazeEvent == BrazeEcommerceEvents.CART_UPDATED && rawProducts == null) {
+    if (brazeEvent == BrazeEcommerceEvents.CART_UPDATED && explicitProducts == null) {
         val product = properties.resolveMapping(productMapping)
         return if (product.isNotEmpty()) listOf(JsonObject(product)) else emptyList()
     }
 
     val consumedKeys = productMapping.consumedSourceKeys()
-    return rawProducts.orEmpty()
-        .mapNotNull { it as? JsonObject }
+    return explicitProducts.orEmpty()
+        .filterIsInstance<JsonObject>()
         .map { item ->
             val product = item.resolveMapping(productMapping).toMutableMap()
             val productMetadata = item.pickUnmappedKeys(consumedKeys)
@@ -246,6 +273,13 @@ private fun buildProductsArray(
         }
         .filter { it.isNotEmpty() }
 }
+
+/**
+ * Returns the `products` value as an array only when it is present and every element is a [JsonObject].
+ * A non-array or mixed/malformed array returns `null` so the original value can flow through to metadata.
+ */
+private fun JsonObject.explicitProductsArray(): JsonArray? =
+    (this[PRODUCTS_KEY] as? JsonArray)?.takeIf { array -> array.all { it is JsonObject } }
 
 /**
  * Resolves a field mapping against this object, keeping only entries whose first non-empty source key resolves.

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
@@ -284,7 +284,9 @@ private fun consumedTopLevelKeysForEvent(
 ): Set<String> {
     val consumed = mutableSetOf(SOURCE_KEY)
     consumed.addAll(eventMapping.consumedSourceKeys())
-    if (productMapping != null) {
+    // Only consume `products` when it is an actual array we build from. A malformed (non-array) `products`
+    // value is left unconsumed so it flows through to metadata instead of being silently dropped.
+    if (productMapping != null && hasExplicitProductsArray) {
         consumed.add(PRODUCTS_KEY)
     }
     // cart_updated folds top-level product fields into products[0] only when no explicit products[] is provided.

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/EcommerceUtils.kt
@@ -365,16 +365,17 @@ private fun JsonObject.resolveMapping(mapping: List<FieldMapping>): Map<String, 
 }
 
 /**
- * Coerces a primitive value to the [type] Braze expects, where possible (e.g. numeric string → number,
- * integer → float, number/boolean → string). Returns the value unchanged when it cannot be coerced
- * (the residual mismatch is then surfaced by [logTypeMismatchedFields]); arrays/objects are never coerced.
+ * Coerces a primitive value to the [type] Braze expects, where possible (numeric string → number,
+ * number/boolean → string). Numbers are left as-is for numeric fields (Braze accepts an integer where a float
+ * is expected). Returns the value unchanged when it cannot be coerced (the residual mismatch is then surfaced
+ * by [logTypeMismatchedFields]); arrays/objects are never coerced.
  */
 private fun JsonElement.coerceToType(type: BrazeFieldType): JsonElement {
     if (this !is JsonPrimitive) return this
     return when (type) {
         BrazeFieldType.STRING -> if (isString) this else JsonPrimitive(content)
-        BrazeFieldType.FLOAT -> doubleOrNull?.let { JsonPrimitive(it) } ?: this
-        BrazeFieldType.INTEGER -> longOrNull?.let { JsonPrimitive(it) } ?: this
+        BrazeFieldType.FLOAT -> if (isString) doubleOrNull?.let { JsonPrimitive(it) } ?: this else this
+        BrazeFieldType.INTEGER -> if (isString) longOrNull?.let { JsonPrimitive(it) } ?: this else this
         BrazeFieldType.STRING_ARRAY, BrazeFieldType.ARRAY -> this
     }
 }

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/RudderBrazeConfig.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/RudderBrazeConfig.kt
@@ -44,7 +44,7 @@ internal sealed class AppKeyResolution {
  * @property customEndpoint The custom endpoint for the data center. Must not be empty or blank.
  * @property supportDedup Flag indicating whether deduplication is supported.
  * @property connectionMode The mode of connection, either HYBRID or DEVICE.
- * @property useRecommendedEcommerceEvents When enabled, maps supported RudderStack ecommerce track events to Braze recommended events. Defaults to false.
+ * @property useEcommerceRecommendedEvents When enabled, maps supported RudderStack ecommerce track events to Braze recommended events. Defaults to false.
  *
  * @throws IllegalArgumentException if resolved appIdentifierKey or customEndpoint is empty or blank.
  */
@@ -61,7 +61,7 @@ internal data class RudderBrazeConfig(
     val customEndpoint: String,
     val supportDedup: Boolean,
     val connectionMode: ConnectionMode,
-    val useRecommendedEcommerceEvents: Boolean = false,
+    val useEcommerceRecommendedEvents: Boolean = false,
 ) {
 
     /**

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/RudderBrazeConfig.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/RudderBrazeConfig.kt
@@ -61,7 +61,6 @@ internal data class RudderBrazeConfig(
     val customEndpoint: String,
     val supportDedup: Boolean,
     val connectionMode: ConnectionMode,
-    @SerialName("useRecommendedEcommerceEvents")
     val useRecommendedEcommerceEvents: Boolean = false,
 ) {
 

--- a/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/RudderBrazeConfig.kt
+++ b/integrations/braze/src/main/java/com/rudderstack/integration/kotlin/braze/RudderBrazeConfig.kt
@@ -44,6 +44,7 @@ internal sealed class AppKeyResolution {
  * @property customEndpoint The custom endpoint for the data center. Must not be empty or blank.
  * @property supportDedup Flag indicating whether deduplication is supported.
  * @property connectionMode The mode of connection, either HYBRID or DEVICE.
+ * @property useRecommendedEcommerceEvents When enabled, maps supported RudderStack ecommerce track events to Braze recommended events. Defaults to false.
  *
  * @throws IllegalArgumentException if resolved appIdentifierKey or customEndpoint is empty or blank.
  */
@@ -60,6 +61,8 @@ internal data class RudderBrazeConfig(
     val customEndpoint: String,
     val supportDedup: Boolean,
     val connectionMode: ConnectionMode,
+    @SerialName("useRecommendedEcommerceEvents")
+    val useRecommendedEcommerceEvents: Boolean = false,
 ) {
 
     /**

--- a/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/BrazeIntegrationTest.kt
+++ b/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/BrazeIntegrationTest.kt
@@ -31,7 +31,6 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray

--- a/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/BrazeIntegrationTest.kt
+++ b/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/BrazeIntegrationTest.kt
@@ -31,6 +31,10 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
@@ -43,6 +47,9 @@ private const val pathToNewBrazeConfig = "config/new_braze_config.json"
 private const val pathToBrazeConfigWithAndroidAppIdentifierKey = "config/braze_config_with_android_app_identifier_key.json"
 private const val pathToBrazeConfigWithFlagDisabled = "config/braze_config_with_flag_disabled.json"
 private const val pathToBrazeConfigWithBlankAndroidAppIdentifierKey = "config/braze_config_with_blank_android_app_identifier_key.json"
+private const val pathToBrazeConfigWithRecommendedEcommerce = "config/braze_config_with_recommended_ecommerce.json"
+private const val pathToBrazeConfigHybridWithRecommendedEcommerce =
+    "config/braze_config_hybrid_with_recommended_ecommerce.json"
 
 private const val INSTALL_ATTRIBUTED = "Install Attributed"
 
@@ -56,6 +63,10 @@ class BrazeIntegrationTest {
     private val mockBrazeIntegrationConfigWithDeDupeDisabled: JsonObject =
         readFileAsJsonObject(pathToBrazeConfigWithDeDupeDisabled)
     private val mockNewBrazeIntegrationConfig: JsonObject = readFileAsJsonObject(pathToNewBrazeConfig)
+    private val mockBrazeIntegrationConfigWithRecommendedEcommerce: JsonObject =
+        readFileAsJsonObject(pathToBrazeConfigWithRecommendedEcommerce)
+    private val mockBrazeIntegrationConfigHybridWithRecommendedEcommerce: JsonObject =
+        readFileAsJsonObject(pathToBrazeConfigHybridWithRecommendedEcommerce)
 
     @MockK
     private lateinit var mockAnalytics: Analytics
@@ -260,6 +271,245 @@ class BrazeIntegrationTest {
                 productId = any(),
                 currencyCode = any(),
                 price = any(),
+                quantity = any(),
+                properties = any<BrazeProperties>()
+            )
+        }
+    }
+
+    @Test
+    fun `given recommended ecommerce flag is on and event is Order Completed, when it is made, then it is logged as ecommerce_order_placed and not as a purchase`() {
+        brazeIntegration.create(mockBrazeIntegrationConfigWithRecommendedEcommerce)
+        val trackEvent = provideTrackEvent(
+            eventName = ORDER_COMPLETED,
+            properties = getOrderCompletedProperties(),
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 1) {
+            mockBrazeInstance.logCustomEvent(eq(BrazeEcommerceEvents.ORDER_PLACED), any<BrazeProperties>())
+        }
+        verify(exactly = 0) {
+            mockBrazeInstance.logPurchase(
+                productId = any(),
+                currencyCode = any(),
+                price = any(),
+                quantity = any(),
+                properties = any<BrazeProperties>()
+            )
+        }
+    }
+
+    @Test
+    fun `given recommended ecommerce flag is on and event is unmapped, when it is made, then it falls through to a custom event`() {
+        brazeIntegration.create(mockBrazeIntegrationConfigWithRecommendedEcommerce)
+        val trackEvent = provideTrackEvent(
+            eventName = "Cart Viewed",
+            properties = getCustomProperties(),
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 1) {
+            mockBrazeInstance.logCustomEvent(eq("Cart Viewed"), any<BrazeProperties>())
+        }
+    }
+
+    @Test
+    fun `given recommended ecommerce flag is off and event is Order Completed, when it is made, then legacy purchase logging is used`() {
+        brazeIntegration.create(mockBrazeIntegrationConfig)
+        val trackEvent = provideTrackEvent(
+            eventName = ORDER_COMPLETED,
+            properties = getOrderCompletedProperties(),
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 0) {
+            mockBrazeInstance.logCustomEvent(eq(BrazeEcommerceEvents.ORDER_PLACED), any<BrazeProperties>())
+        }
+        verify(atLeast = 1) {
+            mockBrazeInstance.logPurchase(
+                productId = any(),
+                currencyCode = any(),
+                price = any(),
+                quantity = any(),
+                properties = any<BrazeProperties>()
+            )
+        }
+    }
+
+    @Test
+    fun `given recommended ecommerce flag is on and event is Product Viewed, when it is made, then it is logged as ecommerce_product_viewed`() {
+        brazeIntegration.create(mockBrazeIntegrationConfigWithRecommendedEcommerce)
+        val trackEvent = provideTrackEvent(
+            eventName = "Product Viewed",
+            properties = buildJsonObject {
+                put("product_id", "P1")
+                put("name", "Shoe")
+                put("variant", "red")
+                put("price", 49.99)
+                put("currency", "USD")
+            },
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 1) {
+            mockBrazeInstance.logCustomEvent(eq(BrazeEcommerceEvents.PRODUCT_VIEWED), any<BrazeProperties>())
+        }
+    }
+
+    @Test
+    fun `given recommended ecommerce flag is on and event is Product Added, when it is made, then it is logged as ecommerce_cart_updated`() {
+        brazeIntegration.create(mockBrazeIntegrationConfigWithRecommendedEcommerce)
+        val trackEvent = provideTrackEvent(
+            eventName = "Product Added",
+            properties = buildJsonObject {
+                put("cart_id", "C1")
+                put("currency", "USD")
+                put("product_id", "P1")
+                put("name", "Shoe")
+                put("variant", "red")
+                put("quantity", 1)
+                put("price", 49.99)
+            },
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 1) {
+            mockBrazeInstance.logCustomEvent(eq(BrazeEcommerceEvents.CART_UPDATED), any<BrazeProperties>())
+        }
+    }
+
+    @Test
+    fun `given recommended ecommerce flag is on and event is Checkout Started, when it is made, then it is logged as ecommerce_checkout_started`() {
+        brazeIntegration.create(mockBrazeIntegrationConfigWithRecommendedEcommerce)
+        val trackEvent = provideTrackEvent(
+            eventName = "Checkout Started",
+            properties = buildJsonObject {
+                put("checkout_id", "CH1")
+                put("total", 99.0)
+                put("currency", "USD")
+                putJsonArray("products") {
+                    add(
+                        buildJsonObject {
+                            put("product_id", "P1")
+                            put("name", "Shoe")
+                            put("variant", "red")
+                            put("quantity", 1)
+                            put("price", 99.0)
+                        }
+                    )
+                }
+            },
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 1) {
+            mockBrazeInstance.logCustomEvent(eq(BrazeEcommerceEvents.CHECKOUT_STARTED), any<BrazeProperties>())
+        }
+    }
+
+    @Test
+    fun `given recommended ecommerce flag is on and event is Order Refunded, when it is made, then it is logged as ecommerce_order_refunded`() {
+        brazeIntegration.create(mockBrazeIntegrationConfigWithRecommendedEcommerce)
+        val trackEvent = provideTrackEvent(
+            eventName = "Order Refunded",
+            properties = buildJsonObject {
+                put("order_id", "O1")
+                put("total", 50.0)
+                put("currency", "USD")
+                putJsonArray("products") {
+                    add(
+                        buildJsonObject {
+                            put("product_id", "P1")
+                            put("name", "Shoe")
+                            put("variant", "red")
+                            put("quantity", 1)
+                            put("price", 50.0)
+                        }
+                    )
+                }
+            },
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 1) {
+            mockBrazeInstance.logCustomEvent(eq(BrazeEcommerceEvents.ORDER_REFUNDED), any<BrazeProperties>())
+        }
+    }
+
+    @Test
+    fun `given recommended ecommerce flag is on and event is Order Cancelled, when it is made, then it is logged as ecommerce_order_cancelled`() {
+        brazeIntegration.create(mockBrazeIntegrationConfigWithRecommendedEcommerce)
+        val trackEvent = provideTrackEvent(
+            eventName = "Order Cancelled",
+            properties = buildJsonObject {
+                put("order_id", "O1")
+                put("total", 50.0)
+                put("currency", "USD")
+                put("cancel_reason", "out of stock")
+                putJsonArray("products") {
+                    add(
+                        buildJsonObject {
+                            put("product_id", "P1")
+                            put("name", "Shoe")
+                            put("variant", "red")
+                            put("quantity", 1)
+                            put("price", 50.0)
+                        }
+                    )
+                }
+            },
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 1) {
+            mockBrazeInstance.logCustomEvent(eq(BrazeEcommerceEvents.ORDER_CANCELLED), any<BrazeProperties>())
+        }
+    }
+
+    @Test
+    fun `given recommended ecommerce flag is on but braze is not initialised, when an ecommerce event is made, then it is dropped without crashing`() {
+        // update() sets the config without initialising the Braze instance, leaving braze == null.
+        brazeIntegration.update(mockBrazeIntegrationConfigWithRecommendedEcommerce)
+        val trackEvent = provideTrackEvent(
+            eventName = ORDER_COMPLETED,
+            properties = getOrderCompletedProperties(),
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 0) {
+            mockBrazeInstance.logCustomEvent(any())
+            mockBrazeInstance.logCustomEvent(any(), any())
+        }
+    }
+
+    @Test
+    fun `given hybrid mode is enabled and recommended ecommerce flag is on, when an ecommerce event is made, then no event is logged`() {
+        brazeIntegration.create(mockBrazeIntegrationConfigHybridWithRecommendedEcommerce)
+        val trackEvent = provideTrackEvent(
+            eventName = ORDER_COMPLETED,
+            properties = getOrderCompletedProperties(),
+        )
+
+        brazeIntegration.track(trackEvent)
+
+        verify(exactly = 0) {
+            mockBrazeInstance.logCustomEvent(any())
+            mockBrazeInstance.logCustomEvent(any(), any())
+            mockBrazeInstance.logPurchase(
+                productId = any(),
+                currencyCode = any(),
+                price = any(),
+                quantity = any(),
                 properties = any<BrazeProperties>()
             )
         }
@@ -415,6 +665,7 @@ class BrazeIntegrationTest {
                 productId = any(),
                 currencyCode = any(),
                 price = any(),
+                quantity = any(),
                 properties = any<BrazeProperties>()
             )
         }

--- a/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
+++ b/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
@@ -260,6 +260,21 @@ class EcommerceUtilsTest {
     }
 
     @Test
+    fun `given a malformed non-array products value, when built, then it flows to metadata instead of being dropped`() {
+        val properties = buildJsonObject {
+            put("order_id", "O1")
+            put("total", 50.0)
+            put("currency", "USD")
+            put("products", "not-an-array") // malformed shape
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.ORDER_REFUNDED)
+
+        assertFalse(result.containsKey("products"))
+        assertEquals(JsonPrimitive("not-an-array"), result.metadata()["products"])
+    }
+
+    @Test
     fun `given checkout started with checkout_id absent, when built, then order_id is used as fallback`() {
         val properties = buildJsonObject {
             put("order_id", "O1")

--- a/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
+++ b/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
@@ -272,6 +273,33 @@ class EcommerceUtilsTest {
 
         assertFalse(result.containsKey("products"))
         assertEquals(JsonPrimitive("not-an-array"), result.metadata()["products"])
+    }
+
+    @Test
+    fun `given a products array containing a non-object element, when built, then the whole array flows to metadata`() {
+        val malformedProducts = buildJsonArray {
+            add(
+                buildJsonObject {
+                    put("product_id", "P1")
+                    put("name", "Shoe")
+                    put("variant", "red")
+                    put("quantity", 1)
+                    put("price", 10)
+                }
+            )
+            add(JsonPrimitive("not-a-product"))
+        }
+        val properties = buildJsonObject {
+            put("order_id", "O1")
+            put("total", 50.0)
+            put("currency", "USD")
+            put("products", malformedProducts)
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.ORDER_REFUNDED)
+
+        assertFalse(result.containsKey("products"))
+        assertEquals(malformedProducts, result.metadata()["products"])
     }
 
     @Test

--- a/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
+++ b/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
@@ -1,0 +1,337 @@
+package com.rudderstack.integration.kotlin.braze
+
+import com.rudderstack.sdk.kotlin.core.internals.logger.Logger
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class EcommerceUtilsTest {
+
+    private val logger: Logger = mockk(relaxed = true)
+
+    private fun build(properties: JsonObject, brazeEvent: String, action: String? = null): JsonObject =
+        buildEcommerceEventProperties(properties, brazeEvent, action, logger)
+
+    private fun JsonObject.products(): JsonArray =
+        this["products"] as? JsonArray ?: error("Expected a 'products' array but found ${this["products"]}")
+
+    private fun JsonObject.metadata(): JsonObject =
+        this["metadata"] as? JsonObject ?: error("Expected a 'metadata' object but found ${this["metadata"]}")
+
+    // region getEcommerceMapping
+
+    @Test
+    fun `given mapped event names with varied casing and padding, when resolving, then correct mapping is returned`() {
+        assertEquals(EcommerceMapping(BrazeEcommerceEvents.PRODUCT_VIEWED), getEcommerceMapping("Product Viewed"))
+        assertEquals(
+            EcommerceMapping(BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.ADD),
+            getEcommerceMapping("product added"),
+        )
+        assertEquals(
+            EcommerceMapping(BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.REMOVE),
+            getEcommerceMapping("Product Removed"),
+        )
+        assertEquals(EcommerceMapping(BrazeEcommerceEvents.ORDER_PLACED), getEcommerceMapping("  Order Completed  "))
+        assertEquals(EcommerceMapping(BrazeEcommerceEvents.CHECKOUT_STARTED), getEcommerceMapping("Checkout Started"))
+        assertEquals(EcommerceMapping(BrazeEcommerceEvents.ORDER_REFUNDED), getEcommerceMapping("Order Refunded"))
+        assertEquals(EcommerceMapping(BrazeEcommerceEvents.ORDER_CANCELLED), getEcommerceMapping("Order Cancelled"))
+    }
+
+    @Test
+    fun `given unmapped or null event names, when resolving, then null is returned`() {
+        assertNull(getEcommerceMapping("Cart Viewed"))
+        assertNull(getEcommerceMapping("Cart Updated"))
+        assertNull(getEcommerceMapping("Some Random Event"))
+        assertNull(getEcommerceMapping(null))
+    }
+
+    // endregion
+
+    // region product_viewed
+
+    @Test
+    fun `given a product viewed event, when built, then fields are mapped, source is android and extras go to metadata`() {
+        val properties = buildJsonObject {
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", 49.99)
+            put("currency", "USD")
+            put("image_url", "http://img")
+            put("url", "http://prod")
+            put("type", "footwear")
+            put("custom_extra", "extra")
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        assertEquals(JsonPrimitive("P1"), result["product_id"])
+        assertEquals(JsonPrimitive("Shoe"), result["product_name"])
+        assertEquals(JsonPrimitive("red"), result["variant_id"])
+        assertEquals(JsonPrimitive(49.99), result["price"])
+        assertEquals(JsonPrimitive("USD"), result["currency"])
+        assertEquals(JsonPrimitive("http://prod"), result["product_url"])
+        assertEquals(JsonPrimitive("footwear"), result["type"])
+        assertEquals(JsonPrimitive("android"), result["source"])
+        assertFalse(result.containsKey("products"))
+        assertEquals(JsonPrimitive("extra"), result.metadata()["custom_extra"])
+    }
+
+    @Test
+    fun `given product viewed without product_id, when built, then sku is used as fallback for product_id and variant_id`() {
+        val properties = buildJsonObject {
+            put("sku", "SKU1")
+            put("name", "Shoe")
+            put("price", 10)
+            put("currency", "USD")
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        assertEquals(JsonPrimitive("SKU1"), result["product_id"])
+        assertEquals(JsonPrimitive("SKU1"), result["variant_id"])
+    }
+
+    // endregion
+
+    // region cart_updated (single-product wrap)
+
+    @Test
+    fun `given product added without products array, when built, then top-level product is wrapped and action is add`() {
+        val properties = buildJsonObject {
+            put("cart_id", "C1")
+            put("currency", "USD")
+            put("total", 99.0)
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("quantity", 2)
+            put("price", 49.5)
+            put("loyalty_points", 10)
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.ADD)
+
+        assertEquals(JsonPrimitive("C1"), result["cart_id"])
+        assertEquals(JsonPrimitive(99.0), result["total_value"])
+        assertEquals(JsonPrimitive("add"), result["action"])
+        assertEquals(JsonPrimitive("android"), result["source"])
+
+        val product = result.products()[0].jsonObject
+        assertEquals(JsonPrimitive("P1"), product["product_id"])
+        assertEquals(JsonPrimitive("Shoe"), product["product_name"])
+        assertEquals(JsonPrimitive("red"), product["variant_id"])
+        assertEquals(JsonPrimitive(2), product["quantity"])
+        assertEquals(JsonPrimitive(49.5), product["price"])
+        // No per-product metadata in the wrap case.
+        assertFalse(product.containsKey("metadata"))
+
+        // Unmapped event-level key goes to metadata; consumed product keys do NOT leak there.
+        assertEquals(JsonPrimitive(10), result.metadata()["loyalty_points"])
+        assertFalse(result.metadata().containsKey("product_id"))
+        assertFalse(result.metadata().containsKey("name"))
+    }
+
+    @Test
+    fun `given product added with explicit products array, when built, then array items are mapped and top-level fields flow to metadata`() {
+        val properties = buildJsonObject {
+            put("cart_id", "C1")
+            put("currency", "USD")
+            put("product_id", "TOP")
+            putJsonArray("products") {
+                add(
+                    buildJsonObject {
+                        put("product_id", "P1")
+                        put("name", "Shoe")
+                        put("variant", "red")
+                        put("quantity", 1)
+                        put("price", 10)
+                        put("color", "blue")
+                    }
+                )
+            }
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.ADD)
+
+        val product = result.products()[0].jsonObject
+        assertEquals(JsonPrimitive("P1"), product["product_id"])
+        assertEquals(JsonPrimitive("blue"), product.metadata()["color"])
+        // With explicit products[], top-level product_id is unmapped → flows to event metadata.
+        assertEquals(JsonPrimitive("TOP"), result.metadata()["product_id"])
+    }
+
+    @Test
+    fun `given product added missing required currency, when built, then a warning is logged`() {
+        val properties = buildJsonObject {
+            put("cart_id", "C1")
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", 10)
+        }
+
+        build(properties, BrazeEcommerceEvents.CART_UPDATED, CartUpdatedAction.ADD)
+
+        verify { logger.warn(match { it.contains("currency") }) }
+    }
+
+    // endregion
+
+    // region order events (iterate products)
+
+    @Test
+    fun `given order completed, when built, then total_value falls back to revenue and products are iterated`() {
+        val properties = buildJsonObject {
+            put("order_id", "O1")
+            put("revenue", 199.0)
+            put("currency", "USD")
+            put("discounts", 5)
+            putJsonArray("products") {
+                add(
+                    buildJsonObject {
+                        put("product_id", "P1")
+                        put("name", "Shoe")
+                        put("variant", "red")
+                        put("quantity", 1)
+                        put("price", 199.0)
+                        put("category", "apparel")
+                    }
+                )
+            }
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.ORDER_PLACED)
+
+        assertEquals(JsonPrimitive("O1"), result["order_id"])
+        assertEquals(JsonPrimitive(199.0), result["total_value"])
+        assertEquals(JsonPrimitive(5), result["discounts"])
+        val product = result.products()[0].jsonObject
+        assertEquals(JsonPrimitive("P1"), product["product_id"])
+        assertEquals(JsonPrimitive("apparel"), product.metadata()["category"])
+    }
+
+    @Test
+    fun `given order refunded with no products, when built, then a warning about products is logged`() {
+        val properties = buildJsonObject {
+            put("order_id", "O1")
+            put("total", 50.0)
+            put("currency", "USD")
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.ORDER_REFUNDED)
+
+        assertFalse(result.containsKey("products"))
+        verify { logger.warn(match { it.contains("products") }) }
+    }
+
+    @Test
+    fun `given order cancelled without cancel_reason, when built, then a warning about cancel_reason is logged`() {
+        val properties = buildJsonObject {
+            put("order_id", "O1")
+            put("total", 50.0)
+            put("currency", "USD")
+            putJsonArray("products") {
+                add(
+                    buildJsonObject {
+                        put("product_id", "P1")
+                        put("name", "Shoe")
+                        put("variant", "red")
+                        put("quantity", 1)
+                        put("price", 50.0)
+                    }
+                )
+            }
+        }
+
+        build(properties, BrazeEcommerceEvents.ORDER_CANCELLED)
+
+        verify { logger.warn(match { it.contains("cancel_reason") }) }
+    }
+
+    @Test
+    fun `given checkout started with checkout_id absent, when built, then order_id is used as fallback`() {
+        val properties = buildJsonObject {
+            put("order_id", "O1")
+            put("total", 75.0)
+            put("currency", "USD")
+            putJsonArray("products") {
+                add(
+                    buildJsonObject {
+                        put("product_id", "P1")
+                        put("name", "Shoe")
+                        put("variant", "red")
+                        put("quantity", 1)
+                        put("price", 75.0)
+                    }
+                )
+            }
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.CHECKOUT_STARTED)
+
+        assertEquals(JsonPrimitive("O1"), result["checkout_id"])
+    }
+
+    // endregion
+
+    // region send-anyway value semantics
+
+    @Test
+    fun `given a numeric zero value, when built, then it is treated as resolved`() {
+        val properties = buildJsonObject {
+            put("product_id", "P1")
+            put("name", "Free")
+            put("variant", "red")
+            put("price", 0)
+            put("currency", "USD")
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        assertEquals(JsonPrimitive(0), result["price"])
+    }
+
+    @Test
+    fun `given an empty string for a required field, when built, then it counts as missing and warns`() {
+        val properties = buildJsonObject {
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", 10)
+            put("currency", "")
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        assertFalse(result.containsKey("currency"))
+        verify { logger.warn(match { it.contains("currency") }) }
+    }
+
+    @Test
+    fun `given all required fields present, when built, then no warning is logged`() {
+        val properties = buildJsonObject {
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", 10)
+            put("currency", "USD")
+        }
+
+        build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        verify(exactly = 0) { logger.warn(any()) }
+    }
+
+    // endregion
+}

--- a/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
+++ b/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
@@ -331,7 +331,7 @@ class EcommerceUtilsTest {
     // region send-anyway value semantics
 
     @Test
-    fun `given a numeric zero value, when built, then it is treated as resolved`() {
+    fun `given a numeric zero value, when built, then it is treated as resolved and coerced to float`() {
         val properties = buildJsonObject {
             put("product_id", "P1")
             put("name", "Free")
@@ -342,7 +342,7 @@ class EcommerceUtilsTest {
 
         val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
 
-        assertEquals(JsonPrimitive(0), result["price"])
+        assertEquals(JsonPrimitive(0.0), result["price"])
     }
 
     @Test
@@ -374,6 +374,154 @@ class EcommerceUtilsTest {
         build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
 
         verify(exactly = 0) { logger.warn(any()) }
+    }
+
+    // endregion
+
+    // region type-mismatch warnings
+
+    @Test
+    fun `given a numeric float sent as a string, when built, then it is coerced to a number and no warning is logged`() {
+        val properties = buildJsonObject {
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", "29.99") // String that can be coerced to Float
+            put("currency", "USD")
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        assertEquals(JsonPrimitive(29.99), result["price"])
+        verify(exactly = 0) { logger.warn(match { it.contains("type-mismatched") }) }
+    }
+
+    @Test
+    fun `given an integer for a float field, when built, then it is coerced to a float`() {
+        val properties = buildJsonObject {
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", 30) // Integer for a Float field
+            put("currency", "USD")
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        assertEquals(JsonPrimitive(30.0), result["price"])
+        verify(exactly = 0) { logger.warn(match { it.contains("type-mismatched") }) }
+    }
+
+    @Test
+    fun `given a number for a string field, when built, then it is coerced to a string`() {
+        val properties = buildJsonObject {
+            put("product_id", 12345) // Number for a String field
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", 10.0)
+            put("currency", "USD")
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        assertEquals(JsonPrimitive("12345"), result["product_id"])
+        verify(exactly = 0) { logger.warn(match { it.contains("type-mismatched") }) }
+    }
+
+    @Test
+    fun `given a per-product quantity sent as a numeric string, when built, then it is coerced to an integer`() {
+        val properties = buildJsonObject {
+            put("order_id", "O1")
+            put("total", 50.0)
+            put("currency", "USD")
+            putJsonArray("products") {
+                add(
+                    buildJsonObject {
+                        put("product_id", "P1")
+                        put("name", "Shoe")
+                        put("variant", "red")
+                        put("quantity", "2") // String that can be coerced to Integer
+                        put("price", 50.0)
+                    }
+                )
+            }
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.ORDER_REFUNDED)
+
+        assertEquals(JsonPrimitive(2), result.products()[0].jsonObject["quantity"])
+        verify(exactly = 0) { logger.warn(match { it.contains("type-mismatched") }) }
+    }
+
+    @Test
+    fun `given a non-numeric string for a float field, when built, then a warning is logged and value is sent as-is`() {
+        val properties = buildJsonObject {
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", "free") // cannot be coerced to Float
+            put("currency", "USD")
+        }
+
+        val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        assertEquals(JsonPrimitive("free"), result["price"])
+        verify { logger.warn(match { it.contains("type-mismatched") && it.contains("price") }) }
+    }
+
+    @Test
+    fun `given a per-product quantity sent as a float, when built, then a type-mismatch warning is logged`() {
+        val properties = buildJsonObject {
+            put("order_id", "O1")
+            put("total", 50.0)
+            put("currency", "USD")
+            putJsonArray("products") {
+                add(
+                    buildJsonObject {
+                        put("product_id", "P1")
+                        put("name", "Shoe")
+                        put("variant", "red")
+                        put("quantity", 2.5) // wrong type: not an Integer
+                        put("price", 50.0)
+                    }
+                )
+            }
+        }
+
+        build(properties, BrazeEcommerceEvents.ORDER_REFUNDED)
+
+        verify { logger.warn(match { it.contains("type-mismatched") && it.contains("products[].quantity") }) }
+    }
+
+    @Test
+    fun `given the type field sent as a non-array, when built, then a type-mismatch warning is logged`() {
+        val properties = buildJsonObject {
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", 10)
+            put("currency", "USD")
+            put("type", "footwear") // wrong type: String instead of Array of strings
+        }
+
+        build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        verify { logger.warn(match { it.contains("type-mismatched") && it.contains("type") }) }
+    }
+
+    @Test
+    fun `given correct field types including zero values, when built, then no type-mismatch warning is logged`() {
+        val properties = buildJsonObject {
+            put("product_id", "P1")
+            put("name", "Shoe")
+            put("variant", "red")
+            put("price", 0) // valid Float
+            put("currency", "USD")
+        }
+
+        build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
+
+        verify(exactly = 0) { logger.warn(match { it.contains("type-mismatched") }) }
     }
 
     // endregion

--- a/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
+++ b/integrations/braze/src/test/java/com/rudderstack/integration/kotlin/braze/EcommerceUtilsTest.kt
@@ -331,7 +331,7 @@ class EcommerceUtilsTest {
     // region send-anyway value semantics
 
     @Test
-    fun `given a numeric zero value, when built, then it is treated as resolved and coerced to float`() {
+    fun `given a numeric zero value, when built, then it is treated as resolved`() {
         val properties = buildJsonObject {
             put("product_id", "P1")
             put("name", "Free")
@@ -342,7 +342,7 @@ class EcommerceUtilsTest {
 
         val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
 
-        assertEquals(JsonPrimitive(0.0), result["price"])
+        assertEquals(JsonPrimitive(0), result["price"])
     }
 
     @Test
@@ -397,18 +397,18 @@ class EcommerceUtilsTest {
     }
 
     @Test
-    fun `given an integer for a float field, when built, then it is coerced to a float`() {
+    fun `given an integer for a float field, when built, then it is left as-is without a warning`() {
         val properties = buildJsonObject {
             put("product_id", "P1")
             put("name", "Shoe")
             put("variant", "red")
-            put("price", 30) // Integer for a Float field
+            put("price", 30) // Integer for a Float field — Braze accepts it, so no coercion
             put("currency", "USD")
         }
 
         val result = build(properties, BrazeEcommerceEvents.PRODUCT_VIEWED)
 
-        assertEquals(JsonPrimitive(30.0), result["price"])
+        assertEquals(JsonPrimitive(30), result["price"])
         verify(exactly = 0) { logger.warn(match { it.contains("type-mismatched") }) }
     }
 

--- a/integrations/braze/src/test/resources/config/braze_config_hybrid_with_recommended_ecommerce.json
+++ b/integrations/braze/src/test/resources/config/braze_config_hybrid_with_recommended_ecommerce.json
@@ -1,0 +1,18 @@
+{
+  "appKey": "someAppKey",
+  "dataCenter": "US-03",
+  "trackAnonymousUser": false,
+  "enableSubscriptionGroupInGroupCall": false,
+  "enableNestedArrayOperations": false,
+  "supportDedup": false,
+  "blacklistedEvents" : [ ],
+  "whitelistedEvents" : [ ],
+  "eventFilteringOption" : "disable",
+  "consentManagement" : [ {
+    "provider" : "oneTrust",
+    "resolutionStrategy" : "",
+    "consents" : [ ]
+  } ],
+  "connectionMode" : "hybrid",
+  "useRecommendedEcommerceEvents": true
+}

--- a/integrations/braze/src/test/resources/config/braze_config_hybrid_with_recommended_ecommerce.json
+++ b/integrations/braze/src/test/resources/config/braze_config_hybrid_with_recommended_ecommerce.json
@@ -14,5 +14,5 @@
     "consents" : [ ]
   } ],
   "connectionMode" : "hybrid",
-  "useRecommendedEcommerceEvents": true
+  "useEcommerceRecommendedEvents": true
 }

--- a/integrations/braze/src/test/resources/config/braze_config_with_recommended_ecommerce.json
+++ b/integrations/braze/src/test/resources/config/braze_config_with_recommended_ecommerce.json
@@ -1,0 +1,18 @@
+{
+  "appKey": "someAppKey",
+  "dataCenter": "US-03",
+  "trackAnonymousUser": false,
+  "enableSubscriptionGroupInGroupCall": false,
+  "enableNestedArrayOperations": false,
+  "supportDedup": true,
+  "blacklistedEvents" : [ ],
+  "whitelistedEvents" : [ ],
+  "eventFilteringOption" : "disable",
+  "consentManagement" : [ {
+    "provider" : "oneTrust",
+    "resolutionStrategy" : "",
+    "consents" : [ ]
+  } ],
+  "connectionMode" : "device",
+  "useRecommendedEcommerceEvents": true
+}

--- a/integrations/braze/src/test/resources/config/braze_config_with_recommended_ecommerce.json
+++ b/integrations/braze/src/test/resources/config/braze_config_with_recommended_ecommerce.json
@@ -14,5 +14,5 @@
     "consents" : [ ]
   } ],
   "connectionMode" : "device",
-  "useRecommendedEcommerceEvents": true
+  "useEcommerceRecommendedEvents": true
 }


### PR DESCRIPTION
## Description

Adds opt-in mapping of RudderStack ecommerce track events to [Braze recommended events](https://www.braze.com/docs/user_guide/data/activation/events/recommended_events) (`ecommerce.*`) in the Android device-mode Braze integration, mirroring the cloud-mode implementation. Gated by a single destination flag, `useEcommerceRecommendedEvents` (default off), so existing behaviour is unchanged unless the flag is enabled.

Resolves [INT-6467](https://linear.app/rudderstack/issue/INT-6467/braze-update-with-recommended-events-in-kotlin-device-mode).

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Implementation Details
- **New flag** `useEcommerceRecommendedEvents` on `RudderBrazeConfig` (default `false`).
- **New `EcommerceUtils.kt`** — the Kotlin port of the cloud `ecommerceUtil`:
  - Per-event field-mapping tables transcribed from the cloud config (with fallback chains and `brazeRequired` markers), plus the shared per-product mapping. RS event/param names are sourced from the core `ECommerceEvents` / `ECommerceParamNames` constants.
  - `getEcommerceMapping()` — case-insensitive (`Locale.ROOT`), trimmed RS-event → Braze-event resolution. `Cart Viewed` / `Cart Updated` intentionally fall through to the legacy custom-event path.
  - `buildEcommerceEventProperties()` — resolves event-level fields, builds `products[]` (single-product wrap for `cart_updated`; iterate `products[]` otherwise), routes unmapped keys to `metadata` / `products[].metadata`, and logs a single warning per event for any missing Braze-required field.
- **`BrazeIntegration.track()`** — when the flag is on and the event is mapped, the new branch runs **before** the legacy `Order Completed → logPurchase` path and dispatches via `braze.logCustomEvent("ecommerce.*", properties)`, then returns. Otherwise control falls through unchanged (non-ecommerce events like `Install Attributed` and generic custom events are preserved).
- **Type coercion + validation**: resolved values are coerced to the type Braze expects where possible (numeric string → number, number/boolean → string; numbers are left as-is for numeric fields since Braze accepts an integer for a float). A value that cannot be coerced (e.g. `quantity` as `2.5`) is sent verbatim and surfaced via a `logger.warn`.
- **Send-anyway posture**: never throws on missing/malformed data; `0`/`false` are valid, only `null`/empty count as missing. Missing required fields surface as a `logger.warn` (no metrics on mobile), and the event is still sent. Malformed `products` values (non-array, or an array with non-object elements) flow through to `metadata` rather than being dropped.
- **Android `source`**: hardcoded to `"android"` (device mode always runs on Android).

Event mapping:

| RudderStack event | Braze event | action |
|---|---|---|
| Product Viewed | `ecommerce.product_viewed` | — |
| Product Added | `ecommerce.cart_updated` | `add` |
| Product Removed | `ecommerce.cart_updated` | `remove` |
| Checkout Started | `ecommerce.checkout_started` | — |
| Order Completed | `ecommerce.order_placed` | — |
| Order Refunded | `ecommerce.order_refunded` | — |
| Order Cancelled | `ecommerce.order_cancelled` | — |

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
- Unit tests: `./gradlew :integrations:braze:test` — `EcommerceUtilsTest` covers mapping resolution, fallback chains, single-product wrap vs. explicit `products[]`, metadata routing (including malformed `products`), missing-required warnings, type coercion, and type-mismatch warnings; `BrazeIntegrationTest` covers the flag-gated track branch across all event families, the flag-off legacy `logPurchase` path, unmapped-event fall-through, hybrid-mode blocking, and the `braze == null` drop.
- Lint: `./gradlew :integrations:braze:detekt`.

## Breaking Changes
None for existing destinations — the flag defaults to off and flag-off output is byte-identical to today. When the flag is enabled, `Order Completed` emits a single `ecommerce.order_placed` event instead of one `logPurchase` per product (granularity change documented in INT-4302).

## Additional Context
- Cloud-mode counterpart: INT-4302. Destination-config field: INT-6465.
