### PR TITLE
ci(release): run the Kotlin sanity suite before and after a release

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -213,6 +213,21 @@ jobs:
           pr_url=$(./scripts/releases/create-backmerge-pr.sh "$VERSION")
           echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
 
+  release-sanity:
+    needs: [detect-modules, publish-release]
+    if: needs.detect-modules.outputs.has_modules == 'true'
+    uses: ./.github/workflows/release-sanity.yml
+    with:
+      phase: post-release
+      snapshot: false
+      affected_modules: ${{ needs.detect-modules.outputs.affected }}
+      release_pr: ${{ github.event.pull_request.html_url }}
+      # The suite waits up to 35m for the Maven Central sync before it can test anything.
+      max_wait_seconds: 5400
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
   notify-slack:
     needs: [detect-modules, publish-release, create-github-releases, back-merge]
     if: needs.detect-modules.outputs.has_modules == 'true'

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -222,8 +222,7 @@ jobs:
       snapshot: false
       affected_modules: ${{ needs.detect-modules.outputs.affected }}
       release_pr: ${{ github.event.pull_request.html_url }}
-      # The suite waits up to 35m for the Maven Central sync before it can test anything.
-      max_wait_seconds: 5400
+      max_wait_seconds: 3000
     secrets:
       RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-sanity.yml
+++ b/.github/workflows/release-sanity.yml
@@ -236,27 +236,36 @@ jobs:
         run: |
           set -uo pipefail
 
-          artifact_id=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${TARGET_REPO}/actions/runs/${RUN_ID}/artifacts" \
-            --jq '.artifacts[] | select(.name == "job-outputs") | .id' | head -1)
-
-          if [ -z "$artifact_id" ]; then
-            echo "::warning::run $RUN_ID published no job-outputs artifact"
-            echo "has_outputs=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          gh api "/repos/${TARGET_REPO}/actions/artifacts/${artifact_id}/zip" > outputs.zip
-          unzip -q -o outputs.zip -d outputs_dir
-          json=$(find outputs_dir -name '*.json' -type f | head -1)
-
-          if [ -z "$json" ] || ! jq empty "$json" 2>/dev/null; then
-            echo "::warning::job-outputs held no readable JSON"
+          give_up() {
+            echo "::warning::$1"
             echo "has_outputs=false" >> "$GITHUB_OUTPUT"
             rm -rf outputs.zip outputs_dir
             exit 0
+          }
+
+          if ! artifacts=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${TARGET_REPO}/actions/runs/${RUN_ID}/artifacts" 2>&1); then
+            give_up "could not list the artifacts of run $RUN_ID: $artifacts"
+          fi
+
+          artifact_id=$(printf '%s' "$artifacts" \
+            | jq -r '.artifacts[]? | select(.name == "job-outputs") | .id' 2>/dev/null | head -1)
+
+          case "$artifact_id" in
+            "")            give_up "run $RUN_ID published no job-outputs artifact" ;;
+            *[!0-9]* | 0*) give_up "unusable artifact id for run $RUN_ID: $artifact_id" ;;
+          esac
+
+          if ! gh api "/repos/${TARGET_REPO}/actions/artifacts/${artifact_id}/zip" > outputs.zip 2>/dev/null; then
+            give_up "could not download the job-outputs artifact of run $RUN_ID"
+          fi
+          unzip -q -o outputs.zip -d outputs_dir 2>/dev/null || give_up "job-outputs was not a readable zip"
+          json=$(find outputs_dir -name '*.json' -type f | head -1)
+
+          if [ -z "$json" ] || ! jq empty "$json" 2>/dev/null; then
+            give_up "job-outputs held no readable JSON"
           fi
 
           jq -C '.' "$json"
@@ -338,7 +347,7 @@ jobs:
           release_ticket_id: ${{ steps.release-info.outputs.ticket_id }}
 
       - name: Post the verdict to the release thread
-        if: always() && steps.thread.outputs.channel_id != ''
+        if: always() && steps.thread.outputs.channel_id != '' && steps.thread.outputs.thread_ts != ''
         continue-on-error: true
         uses: ./.github/actions/slack-release-notify
         with:

--- a/.github/workflows/release-sanity.yml
+++ b/.github/workflows/release-sanity.yml
@@ -29,10 +29,10 @@ on:
         type: string
         default: ""
       max_wait_seconds:
-        description: "How long to wait for the suite. post-release needs more: the suite waits on the Maven Central sync."
+        description: "How long to wait for the suite. Keep at or below 3000. The app token this job mints dies 60 minutes after it is issued, and a dead token reports a passing run as a timeout."
         required: false
         type: number
