### PR TITLE
feat(clevertap)!: add CleverTap device-mode integration

### DIFF
--- a/integrations/clevertap/CHANGELOG.md
+++ b/integrations/clevertap/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.


### PR DESCRIPTION
## Why

PR #336 merged from a stale merge form. The squash commit on `develop` (`0f5deaf`) carries the subject `Merge pull request #336 from rudderlabs/harness/...` instead of the PR title. Its body holds both the old and the new PR title, which is what a form rendered before the rename produces.

The integration content on `develop` is correct. Only the conventional-commit label was lost.

`detect-affected-modules.sh` parses commit subjects. `0f5deaf` does not match the pattern, so the detector skips it and reports nothing releasable:

```
detect-affected-modules.sh   ->  (empty)
read-affected-modules.sh     ->  clevertap|new||0.0.0
```

This PR re-applies the lost label so the release can proceed.

## What it does

Adds `integrations/clevertap/CHANGELOG.md` with the standard three-line header, byte-identical to every other integration. `generate-changelog.sh` creates this exact file when it is absent, so the release workflow prepends its generated entry cleanly.

The file also gives the commit a path under `integrations/clevertap/`, which is what maps it to the module.

## Effect on the release

The `!` forces a major bump, which lands the first published version on `1.0.0`. Verified locally:

```
$ ./scripts/releases/detect-affected-modules.sh
clevertap|major|0.0.0|1.0.0
```

This matches how the Sprig integration cut its first release (PR #313, `feat(sprig)!:`, `0.0.0` -> `1.0.0`).

## Expected CI failure

`PR Title Check` will fail. The pinned commitlint action (v1.0.11) cannot parse `!` and reports `type-empty` and `subject-empty`. Sprig's PR #313 failed the same check and was merged anyway.

Only `Test Check` is a required status check on `develop`.

## Before merging

Refresh this page, then confirm the squash title field reads `feat(clevertap)!: add CleverTap device-mode integration (#NNN)` before you confirm the merge. A stale form is what caused this PR to be necessary.