### PR TITLE
chore: sdk-5133 update pom validator license baselines

### DIFF
--- a/.claude/skills/rsa-validate-release-pom/SKILL.md
+++ b/.claude/skills/rsa-validate-release-pom/SKILL.md
@@ -103,7 +103,7 @@ For each fetched POM, run these checks.
 
 **Check 2: Licence block**
 
-- licence name = `Elastic License 2.0 (ELv2)`
+- licence name = `MIT License`
 - licence url = `https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md`
 - licence distribution = `repo`
 

--- a/.claude/skills/rsa-validate-release-pom/references/adjust-1.4.0.md
+++ b/.claude/skills/rsa-validate-release-pom/references/adjust-1.4.0.md
@@ -15,7 +15,7 @@ Published: 07 Apr 2026 | Maven Central
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-release-pom/references/android-1.6.0.md
+++ b/.claude/skills/rsa-validate-release-pom/references/android-1.6.0.md
@@ -15,7 +15,7 @@ Published: 07 Apr 2026 | Maven Central
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-release-pom/references/appsflyer-1.3.0.md
+++ b/.claude/skills/rsa-validate-release-pom/references/appsflyer-1.3.0.md
@@ -15,7 +15,7 @@ Published: 07 Apr 2026 | Maven Central
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-release-pom/references/braze-1.4.0.md
+++ b/.claude/skills/rsa-validate-release-pom/references/braze-1.4.0.md
@@ -15,7 +15,7 @@ Published: 07 Apr 2026 | Maven Central
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-release-pom/references/core-1.6.0.md
+++ b/.claude/skills/rsa-validate-release-pom/references/core-1.6.0.md
@@ -14,7 +14,7 @@ Published: 07 Apr 2026 | Maven Central
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-release-pom/references/facebook-1.2.1.md
+++ b/.claude/skills/rsa-validate-release-pom/references/facebook-1.2.1.md
@@ -15,7 +15,7 @@ Published: 07 Apr 2026 | Maven Central
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-release-pom/references/firebase-1.3.1.md
+++ b/.claude/skills/rsa-validate-release-pom/references/firebase-1.3.1.md
@@ -15,7 +15,7 @@ Published: 07 Apr 2026 | Maven Central
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-release-pom/references/release-validation-reference.md
+++ b/.claude/skills/rsa-validate-release-pom/references/release-validation-reference.md
@@ -56,7 +56,7 @@ should change between releases - everything else must remain identical.
 Licence:
 | Field | Value |
 |---|---|
-| name | `Elastic License 2.0 (ELv2)` |
+| name | `MIT License` |
 | url | `https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md` |
 | distribution | `repo` |
 

--- a/.claude/skills/rsa-validate-release-pom/references/sprig-1.0.0.md
+++ b/.claude/skills/rsa-validate-release-pom/references/sprig-1.0.0.md
@@ -15,7 +15,7 @@ Published: 29 Apr 2026 | Maven Central
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-snapshot-pom/SKILL.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/SKILL.md
@@ -94,7 +94,7 @@ For each module, run these checks against the baseline reference:
 - `url` = `https://github.com/rudderlabs/rudder-sdk-kotlin`
 
 **Check 2: Licence block**
-- licence name = `Elastic License 2.0 (ELv2)`
+- licence name = `MIT License`
 - licence url = `https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md`
 - licence distribution = `repo`
 

--- a/.claude/skills/rsa-validate-snapshot-pom/references/adjust-1.3.0-SNAPSHOT.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/references/adjust-1.3.0-SNAPSHOT.md
@@ -15,7 +15,7 @@ Published: 16 Mar 2026, 21:58:44 UTC | Build #2
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-snapshot-pom/references/android-1.5.0-SNAPSHOT.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/references/android-1.5.0-SNAPSHOT.md
@@ -15,7 +15,7 @@ Published: 16 Mar 2026, 21:55:31 UTC | Build #2
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-snapshot-pom/references/appsflyer-1.2.0-SNAPSHOT.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/references/appsflyer-1.2.0-SNAPSHOT.md
@@ -15,7 +15,7 @@ Published: 16 Mar 2026, 22:00:40 UTC | Build #2
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-snapshot-pom/references/braze-1.3.0-SNAPSHOT.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/references/braze-1.3.0-SNAPSHOT.md
@@ -15,7 +15,7 @@ Published: 16 Mar 2026, 22:01:56 UTC | Build #2
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-snapshot-pom/references/core-1.5.0-SNAPSHOT.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/references/core-1.5.0-SNAPSHOT.md
@@ -14,7 +14,7 @@ Published: 16 Mar 2026, 21:55:31 UTC | Build #2
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-snapshot-pom/references/facebook-1.2.0-SNAPSHOT.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/references/facebook-1.2.0-SNAPSHOT.md
@@ -15,7 +15,7 @@ Published: 16 Mar 2026, 22:02:41 UTC | Build #2
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-snapshot-pom/references/firebase-1.3.0-SNAPSHOT.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/references/firebase-1.3.0-SNAPSHOT.md
@@ -15,7 +15,7 @@ Published: 16 Mar 2026, 22:03:37 UTC | Build #2
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>

--- a/.claude/skills/rsa-validate-snapshot-pom/references/snapshot-validation-reference.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/references/snapshot-validation-reference.md
@@ -51,7 +51,7 @@ should change between releases - everything else must remain identical.
 Licence:
 | Field | Value |
 |---|---|
-| name | `Elastic License 2.0 (ELv2)` |
+| name | `MIT License` |
 | url | `https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md` |
 | distribution | `repo` |
 

--- a/.claude/skills/rsa-validate-snapshot-pom/references/sprig-1.0.1-SNAPSHOT.md
+++ b/.claude/skills/rsa-validate-snapshot-pom/references/sprig-1.0.1-SNAPSHOT.md
@@ -15,7 +15,7 @@ Published: 03 Jun 2026, 07:15:03 UTC | Build #1
   <url>https://github.com/rudderlabs/rudder-sdk-kotlin</url>
   <licenses>
     <license>
-      <name>Elastic License 2.0 (ELv2)</name>
+      <name>MIT License</name>
       <url>https://github.com/rudderlabs/rudder-sdk-kotlin/blob/main/LICENSE.md</url>
       <distribution>repo</distribution>
     </license>


### PR DESCRIPTION
## Summary

- update the release and snapshot POM validator licence expectations from Elastic License 2.0 (ELv2) to MIT License
- update all 16 per-module reference POMs and both shared baseline tables
- preserve the existing licence URL, distribution value, and pinned reference versions

## Why

The repository has been relicensed to MIT and the published release and snapshot POMs already use `MIT License`. The validator baselines still expected the former ELv2 name, causing false licence-check failures across all eight modules.

This is validator documentation/baseline-only work and does not require an SDK release.

## Validation

- confirmed all 8 current release POMs publish `MIT License`
- confirmed all 8 latest snapshot POMs publish `MIT License`
- confirmed there are no remaining `Elastic License 2.0 (ELv2)` occurrences in either validator
- confirmed exactly 20 `MIT License` baseline occurrences
- `git diff --check`

Linear: https://linear.app/rudderstack/issue/SDK-5133/update-pom-validator-baselines-to-mit-license