-        default: 3600
+        default: 3000
     secrets:
       RELEASE_PRIVATE_KEY:
         description: "Private key of the release GitHub App, used to reach the test repository."
@@ -61,15 +61,18 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Harden the runner (Audit all outbound calls)
+        continue-on-error: true
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 
       - name: Checkout code
+        continue-on-error: true
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Resolve the android version
         id: version
+        continue-on-error: true
         shell: bash
         env:
           AFFECTED: ${{ inputs.affected_modules }}
@@ -94,16 +97,40 @@ jobs:
       - name: Extract release info from branch
         id: release-info
         if: steps.version.outputs.should_run == 'true'
+        continue-on-error: true
         shell: bash
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           # Branch format: release/6.2.0-SDK-4567 or hotfix-release/6.2.0-SDK-4567
           suffix="${BRANCH#*/}"
-          version=$(echo "$suffix" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+          version=$(echo "$suffix" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+') || version=""
+          if [ -z "$version" ]; then
+            echo "::warning::branch '$BRANCH' carries no version, so the release thread cannot be found"
+            exit 0
+          fi
           ticket_id="${suffix#"${version}"-}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "ticket_id=${ticket_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the version on Maven Central
+        if: steps.version.outputs.should_run == 'true' && !inputs.snapshot
+        continue-on-error: true
+        shell: bash
+        env:
+          SDK_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -uo pipefail
+          url="https://repo1.maven.org/maven2/com/rudderstack/sdk/kotlin/android/${SDK_VERSION}/android-${SDK_VERSION}.pom"
+          deadline=$(( $(date +%s) + 2400 ))
+          until curl -fsI -o /dev/null "$url"; do
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::warning::$SDK_VERSION has not reached Maven Central after 40m; dispatching anyway"
+              exit 0
+            fi
+            sleep 30 & wait $!
+          done
+          echo "$SDK_VERSION is on Maven Central"
 
       - name: Generate token
         id: app-token
@@ -208,8 +235,14 @@ jobs:
               continue
             }
 
-            status=$(printf '%s' "$run" | jq -r '.status')
-            conclusion=$(printf '%s' "$run" | jq -r '.conclusion // ""')
+            status=$(printf '%s' "$run" | jq -r '.status' 2>/dev/null) || status=""
+            conclusion=$(printf '%s' "$run" | jq -r '.conclusion // ""' 2>/dev/null) || conclusion=""
+            if [ -z "$status" ]; then
+              echo "::warning::run $RUN_ID returned no readable status; retrying"
+              sleep "$CHECK_INTERVAL" & wait $!
+              elapsed=$((elapsed + CHECK_INTERVAL))
+              continue
+            fi
             echo "status=$status conclusion=$conclusion elapsed=${elapsed}s"
 
             if [ "$status" = "completed" ]; then
@@ -222,12 +255,12 @@ jobs:
             elapsed=$((elapsed + CHECK_INTERVAL))
           done
 
-          echo "::warning::the suite was still running after $((MAX_WAIT / 60))m — $RUN_URL"
+          echo "::warning::stopped waiting after $((MAX_WAIT / 60))m - the suite is still running at $RUN_URL and will report itself"
           echo "conclusion=timed-out" >> "$GITHUB_OUTPUT"
 
       - name: Read the suite outputs
         id: outputs
-        if: always() && steps.dispatch.outputs.run_id != ''
+        if: ${{ !cancelled() && steps.dispatch.outputs.run_id != '' }}
         continue-on-error: true
         shell: bash
         env:
@@ -251,7 +284,7 @@ jobs:
           fi
 
           artifact_id=$(printf '%s' "$artifacts" \
-            | jq -r '.artifacts[]? | select(.name == "job-outputs") | .id' 2>/dev/null | head -1)
+            | jq -r '.artifacts[]? | select(.name == "job-outputs") | .id' 2>/dev/null | head -1) || artifact_id=""
 
           case "$artifact_id" in
             "")            give_up "run $RUN_ID published no job-outputs artifact" ;;
@@ -262,7 +295,7 @@ jobs:
             give_up "could not download the job-outputs artifact of run $RUN_ID"
           fi
           unzip -q -o outputs.zip -d outputs_dir 2>/dev/null || give_up "job-outputs was not a readable zip"
-          json=$(find outputs_dir -name '*.json' -type f | head -1)
+          json=$(find outputs_dir -name '*.json' -type f 2>/dev/null | head -1) || json=""
 
           if [ -z "$json" ] || ! jq empty "$json" 2>/dev/null; then
             give_up "job-outputs held no readable JSON"
