### PR TITLE
fix(release): handle pre-release tags in version sort

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -261,7 +261,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Find previous monorepo tag for compare URL
-          prev_tag=$(git tag -l 'v*.*.*' --sort=-v:refname | grep -v "v${VERSION}" | head -1)
+          # versionsort.suffix ranks pre-release tags (v1.0.0-alpha.1) below GA (v1.0.0)
+          prev_tag=$(git -c versionsort.suffix=- tag -l 'v*.*.*' --sort=-v:refname | grep -v "v${VERSION}" | head -1)
 
           # Build inline module list: "core 6.2.0 · android 6.0.4 · ..."
           module_line=""

--- a/scripts/releases/common.sh
+++ b/scripts/releases/common.sh
@@ -47,7 +47,8 @@ sed_inplace() {
 # --- Monorepo tag ---
 
 find_monorepo_tag() {
-    git tag -l 'v*.*.*' --sort=-v:refname | head -1
+    # versionsort.suffix ranks pre-release tags (v1.0.0-alpha.1) below GA (v1.0.0)
+    git -c versionsort.suffix=- tag -l 'v*.*.*' --sort=-v:refname | head -1
     return 0
 }
 

--- a/scripts/releases/read-affected-modules.sh
+++ b/scripts/releases/read-affected-modules.sh
@@ -19,7 +19,8 @@ while IFS='|' read -r name _ _ _ _ _; do
     current_version=$(get_module_version "$name")
 
     # Find the latest tag for this module
-    latest_tag=$(git tag -l "${tag_prefix}@v*" --sort=-v:refname | head -1)
+    # versionsort.suffix ranks pre-release tags (v1.7.0-beta.1) below GA (v1.7.0)
+    latest_tag=$(git -c versionsort.suffix=- tag -l "${tag_prefix}@v*" --sort=-v:refname | head -1)
 
     if [[ -z "$latest_tag" ]]; then
         # No tag exists — this module is new, treat as affected
@@ -29,6 +30,12 @@ while IFS='|' read -r name _ _ _ _ _; do
 
     # Extract version from tag: com.rudderstack.sdk.kotlin.core@v6.0.0 → 6.0.0
     tagged_version="${latest_tag##*@v}"
+
+    # Guard: if the current version is already tagged, the module was already
+    # released — never re-add it to the publish matrix
+    if [[ -n $(git tag -l "${tag_prefix}@v${current_version}") ]]; then
+        continue
+    fi
 
     if [[ "$tagged_version" != "$current_version" ]]; then
         echo "${name}|bumped|${tagged_version}|${current_version}"

--- a/scripts/releases/tests/test-read-affected-modules.sh
+++ b/scripts/releases/tests/test-read-affected-modules.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression test for read-affected-modules.sh.
+# Verifies a leftover pre-release tag on an unchanged module does not
+# re-add the module to the publish matrix, while bumped and brand-new
+# modules are still detected.
+#
+# Runs fully offline: throwaway git repo + stub gradlew.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+READ_AFFECTED="${SCRIPT_DIR}/../read-affected-modules.sh"
+
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+cd "$workdir"
+
+# Isolate from user/system git config (hooks, tag signing, etc.)
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
+git init -q
+git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "init"
+
+# Stub gradlew: prints the dependency chain the scripts normally get from Gradle
+cat > gradlew <<'EOF'
+#!/usr/bin/env bash
+echo "name|group|artifact|version|bump|deps"
+echo "android|com.test.sdk|android|1.7.0|minor|"
+echo "braze|com.test.sdk|braze|1.5.0|minor|"
+echo "sprig|com.test.sdk|sprig|1.0.0|minor|"
+EOF
+chmod +x gradlew
+
+# android: unchanged at 1.7.0, with a leftover pre-release tag
+git tag "com.test.sdk.android@v1.7.0"
+git tag "com.test.sdk.android@v1.7.0-beta.1"
+# braze: genuinely bumped 1.4.1 -> 1.5.0
+git tag "com.test.sdk.braze@v1.4.1"
+# sprig: no tags at all -> new module
+
+actual=$(bash "$READ_AFFECTED")
+expected="braze|bumped|1.4.1|1.5.0
+sprig|new||1.0.0"
+
+if [[ "$actual" == "$expected" ]]; then
+    echo "PASS: unchanged module with leftover pre-release tag is not re-published"
+else
+    echo "FAIL: read-affected-modules.sh output mismatch"
+    echo "--- expected ---"; echo "$expected"
+    echo "--- actual ---";   echo "$actual"
+    exit 1
+fi


### PR DESCRIPTION
## Description
The release tooling picks the "latest" tag with `git tag --sort=-v:refname`, but git's default version sort ranks pre-release tags (e.g. `v1.7.0-beta.1`) *above* their GA counterpart (`v1.7.0`). When a leftover pre-release tag existed for a module, `read-affected-modules.sh` compared the current version against the beta tag, concluded the module was "bumped", and re-added an already-released module to the publish matrix — causing attempted re-publishing of unchanged artifacts. This PR fixes the tag ordering with `versionsort.suffix=-` (which ranks suffixed pre-release tags below GA) and adds an explicit guard so a module whose current version is already tagged is never re-published.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- `scripts/releases/read-affected-modules.sh` — latest module tag is now resolved with `git -c versionsort.suffix=- tag -l ... --sort=-v:refname`, so pre-release tags sort below GA tags; added a guard that skips a module entirely when its current version is already tagged (`${tag_prefix}@v${current_version}` exists), preventing re-publishing regardless of sort order.
- `scripts/releases/common.sh` — `find_monorepo_tag()` uses the same `versionsort.suffix=-` config so the monorepo tag lookup can't return a pre-release tag as the latest.
- `.github/workflows/publish-new-release.yml` — the `prev_tag` lookup used for the GitHub release compare URL applies the same sort fix.
- `scripts/releases/tests/test-read-affected-modules.sh` (new) — offline regression test using a throwaway git repo and a stub `gradlew`; verifies an unchanged module with a leftover pre-release tag is excluded, while genuinely bumped and brand-new modules are still detected.

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
- Run the regression test: `bash scripts/releases/tests/test-read-affected-modules.sh` — it builds a temporary git repo with an unchanged module carrying a leftover pre-release tag (`v1.7.0` + `v1.7.0-beta.1`), a bumped module, and a new module, and asserts only the bumped and new modules are reported. Expected output: `PASS: unchanged module with leftover pre-release tag is not re-published`.
- Manually verify the sort behavior: in a repo with both `v1.7.0` and `v1.7.0-beta.1` tags, compare `git tag -l 'v*' --sort=-v:refname | head -1` (returns the beta) against `git -c versionsort.suffix=- tag -l 'v*' --sort=-v:refname | head -1` (returns the GA tag).

## Breaking Changes
No breaking changes. This only affects internal release tooling; published artifacts and SDK behavior are unchanged.

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
No UI changes in this PR.

## Additional Context
Tracked as SDK-5101. Root cause: `git tag --sort=-v:refname` without `versionsort.suffix` treats `v1.7.0-beta.1` as newer than `v1.7.0`, so any leftover pre-release tag made an already-released module look bumped and re-entered it into the publish matrix. The `versionsort.suffix=-` config makes any `-suffixed` tag sort below the corresponding GA tag, and the new already-tagged guard provides defense in depth.