@@ -273,14 +306,15 @@ jobs:
             echo "has_outputs=true"
             echo "success=$(jq -r '.test_status.success // false' "$json")"
             echo "summary=$(jq -r '.test_status.summary // ""' "$json" | tr '\n\r' '  ')"
-            echo "report_url=$(jq -r '.report_url // ""' "$json")"
-            echo "slack_message_url=$(jq -r '.slack_message_url // ""' "$json")"
+            echo "report_url=$(jq -r '.report_url // ""' "$json" | tr -d '\n\r')"
+            echo "slack_message_url=$(jq -r '.slack_message_url // ""' "$json" | tr -d '\n\r')"
           } >> "$GITHUB_OUTPUT"
           rm -rf outputs.zip outputs_dir
 
       - name: Build the verdict
         id: verdict
-        if: always() && steps.version.outputs.should_run == 'true'
+        if: ${{ !cancelled() && steps.version.outputs.should_run == 'true' }}
+        continue-on-error: true
         shell: bash
         env:
           PHASE: ${{ inputs.phase }}
@@ -338,7 +372,7 @@ jobs:
 
       - name: Download release thread info
         id: thread
-        if: always() && steps.version.outputs.should_run == 'true'
+        if: ${{ !cancelled() && steps.version.outputs.should_run == 'true' }}
         continue-on-error: true
         uses: ./.github/actions/slack-release-notify
         with:
@@ -347,7 +381,7 @@ jobs:
           release_ticket_id: ${{ steps.release-info.outputs.ticket_id }}
 
       - name: Post the verdict to the release thread
-        if: always() && steps.thread.outputs.channel_id != '' && steps.thread.outputs.thread_ts != ''
+        if: ${{ !cancelled() && steps.thread.outputs.channel_id != '' && steps.thread.outputs.thread_ts != '' }}
         continue-on-error: true
         uses: ./.github/actions/slack-release-notify
         with:

--- a/.github/workflows/release-sanity.yml
+++ b/.github/workflows/release-sanity.yml
@@ -96,7 +96,6 @@ jobs:
 
       - name: Extract release info from branch
         id: release-info
-        if: steps.version.outputs.should_run == 'true'
         continue-on-error: true
         shell: bash
         env:
@@ -313,10 +312,11 @@ jobs:
 
       - name: Build the verdict
         id: verdict
-        if: ${{ !cancelled() && steps.version.outputs.should_run == 'true' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         shell: bash
         env:
+          SHOULD_RUN: ${{ steps.version.outputs.should_run }}
           PHASE: ${{ inputs.phase }}
           SDK_VERSION: ${{ steps.version.outputs.version }}
           RUN_URL: ${{ steps.dispatch.outputs.run_url }}
@@ -328,7 +328,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "$HAS_OUTPUTS" = "true" ] && [ "$SUCCESS" = "true" ]; then
+          if [ "$SHOULD_RUN" != "true" ]; then
+            icon=":fast_forward:"; headline="$PHASE sanity skipped"
+            detail="This release publishes no android artifact, so there is nothing to test."
+          elif [ "$HAS_OUTPUTS" = "true" ] && [ "$SUCCESS" = "true" ]; then
             icon=":white_check_mark:"; headline="$PHASE sanity passed"
             detail="$SUMMARY"
           elif [ "$HAS_OUTPUTS" = "true" ]; then
@@ -345,7 +348,7 @@ jobs:
             detail="The suite ended without publishing results. Open the suite run to see why."
           fi
 
-          msg="${icon} *Kotlin SDK ${SDK_VERSION} — ${headline}*"
+          msg="${icon} *Kotlin SDK${SDK_VERSION:+ $SDK_VERSION} — ${headline}*"
           msg+=$'\n'"${detail}"
           if [ -n "$REPORT_URL" ]; then
             msg+=$'\n'"<${REPORT_URL}|Full report>"
@@ -357,7 +360,7 @@ jobs:
           {
             echo "### ${icon} ${headline}"
             echo ""
-            echo "- **Version:** \`${SDK_VERSION}\`"
+            [ -z "$SDK_VERSION" ] || echo "- **Version:** \`${SDK_VERSION}\`"
             echo "- **Result:** ${detail}"
             [ -z "$REPORT_URL" ] || echo "- **Report:** ${REPORT_URL}"
             [ -z "$RUN_URL" ] || echo "- **Suite run:** ${RUN_URL}"
@@ -368,11 +371,13 @@ jobs:
           echo "$msg" >> "$GITHUB_OUTPUT"
           echo "${EOF_MARKER}" >> "$GITHUB_OUTPUT"
 
-          [ "$SUCCESS" = "true" ] || echo "::warning::${headline} — ${detail}"
+          if [ "$SHOULD_RUN" = "true" ] && [ "$SUCCESS" != "true" ]; then
+            echo "::warning::${headline} — ${detail}"
+          fi
 
       - name: Download release thread info
         id: thread
-        if: ${{ !cancelled() && steps.version.outputs.should_run == 'true' }}
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: ./.github/actions/slack-release-notify
         with:

--- a/.github/workflows/release-sanity.yml
+++ b/.github/workflows/release-sanity.yml
@@ -1,0 +1,349 @@
+# Runs the Kotlin scenario suite in rudderlabs/rudder-mobile-sdk-test against a published android
+# artifact, then reports the verdict into the release Slack thread.
+#
+# Advisory by design: the suite reports, it never fails the release. Every step that can fail is
+# `continue-on-error`, and the job is too, so a broken sanity run can not hold a release.
+#
+# The caller must be triggered by `pull_request` on a release branch. The Slack thread id is keyed
+# by the monorepo version and the ticket id, and both come from the branch name.
+name: Release Sanity
+
+on:
+  workflow_call:
+    inputs:
+      phase:
+        description: "pre-release or post-release. Chooses the suite's own wait budget for the artifact."
+        required: true
+        type: string
+      snapshot:
+        description: "true to test <version>-SNAPSHOT from the snapshots repo."
+        required: true
+        type: boolean
+      affected_modules:
+        description: "The release's `module|bump|old|new` lines. The android line decides whether to run."
+        required: true
+        type: string
+      release_pr:
+        description: "Release PR URL. Linked in the suite's own Slack message."
+        required: false
+        type: string
+        default: ""
+      max_wait_seconds:
+        description: "How long to wait for the suite. post-release needs more: the suite waits on the Maven Central sync."
+        required: false
+        type: number
+        default: 3600
+    secrets:
+      RELEASE_PRIVATE_KEY:
+        description: "Private key of the release GitHub App, used to reach the test repository."
+        required: true
+      SLACK_BOT_TOKEN:
+        description: "Slack bot token, for the release thread message."
+        required: false
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  TARGET_REPO: rudderlabs/rudder-mobile-sdk-test
+  TARGET_WORKFLOW: kotlin-release-sanity.yaml
+  # `workflow_dispatch` registers only from the default branch, so the suite is dispatchable on main only.
+  TARGET_REF: main
+  CHECK_INTERVAL: 60
+  CORRELATION_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  sanity:
+    name: Release sanity
+    runs-on: [self-hosted, Linux, X64]
+    continue-on-error: true
+    timeout-minutes: 120
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Resolve the android version
+        id: version
+        shell: bash
+        env:
+          AFFECTED: ${{ inputs.affected_modules }}
+          SNAPSHOT: ${{ inputs.snapshot }}
+        run: |
+          set -euo pipefail
+          version=$(printf '%s\n' "$AFFECTED" | awk -F'|' '$1 == "android" { print $4 }' | head -1)
+
+          if [ -z "$version" ]; then
+            echo "::notice::this release publishes no android artifact — the suite has nothing to test"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$SNAPSHOT" = "true" ]; then
+            version="${version}-SNAPSHOT"
+          fi
+          echo "::notice::testing android $version"
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract release info from branch
+        id: release-info
+        if: steps.version.outputs.should_run == 'true'
+        shell: bash
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          # Branch format: release/6.2.0-SDK-4567 or hotfix-release/6.2.0-SDK-4567
+          suffix="${BRANCH#*/}"
+          version=$(echo "$suffix" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
+          ticket_id="${suffix#"${version}"-}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "ticket_id=${ticket_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate token
+        id: app-token
+        if: steps.version.outputs.should_run == 'true'
+        continue-on-error: true
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-actions: write
+          repositories: rudder-mobile-sdk-test
+
+      - name: Dispatch the suite
+        id: dispatch
+        if: steps.version.outputs.should_run == 'true' && steps.app-token.outcome == 'success'
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SDK_VERSION: ${{ steps.version.outputs.version }}
+          PHASE: ${{ inputs.phase }}
+          RELEASE_PR: ${{ inputs.release_pr }}
+          LINEAR_TICKET: ${{ steps.release-info.outputs.ticket_id }}
+        run: |
+          set -euo pipefail
+
+          # `api_levels` and `suite` are deliberately not sent. An omitted dispatch input takes the
+          # target workflow's own default, so the test repo keeps ownership of what the suite covers.
+          jq -n --arg ref "$TARGET_REF" \
+                --arg version "$SDK_VERSION" \
+                --arg phase "$PHASE" \
+                --arg cid "$CORRELATION_ID" \
+                --arg pr "$RELEASE_PR" \
+                --arg ticket "$LINEAR_TICKET" \
+            '{ref: $ref, inputs: {sdk_version: $version, phase: $phase, correlation_id: $cid,
+                                  release_pr: $pr, linear_ticket: $ticket}}' > dispatch.json
+
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --input dispatch.json \
+            "/repos/${TARGET_REPO}/actions/workflows/${TARGET_WORKFLOW}/dispatches"
+          rm -f dispatch.json
+          echo "dispatched $SDK_VERSION ($PHASE) as $CORRELATION_ID"
+
+          # The dispatch API returns no run id. The suite echoes the correlation id into its
+          # run-name for exactly this lookup, so no timestamp or branch heuristic is needed.
+          run_id=""
+          for _ in $(seq 1 20); do
+            sleep 3
+            run_id=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/${TARGET_REPO}/actions/workflows/${TARGET_WORKFLOW}/runs?event=workflow_dispatch&per_page=20" \
+              --jq "[.workflow_runs[]
+                     | select(((.display_title // \"\") + \" \" + (.name // \"\"))
+                              | contains(\"[${CORRELATION_ID}]\"))]
+                    | first | .id // empty" 2>/dev/null) || run_id=""
+            [ -z "$run_id" ] || break
+          done
+
+          if [ -z "$run_id" ]; then
+            echo "::warning::dispatched $CORRELATION_ID but no run carried it back within 60s"
+            exit 1
+          fi
+
+          echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
+          echo "run_url=https://github.com/${TARGET_REPO}/actions/runs/${run_id}" >> "$GITHUB_OUTPUT"
+          echo "found run $run_id"
+
+      - name: Wait for the suite
+        id: wait
+        if: steps.dispatch.outputs.run_id != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+          RUN_URL: ${{ steps.dispatch.outputs.run_url }}
+          MAX_WAIT: ${{ inputs.max_wait_seconds }}
+        run: |
+          set -uo pipefail
+
+          # A cancelled release must not leave two emulators running for another half hour.
+          cancel_remote() {
+            echo "cancelling $RUN_URL"
+            gh api --method POST "/repos/${TARGET_REPO}/actions/runs/${RUN_ID}/cancel" >/dev/null 2>&1 || true
+            exit 1
+          }
+          trap cancel_remote SIGTERM SIGINT
+
+          echo "waiting up to $((MAX_WAIT / 60))m for $RUN_URL"
+          elapsed=0
+          while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+            run=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/${TARGET_REPO}/actions/runs/${RUN_ID}") || {
+              echo "::warning::could not read run $RUN_ID; retrying"
+              sleep "$CHECK_INTERVAL" & wait $!
+              elapsed=$((elapsed + CHECK_INTERVAL))
+              continue
+            }
+
+            status=$(printf '%s' "$run" | jq -r '.status')
+            conclusion=$(printf '%s' "$run" | jq -r '.conclusion // ""')
+            echo "status=$status conclusion=$conclusion elapsed=${elapsed}s"
+
+            if [ "$status" = "completed" ]; then
+              echo "conclusion=${conclusion}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            # Backgrounded so the cancel trap fires at once; a foreground sleep defers it a minute.
+            sleep "$CHECK_INTERVAL" & wait $!
+            elapsed=$((elapsed + CHECK_INTERVAL))
+          done
+
+          echo "::warning::the suite was still running after $((MAX_WAIT / 60))m — $RUN_URL"
+          echo "conclusion=timed-out" >> "$GITHUB_OUTPUT"
+
+      - name: Read the suite outputs
+        id: outputs
+        if: always() && steps.dispatch.outputs.run_id != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: |
+          set -uo pipefail
+
+          artifact_id=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${TARGET_REPO}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '.artifacts[] | select(.name == "job-outputs") | .id' | head -1)
+
+          if [ -z "$artifact_id" ]; then
+            echo "::warning::run $RUN_ID published no job-outputs artifact"
+            echo "has_outputs=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh api "/repos/${TARGET_REPO}/actions/artifacts/${artifact_id}/zip" > outputs.zip
+          unzip -q -o outputs.zip -d outputs_dir
+          json=$(find outputs_dir -name '*.json' -type f | head -1)
+
+          if [ -z "$json" ] || ! jq empty "$json" 2>/dev/null; then
+            echo "::warning::job-outputs held no readable JSON"
+            echo "has_outputs=false" >> "$GITHUB_OUTPUT"
+            rm -rf outputs.zip outputs_dir
+            exit 0
+          fi
+
+          jq -C '.' "$json"
+          {
+            echo "has_outputs=true"
+            echo "success=$(jq -r '.test_status.success // false' "$json")"
+            echo "summary=$(jq -r '.test_status.summary // ""' "$json" | tr '\n\r' '  ')"
+            echo "report_url=$(jq -r '.report_url // ""' "$json")"
+            echo "slack_message_url=$(jq -r '.slack_message_url // ""' "$json")"
+          } >> "$GITHUB_OUTPUT"
+          rm -rf outputs.zip outputs_dir
+
+      - name: Build the verdict
+        id: verdict
+        if: always() && steps.version.outputs.should_run == 'true'
+        shell: bash
+        env:
+          PHASE: ${{ inputs.phase }}
+          SDK_VERSION: ${{ steps.version.outputs.version }}
+          RUN_URL: ${{ steps.dispatch.outputs.run_url }}
+          CONCLUSION: ${{ steps.wait.outputs.conclusion }}
+          HAS_OUTPUTS: ${{ steps.outputs.outputs.has_outputs }}
+          SUCCESS: ${{ steps.outputs.outputs.success }}
+          SUMMARY: ${{ steps.outputs.outputs.summary }}
+          REPORT_URL: ${{ steps.outputs.outputs.report_url }}
+        run: |
+          set -euo pipefail
+
+          if [ "$HAS_OUTPUTS" = "true" ] && [ "$SUCCESS" = "true" ]; then
+            icon=":white_check_mark:"; headline="$PHASE sanity passed"
+            detail="$SUMMARY"
+          elif [ "$HAS_OUTPUTS" = "true" ]; then
+            icon=":x:"; headline="$PHASE sanity failed"
+            detail="$SUMMARY"
+          elif [ -z "$RUN_URL" ]; then
+            icon=":warning:"; headline="$PHASE sanity could not be started"
+            detail="The suite was never dispatched. Check the Release Sanity job in this run."
+          elif [ "$CONCLUSION" = "timed-out" ]; then
+            icon=":hourglass:"; headline="$PHASE sanity did not finish in time"
+            detail="The suite was still running when this job stopped waiting for it."
+          else
+            icon=":warning:"; headline="$PHASE sanity reported nothing"
+            detail="The suite ended without publishing results. Open the suite run to see why."
+          fi
+
+          msg="${icon} *Kotlin SDK ${SDK_VERSION} — ${headline}*"
+          msg+=$'\n'"${detail}"
+          if [ -n "$REPORT_URL" ]; then
+            msg+=$'\n'"<${REPORT_URL}|Full report>"
+            [ -z "$RUN_URL" ] || msg+=" · <${RUN_URL}|Suite run>"
+          elif [ -n "$RUN_URL" ]; then
+            msg+=$'\n'"<${RUN_URL}|Suite run>"
+          fi
+
+          {
+            echo "### ${icon} ${headline}"
+            echo ""
+            echo "- **Version:** \`${SDK_VERSION}\`"
+            echo "- **Result:** ${detail}"
+            [ -z "$REPORT_URL" ] || echo "- **Report:** ${REPORT_URL}"
+            [ -z "$RUN_URL" ] || echo "- **Suite run:** ${RUN_URL}"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+          EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "text<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+          echo "$msg" >> "$GITHUB_OUTPUT"
+          echo "${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+
+          [ "$SUCCESS" = "true" ] || echo "::warning::${headline} — ${detail}"
+
+      - name: Download release thread info
+        id: thread
+        if: always() && steps.version.outputs.should_run == 'true'
+        continue-on-error: true
+        uses: ./.github/actions/slack-release-notify
+        with:
+          mode: download-artifact
+          release_version: ${{ steps.release-info.outputs.version }}
+          release_ticket_id: ${{ steps.release-info.outputs.ticket_id }}
+
+      - name: Post the verdict to the release thread
+        if: always() && steps.thread.outputs.channel_id != ''
+        continue-on-error: true
+        uses: ./.github/actions/slack-release-notify
+        with:
+          mode: post-thread
+          slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel_id: ${{ steps.thread.outputs.channel_id }}
+          thread_ts: ${{ steps.thread.outputs.thread_ts }}
+          message: ${{ steps.verdict.outputs.text }}

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -122,7 +122,7 @@ jobs:
       snapshot: true
       affected_modules: ${{ needs.detect-modules.outputs.affected }}
       release_pr: ${{ github.event.pull_request.html_url }}
-      max_wait_seconds: 3600
+      max_wait_seconds: 3000
     secrets:
       RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -113,6 +113,20 @@ jobs:
         run: |
           ./scripts/releases/publish-module.sh "$MODULE" snapshot "$SNAPSHOT_MODULES"
 
+  release-sanity:
+    needs: [detect-modules, publish-snapshot]
+    if: needs.detect-modules.outputs.has_modules == 'true'
+    uses: ./.github/workflows/release-sanity.yml
+    with:
+      phase: pre-release
+      snapshot: true
+      affected_modules: ${{ needs.detect-modules.outputs.affected }}
+      release_pr: ${{ github.event.pull_request.html_url }}
+      max_wait_seconds: 3600
+    secrets:
+      RELEASE_PRIVATE_KEY: ${{ secrets.RELEASE_PRIVATE_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
   notify-slack:
     needs: [detect-modules, publish-snapshot]
     if: needs.detect-modules.outputs.has_modules == 'true'


### PR DESCRIPTION
## Description

The Kotlin scenario suite lives in [`rudderlabs/rudder-mobile-sdk-test`](https://github.com/rudderlabs/rudder-mobile-sdk-test). Nothing calls it today. A person has to remember to start it, and the result never reaches the release thread.

This PR makes the release start it twice, and report the verdict where the release is already being discussed.

| Phase | Trigger | Artifact under test |
| --- | --- | --- |
| `pre-release` | `snapshot-release.yml`, after `publish-snapshot` | `<version>-SNAPSHOT` from the Maven Central snapshots repo |
| `post-release` | `publish-new-release.yml`, after `publish-release` | `<version>` from Maven Central |

`rudder-sdk-js` already does this against `rudder-client-side-test`. The suite's `outputs.json` copies that suite's `test_status` field names, so the reading side here is a port of a shape that already works in production.

**This is advisory.** A red suite, a missing artifact, or a timeout is reported and never blocks a release.

Related: [rudder-mobile-sdk-test#16](https://github.com/rudderlabs/rudder-mobile-sdk-test/pull/16) — the suite this PR calls.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) — CI only, no SDK code changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details

**New — `.github/workflows/release-sanity.yml`** (349 lines, one `workflow_call` job)

- Resolves the android version from the caller's `module|bump|old|new` list, and appends `-SNAPSHOT` for the pre-release phase.
- Mints a GitHub App token scoped to `rudder-mobile-sdk-test` alone, with `permission-actions: write`.
- Dispatches the suite, waits for it, downloads its `job-outputs` artifact, and reads the verdict.
- Posts a one-line verdict into the release Slack thread, through the repo's existing `./.github/actions/slack-release-notify`.
- Writes the same verdict to the job summary.

**Finds its run by correlation id, not by a timestamp guess.** The dispatch API returns no run id. The `rudder-sdk-js` equivalent snapshots run ids, back-dates a timestamp by 10 seconds, and takes the oldest run created after it — which races whenever two dispatches overlap. The suite echoes `correlation_id` into its `run-name` for exactly this lookup, so this workflow matches on `[<id>]` instead. That removes the id snapshot, the clock-skew buffer, and the `head_branch` fallback ladder.

**Skips when the release publishes no android artifact.** A `core` bump always carries an `android` bump with it. An integration-only release does not, and there the suite would test an artifact this release did not change.

**Cancels the remote run.** `snapshot-release.yml` already sets `cancel-in-progress: true`. A trap on `SIGTERM`/`SIGINT` cancels the emulator run in the test repo too, rather than leaving it holding a runner for another half hour.

**Advisory by construction.** Every step that can fail carries `continue-on-error`, and so does the job. The verdict step always exits 0.

**Modified — `snapshot-release.yml` and `publish-new-release.yml`** (one job each, 14 and 15 lines)

- Each calls the reusable workflow with its phase, the affected-module list, and the release PR URL.
- Waits are 60 min pre-release and 90 min post-release. The larger budget covers the suite's own 35-minute wait for the Maven Central sync, which only the post-release phase takes.
- Neither `notify-slack` job gains a dependency, so release announcements are never delayed by a 40-minute suite.

**Deliberate omissions**

- `api_levels` and `suite` are not sent. An omitted dispatch input takes the target workflow's own default, so the test repo keeps ownership of what the suite covers.
- All third-party actions are pinned to the SHAs this repo already uses, so no new entry is needed on the Actions allowlist.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works. — No test files. This is workflow YAML. Every shell block was extracted from the file and executed against the live API; see **How to test?**
- [x] I have added the necessary documentation (if appropriate). — Header comment plus a description on every input and secret.
- [x] I have ensured that my code follows the project's code style. — `actionlint` clean; pinned action SHAs, `harden-runner`, and self-hosted runners match the existing workflows.
- [x] I have checked for potential performance impacts and optimized if necessary. — The waiting job only polls an API, so it runs on a self-hosted runner and costs no billed minutes. `notify-slack` is not made to wait on it.
- [x] I have checked the code for security issues. — The app token is scoped to one repository with one permission. No input reaches a shell through `${{ }}`; every value passes through `env`. The dispatch body is built with `jq`, not string concatenation.
- [ ] I have updated the changelog (if required). — Not required. No SDK module changes.

## How to test?

The live dispatch cannot run until [rudder-mobile-sdk-test#16](https://github.com/rudderlabs/rudder-mobile-sdk-test/pull/16) merges, because `workflow_dispatch` registers only from the default branch. Everything below was executed locally against real data, using the shell blocks extracted verbatim from the workflow file.

**Static**

- `actionlint` is clean on all three files.
- Mutation-tested that check: a misspelled input name and a missing required secret are both caught. A wrong input *type* is not — `actionlint` does not validate those, so do not read the clean run as a type check.

**Executed against the live GitHub API**

| What | Result |
| --- | --- |
| Wait loop, real completed run `32332958282` | Returns `conclusion=failure`, exits 0 |
| Wait loop, exhausted budget | Takes the timeout branch, exits 0 |
| Wait loop, bogus run id | Retries the 404, then times out cleanly |
| Outputs step, real `job-outputs` artifact | Correct artifact id, unzip, `jq empty`, all four fields |
| Dispatch step, stubbed `gh` | The file's own `jq` builds the correct body; the file's own matcher resolves the run id |
| Dispatch step, another caller's run present | Refuses to match, emits no `run_id`, downstream steps skip |
| Full outputs → verdict chain | Renders the Slack message and job summary from the real artifact |

That sixth row is the point of the correlation id. The `rudder-sdk-js` heuristic would have claimed that other run.

**Also covered**

- Version resolution across six inputs: core plus android in snapshot and release form, integration-only, an empty list, a major bump, and a trailing blank line. It skips in exactly the two cases that publish no android artifact.
- The run matcher rejects a prefix — `9988776` does not match `[99887766-1]`, because the brackets anchor it.
- `name` and `display_title` both carry the rendered `run-name` on real runs, so matching either is safe.
- All five verdict branches — green, red, never dispatched, timed out, no outputs — render and exit 0.
- The branch parse yields the same `release-info-v<version>-<ticket>` artifact name the draft workflow uploads, for both `release/` and `hotfix-release/`.

**What is still unproven**

1. Whether `gh`, `jq`, and `unzip` exist on this repo's self-hosted runners. The existing self-hosted jobs run Gradle and use none of them.
2. The live dispatch `POST`, and the GitHub App install.
3. The Slack post when called from a reusable workflow.

Each one degrades the same way: a warning, a Slack line saying the run did not report, and a green release.

**Reviewer note on branches.** This PR targets `develop`, and that is sufficient. For `pull_request` events GitHub runs the workflow from the PR head, and the release branch is cut from `develop`. Verified against real runs — every past `snapshot-release` and `publish-new-release` run shows `headBranch=release/1.12.0-SDK-5285`, not `main`.

## Breaking Changes

None. No SDK module, public API, or build file changes. The two edited workflows gain one job each and lose nothing.

## Prerequisites

Neither blocks review. Both block a working run.

1. **[rudder-mobile-sdk-test#16](https://github.com/rudderlabs/rudder-mobile-sdk-test/pull/16) must merge.** `workflow_dispatch` registers only from the default branch.
2. **The release GitHub App needs installing on `rudderlabs/rudder-mobile-sdk-test`**, with Actions read and write. `create-github-app-token` fails with `repositories: rudder-mobile-sdk-test` until then. This is the same install the JS suite already has for `rudder-client-side-test`, and it needs an org admin.

## Maintainers Checklist

- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Context

**What the Slack thread message looks like**, rendered from the real artifact of run `32332958282`:

```
:x: *Kotlin SDK 1.7.1 — post-release sanity failed*
Results: 122 / 122 Passed (100%)
<https://cdn.dev.rudderlabs.com/…/index.html|Full report> · <https://github.com/…/runs/32332958282|Suite run>
```

**Follow-up, not in this PR.** The suite publishes its report to the **dev** CDN. A production role and bucket would be a separate infra request once this gates real releases.
